### PR TITLE
Remove dependency on sequoia-rfc2822, and replace with simple datatype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,14 +592,15 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nettle 5.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nonempty 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "olpc-cjson 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sequoia-openpgp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sequoia-rfc2822 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1218,16 +1219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sequoia-rfc2822"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,7 +1725,6 @@ dependencies = [
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb003d53cef244a97516226b01155057c7fa6eb52914933c32f6c98a84182188"
 "checksum sequoia-openpgp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33554f73114b96e1275ebec51131010c15e6c91f18a8d29a7d234112f9be43c5"
-"checksum sequoia-rfc2822 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "270d16627fe2cc0fc9dc24f96322f72a0c829d921e2d4ee4b336d49569307361"
 "checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
 "checksum serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f7081ed758ec726a6ed8ee7e92f5d3f6e6f8c3901b1f972e3a4a2f2599fad14f"
 "checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -10,12 +10,13 @@ directories = "2.0"
 failure = { version = "0.1", features = ["backtrace"] }
 failure_derive = "0.1"
 git2 = "0.10"
+lazy_static = "1.4"
 nettle = { version = "5.0", features = ["vendored"]  }
 nonempty = "0.1"
 olpc-cjson = "0.1"
+regex = "1.3"
 secstr = "0.3"
 sequoia-openpgp = "0.12"
-sequoia-rfc2822 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
 serde_json = "1.0"

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -2,6 +2,8 @@ extern crate sequoia_openpgp as pgp;
 extern crate sodiumoxide;
 #[macro_use]
 extern crate failure_derive;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod git;
 pub mod keys;

--- a/librad/src/meta/common.rs
+++ b/librad/src/meta/common.rs
@@ -140,20 +140,20 @@ pub mod tests {
     use super::*;
     use serde_json;
 
-    const SIMPLE_VALID: &str = "leboeuf@example.org";
+    const SIMPLE_EMAIL: &str = "leboeuf@example.org";
 
     #[test]
     fn test_email_roundtrip() {
-        let addr = EmailAddr::parse(SIMPLE_VALID).expect("Invalid EmailAddr");
-        assert_eq!(addr.to_string(), SIMPLE_VALID.to_string())
+        let addr = EmailAddr::parse(SIMPLE_EMAIL).expect("Invalid EmailAddr");
+        assert_eq!(addr.to_string(), SIMPLE_EMAIL.to_string())
     }
 
     #[test]
     fn test_email_serde() {
-        let addr = EmailAddr::parse(SIMPLE_VALID).expect("Invalid EmailAddr");
+        let addr = EmailAddr::parse(SIMPLE_EMAIL).expect("Invalid EmailAddr");
         let ser = serde_json::to_string(&addr).unwrap();
         let de = serde_json::from_str(&ser).unwrap();
-        assert_eq!(ser, format!("\"{}\"", SIMPLE_VALID));
+        assert_eq!(ser, format!("\"{}\"", SIMPLE_EMAIL));
         assert_eq!(addr, de)
     }
 }

--- a/librad/src/meta/common.rs
+++ b/librad/src/meta/common.rs
@@ -1,3 +1,159 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 pub const RAD_VERSION: u8 = 2;
 
 pub type Label = String;
+
+/// An RFC2822-ish email address.
+///
+/// While we validate the `local-part`, and ensure that the entire address is shorter than 255
+/// characters, we don't care much about the `domain`: pseudo email addresses of the form
+/// `<local-part>@<some hash value>` are generally acceptable within Radicle.
+///
+/// The validation logic is mostly stolen from the `addr` resp. `publicsuffix` crates.
+#[derive(Clone, Debug, PartialEq)]
+pub struct EmailAddr {
+    local: String,
+    domain: String,
+}
+
+impl EmailAddr {
+    pub fn parse(addr: &str) -> Result<Self, email::Error> {
+        Self::from_str(addr)
+    }
+
+    pub fn local(&self) -> &str {
+        &self.local
+    }
+
+    pub fn domain(&self) -> &str {
+        &self.domain
+    }
+}
+
+pub mod email {
+    use failure::Fail;
+    use regex::RegexSet;
+
+    lazy_static! {
+        pub static ref LOCAL: RegexSet = {
+            // these characters can be anywhere in the expresion
+            let global = r#"[[:alnum:]!#$%&'*+/=?^_`{|}~-]"#;
+            // non-ascii characters (an also be unquoted)
+            let non_ascii = r#"[^\x00-\x7F]"#;
+            // the pattern to match
+            let quoted = r#"["(),\\:;<>@\[\]. ]"#;
+            // combined regex
+            let combined = format!(r#"({}*{}*)"#, global, non_ascii);
+
+            let exprs = vec![
+                // can be any combination of allowed characters
+                format!(r#"^{}+$"#, combined),
+                // can be any combination of allowed charaters
+                // separated by a . in between
+                format!(r#"^({0}+[.]?{0}+)+$"#, combined),
+                // can be a quoted string with allowed plus
+                // additional characters
+                format!(r#"^"({}*{}*)*"$"#, combined, quoted),
+            ];
+
+            RegexSet::new(exprs).unwrap()
+        };
+    }
+
+    #[derive(Debug, Fail)]
+    pub enum Error {
+        #[fail(display = "Email address exceeds 254 character limit")]
+        AddrTooLong,
+
+        #[fail(display = "Invalid local-part of email address")]
+        InvalidLocalPart,
+
+        #[fail(display = "Invalid domain of email address")]
+        InvalidDomain,
+    }
+}
+
+impl FromStr for EmailAddr {
+    type Err = email::Error;
+
+    fn from_str(addr: &str) -> Result<Self, Self::Err> {
+        if addr.chars().count() > 254 {
+            return Err(Self::Err::AddrTooLong);
+        }
+
+        let mut parts = addr.rsplitn(2, '@');
+
+        let domain = match parts.next() {
+            Some(domain) => domain,
+            None => return Err(Self::Err::InvalidDomain),
+        };
+        let local = match parts.next() {
+            Some(local) => local,
+            None => return Err(Self::Err::InvalidLocalPart),
+        };
+
+        if local.chars().count() > 64
+            || (!local.starts_with('"') && local.contains(".."))
+            || !email::LOCAL.is_match(local)
+        {
+            return Err(Self::Err::InvalidLocalPart);
+        }
+
+        Ok(Self {
+            local: local.to_owned(),
+            domain: domain.to_owned(),
+        })
+    }
+}
+
+impl fmt::Display for EmailAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}@{}", self.local, self.domain)
+    }
+}
+
+impl Serialize for EmailAddr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for EmailAddr {
+    fn deserialize<D>(deserializer: D) -> Result<EmailAddr, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        EmailAddr::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use serde_json;
+
+    const SIMPLE_VALID: &str = "leboeuf@example.org";
+
+    #[test]
+    fn test_email_roundtrip() {
+        let addr = EmailAddr::parse(SIMPLE_VALID).expect("Invalid EmailAddr");
+        assert_eq!(addr.to_string(), SIMPLE_VALID.to_string())
+    }
+
+    #[test]
+    fn test_email_serde() {
+        let addr = EmailAddr::parse(SIMPLE_VALID).expect("Invalid EmailAddr");
+        let ser = serde_json::to_string(&addr).unwrap();
+        let de = serde_json::from_str(&ser).unwrap();
+        assert_eq!(ser, format!("\"{}\"", SIMPLE_VALID));
+        assert_eq!(addr, de)
+    }
+}

--- a/librad/src/meta/mod.rs
+++ b/librad/src/meta/mod.rs
@@ -11,5 +11,4 @@ pub use contributor::{Contributor, ProfileRef};
 pub use profile::{Geo, ProfileImage, UserProfile};
 pub use project::{Project, Relation};
 
-pub use sequoia_rfc2822::AddrSpec;
 pub use url::Url;

--- a/librad/src/meta/profile.rs
+++ b/librad/src/meta/profile.rs
@@ -1,12 +1,10 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use sequoia_rfc2822::AddrSpec;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::meta::common::Label;
-use crate::meta::serde_helpers;
+use crate::meta::common::{EmailAddr, Label};
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct UserProfile {
@@ -21,13 +19,8 @@ pub struct UserProfile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bio: Option<String>,
 
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "serde_helpers::addrspec::serialize_opt",
-        deserialize_with = "serde_helpers::addrspec::deserialize_opt"
-    )]
-    pub email: Option<AddrSpec>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<EmailAddr>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub geo: Option<Geo>,
@@ -88,8 +81,8 @@ pub mod tests {
         ]
     }
 
-    pub fn gen_addr_spec() -> impl Strategy<Value = AddrSpec> {
-        Just(AddrSpec::parse("leboeuf@acme.org").expect("Invalid AddrSpec"))
+    pub fn gen_addr_spec() -> impl Strategy<Value = EmailAddr> {
+        Just(EmailAddr::parse("leboeuf@acme.org").expect("Invalid EmailAddr"))
     }
 
     pub fn gen_user_profile() -> impl Strategy<Value = UserProfile> {

--- a/librad/src/meta/serde_helpers.rs
+++ b/librad/src/meta/serde_helpers.rs
@@ -63,48 +63,6 @@ pub(crate) mod urltemplate {
     }
 }
 
-pub(crate) mod addrspec {
-    use sequoia_rfc2822::AddrSpec;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(addr: &AddrSpec, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(addr.address())
-    }
-
-    pub fn serialize_opt<S>(opt: &Option<AddrSpec>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        if let Some(addr) = opt {
-            serialize(addr, serializer)
-        } else {
-            serializer.serialize_none()
-        }
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<AddrSpec, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let string = String::deserialize(deserializer)?;
-        AddrSpec::parse(&string).map_err(serde::de::Error::custom)
-    }
-
-    pub fn deserialize_opt<'de, D>(deserializer: D) -> Result<Option<AddrSpec>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct Wrapper(#[serde(deserialize_with = "deserialize")] AddrSpec);
-
-        let v = Option::deserialize(deserializer)?;
-        Ok(v.map(|Wrapper(a)| a))
-    }
-}
-
 pub(crate) mod pgp_fingerprint {
     use pgp::Fingerprint;
     use serde::{Deserialize, Deserializer, Serializer};

--- a/rad2/src/commands/profiles.rs
+++ b/rad2/src/commands/profiles.rs
@@ -6,7 +6,7 @@ use failure::Fail;
 use serde_yaml as yaml;
 use structopt::StructOpt;
 
-use librad::meta::{AddrSpec, UserProfile};
+use librad::meta::{EmailAddr, UserProfile};
 use librad::paths::Paths;
 
 use crate::editor;
@@ -121,7 +121,8 @@ fn create_profile(paths: &Paths, name: &str) -> Result<(), Error> {
             profile.email = git_config
                 .get_string("user.email")
                 .ok()
-                .and_then(|addr| AddrSpec::parse(addr).ok());
+                .as_ref()
+                .and_then(|addr| EmailAddr::parse(addr).ok());
         }
 
         profile


### PR DESCRIPTION
The sequoia-rfc2822 crate is deprecated[0][1], and some people are even
contemplating yanking it completely from crates.io[2]. We also don't
need full RFC2822-compliance, as we might do funky things with the
domain part.

[0]: https://gitlab.com/sequoia-pgp/sequoia/issues/279
[1]: https://gitlab.com/sequoia-pgp/sequoia/merge_requests/221
[2]: https://gitlab.com/sequoia-pgp/sequoia/issues/376