### PR TITLE
Use open over open_bare

### DIFF
--- a/librad/src/git/mod.rs
+++ b/librad/src/git/mod.rs
@@ -140,7 +140,7 @@ pub struct GitProject(git2::Repository);
 
 impl GitProject {
     pub fn open(path: &Path) -> Result<GitProject, Error> {
-        git2::Repository::open_bare(path)
+        git2::Repository::open(path)
             .map(GitProject)
             .map_err(|e| e.into())
     }


### PR DESCRIPTION
[`open`](https://docs.rs/git2/0.11.0/git2/struct.Repository.html#method.open) says:

```
Attempt to open an already-existing repository at path.

The path can point to either a normal or bare repository.
```

So if the project already exists then we will have all the refs and what not. Whereas with bare we have nothing :(