### PR TITLE
CLI: Refactor option parsing and effectful state setup

### DIFF
--- a/librad/src/keys/mod.rs
+++ b/librad/src/keys/mod.rs
@@ -1,3 +1,5 @@
 pub mod device;
 pub mod pgp;
 pub mod storage;
+
+pub use storage::Storage;

--- a/rad2/src/commands/keys.rs
+++ b/rad2/src/commands/keys.rs
@@ -1,16 +1,13 @@
 use failure::Fail;
 use structopt::StructOpt;
 
-use librad::{
-    keys::{
-        device,
-        storage,
-        storage::{FileStorage, Pinentry, Storage},
-    },
-    paths::Paths,
+use librad::keys::{
+    device,
+    storage,
+    storage::{Pinentry, Storage},
 };
 
-use crate::error::Error;
+use crate::{config::Config, error::Error};
 
 #[derive(StructOpt)]
 /// Manage keys
@@ -21,49 +18,27 @@ pub enum Commands {
     Show,
 }
 
-pub fn run<F, P>(paths: Paths, cmd: Commands, verbose: bool, pin: F) -> Result<(), Error<P::Error>>
-where
-    F: FnOnce(&'static str) -> P,
-    P: Pinentry,
-    P::Error: Fail,
-{
-    match cmd {
-        Commands::New => create_device_key(paths, verbose, pin),
-        Commands::Show => show_keys(paths, verbose, pin).map_err(|e| match e {
-            Error::Storage(storage::Error::NoSuchKey) => Error::EmptyKeyStore,
-            _ => e,
-        }),
+impl Commands {
+    pub fn run<K, P>(self, cfg: Config<K, P>) -> Result<(), Error<P::Error>>
+    where
+        K: Storage<P>,
+        P: Pinentry,
+        P::Error: Fail,
+    {
+        match self {
+            Self::New => {
+                let key = device::Key::new();
+                let mut store = cfg.keystore;
+                store.put_device_key(&key).map_err(|e| e.into())
+            },
+            Self::Show => cfg
+                .keystore
+                .get_device_key()
+                .map_err(|e| match e {
+                    storage::Error::NoSuchKey => Error::EmptyKeyStore,
+                    _ => e.into(),
+                })
+                .map(|key| println!("Device key: {}", key)),
+        }
     }
-}
-
-fn create_device_key<F, P>(paths: Paths, _verbose: bool, pin: F) -> Result<(), Error<P::Error>>
-where
-    F: FnOnce(&'static str) -> P,
-    P: Pinentry,
-    P::Error: Fail,
-{
-    let mut store = FileStorage::new(paths);
-    let key = device::Key::new();
-    store
-        .put_device_key(&key, pin("Enter a passphrase for your device key:"))
-        .map_err(|e| e.into())
-}
-
-fn show_keys<F, P>(paths: Paths, verbose: bool, pin: F) -> Result<(), Error<P::Error>>
-where
-    F: FnOnce(&'static str) -> P,
-    P: Pinentry,
-    P::Error: Fail,
-{
-    let store = FileStorage::new(paths);
-    store
-        .get_device_key(pin("Unlock your key store:"))
-        .map(|key| {
-            if verbose {
-                println!("Device Key: {} ({:?})", key, store.key_file_path())
-            } else {
-                println!("Device Key: {}", key)
-            }
-        })
-        .map_err(|e| e.into())
 }

--- a/rad2/src/commands/profiles.rs
+++ b/rad2/src/commands/profiles.rs
@@ -9,11 +9,12 @@ use serde_yaml as yaml;
 use structopt::StructOpt;
 
 use librad::{
+    keys::storage::{Pinentry, Storage},
     meta::{EmailAddr, UserProfile},
     paths::Paths,
 };
 
-use crate::editor;
+use crate::{config::Config, editor};
 
 #[derive(StructOpt)]
 /// Manage user profiles
@@ -100,13 +101,19 @@ impl ProfilePath {
     }
 }
 
-pub fn run(paths: Paths, cmd: Commands, _verbose: bool) -> Result<(), Error> {
-    match cmd {
-        Commands::New { name } => create_profile(&paths, &name),
-        Commands::Edit { name } => edit_profile(&paths, &name),
-        Commands::Show { name } => show_profile(&paths, &name),
-        Commands::Delete { name } => delete_profile(&paths, &name),
-        Commands::List => list_profiles(&paths),
+impl Commands {
+    pub fn run<K, P>(self, cfg: Config<K, P>) -> Result<(), Error>
+    where
+        K: Storage<P>,
+        P: Pinentry,
+    {
+        match self {
+            Self::New { name } => create_profile(&cfg.paths, &name),
+            Self::Edit { name } => edit_profile(&cfg.paths, &name),
+            Self::Show { name } => show_profile(&cfg.paths, &name),
+            Self::Delete { name } => delete_profile(&cfg.paths, &name),
+            Self::List => list_profiles(&cfg.paths),
+        }
     }
 }
 

--- a/rad2/src/config.rs
+++ b/rad2/src/config.rs
@@ -1,0 +1,62 @@
+use std::{marker::PhantomData, path::PathBuf};
+
+use librad::{
+    keys::{self, storage::Pinentry},
+    paths::Paths,
+};
+use structopt::StructOpt;
+
+use crate::error::Error;
+
+/// Common options
+#[derive(StructOpt)]
+pub struct CommonOpts {
+    /// Verbose output
+    #[structopt(short, long)]
+    pub verbose: bool,
+
+    /// Override the default, platform-specific configuration and state
+    /// directory root
+    ///
+    /// Most useful for local testing with multiple identities.
+    #[structopt(long, env = "RAD_ROOT", parse(from_os_str))]
+    pub paths: Option<PathBuf>,
+}
+
+/// Stateful configuration, derived from [`CommonOpts`] and passed around to
+/// commands.
+pub struct Config<K, P>
+where
+    K: keys::Storage<P>,
+    P: Pinentry,
+{
+    pub verbose: bool,
+    pub paths: Paths,
+    pub keystore: K,
+
+    _marker: PhantomData<P>,
+}
+
+impl CommonOpts {
+    pub fn into_config<F, K, P>(self, init_keystore: F) -> Result<Config<K, P>, Error<P::Error>>
+    where
+        F: FnOnce(&Paths) -> K,
+        K: keys::Storage<P>,
+        P: Pinentry,
+    {
+        let verbose = self.verbose;
+        let paths = if let Some(root) = self.paths {
+            Paths::from_root(&root)
+        } else {
+            Paths::new()
+        }?;
+        let keystore = init_keystore(&paths);
+
+        Ok(Config {
+            verbose,
+            paths,
+            keystore,
+            _marker: PhantomData,
+        })
+    }
+}


### PR DESCRIPTION
I got a bit annoyed by the way I set this up the first time, namely that I was
instantiating effectful state (storage, pinentry, ...) ad-hoc everywhere, so I
centralisised that.

There is also now the option to override the (equivalent of) XDG_* root by
setting the RAD_ROOT environment variable or passing --paths (oof feel free to
bikeshed that naming choice).

Additionally, the pinentry (i.e. password prompt) for the keystore is now
threaded as part of the type, and doesn't have to be passed to the methods. This
is a breaking change @xla.