### PR TITLE
fmt: Enable wrap_comments

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,7 @@
 max_width = 100
 # yeap
 comment_width = 80
-wrap_comments = false
+wrap_comments = true
 hard_tabs = false
 tab_spaces = 4
 imports_layout = "HorizontalVertical"


### PR DESCRIPTION
Forgot to enable that when switching to nightly. I draw unreasonable enjoyment
from this weird Rust convention to limit code to 100, but comments to 80
columns.