### PR TITLE
Wrap `Url`

### DIFF
--- a/librad/src/keys/device.rs
+++ b/librad/src/keys/device.rs
@@ -2,8 +2,8 @@ use std::fmt;
 use std::ops::Deref;
 use std::time::SystemTime;
 
-use bs58;
 use ::pgp::conversions::Time;
+use bs58;
 use sodiumoxide::crypto::sign;
 
 use crate::keys::pgp;

--- a/librad/src/meta/contributor.rs
+++ b/librad/src/meta/contributor.rs
@@ -1,9 +1,8 @@
 use pgp;
 use serde::{Deserialize, Serialize};
-use url::Url;
 use urltemplate::UrlTemplate;
 
-use crate::meta::common::RAD_VERSION;
+use crate::meta::common::{Url, RAD_VERSION};
 use crate::meta::profile::UserProfile;
 use crate::meta::serde_helpers;
 

--- a/librad/src/meta/mod.rs
+++ b/librad/src/meta/mod.rs
@@ -10,5 +10,3 @@ pub use common::*;
 pub use contributor::{Contributor, ProfileRef};
 pub use profile::{Geo, ProfileImage, UserProfile};
 pub use project::{Project, Relation};
-
-pub use url::Url;

--- a/librad/src/meta/profile.rs
+++ b/librad/src/meta/profile.rs
@@ -2,9 +2,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use url::Url;
 
-use crate::meta::common::{EmailAddr, Label};
+use crate::meta::common::{EmailAddr, Label, Url};
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct UserProfile {

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -2,9 +2,8 @@ use std::path::PathBuf;
 
 use nonempty::NonEmpty;
 use serde::{Deserialize, Serialize};
-use url::Url;
 
-use crate::meta::common::{Label, RAD_VERSION};
+use crate::meta::common::{Label, Url, RAD_VERSION};
 use crate::meta::serde_helpers;
 use crate::peer::PeerId;
 


### PR DESCRIPTION
As @xla [points out](https://github.com/radicle-dev/radicle-link/pull/22#discussion_r359914612), Rust admits multiple versions of the same dependency to be linked into a program. Friends and acquaintances of `java.lang.ClassLoader` will notice that the smartness of presenting this as a solution to "dependency hell" is bounded. In particular, re-exporting from a dependency allows the dependency to break the public API (pinning to a patch version is a non-solution for a library).

Hence, we wrap the `url::Url` type (exposing only the minimally needed functionality for now). Access to underlying `ParseError`s is permitted via the `.cause()` method, although implementing control flow in them is discouraged.

There might be similar cases already introduced, which will be addressed at a later point.