### PR TITLE
Fixed maintainers dedup.

### DIFF
--- a/librad/src/keys/device.rs
+++ b/librad/src/keys/device.rs
@@ -17,7 +17,7 @@ pub struct Key {
 }
 
 /// The public part of a `Key``
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct PublicKey(sign::PublicKey);
 
 /// A signature produced by `Key::sign`

--- a/librad/src/peer.rs
+++ b/librad/src/peer.rs
@@ -9,7 +9,7 @@ use crate::keys::device;
 
 pub const PEER_ID_PREFIX_ED25519: char = '0';
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct PeerId(device::PublicKey);
 
 impl From<device::PublicKey> for PeerId {


### PR DESCRIPTION
`dedup` works like the unix shell `uniq` cmd: it needs the vector to be sorted.