### PR TITLE
PGP certification of device key

### DIFF
--- a/librad2/src/keys/device.rs
+++ b/librad2/src/keys/device.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use bs58;
-use secstr::SecVec;
 use sodiumoxide::crypto::sign;
 use time;
 
@@ -54,14 +53,10 @@ impl Key {
     }
 
     pub fn as_pgp(&self, nickname: &str) -> Result<pgp::Key, pgp::Error> {
-        let scalar = {
-            let bytes = self.sk.as_ref();
-            SecVec::new(Vec::from(&bytes[..32]))
-        };
         let uid = pgp::UserID::from_address(None, None, format!("{}@{}", nickname, self))
             .expect("messed up UserID");
-        pgp::Key::from_scalar(
-            scalar,
+        pgp::Key::from_sodium(
+            &self.sk,
             uid,
             time::at(time::Timespec::new(self.created_at, 0)),
         )


### PR DESCRIPTION
We want our device key to not leave the device. What we want to enable, though, is that people use their primary GPG key (published to keyservers) to certify that they own the device key. That is, associate the device key with their identity.

After studying [RFC448](https://tools.ietf.org/html/rfc4880) for a while, I realised that it's quite possible to forego a sequence of arcane GPG commands (with the risk of leaving the device key in they GPG keyring): we simply make them export their (secret) primary key (`gpg --export-secret-keys --armor`), read it in, create a subkey binding, and ouput the armored public parts again. The ouput can be uploaded to keyservers directly.

We may need to think about revocation at some later point.