### PR TITLE
Set up GH CODEOWNERS feature

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+librad/ @radicle-dev/cococo @radicle-dev/upstream-proxy
+
+@radicle-dev/cococo


### PR DESCRIPTION
To save myself a couple of pointing-device movements.

Every PR should now automatically request a review from the radicle-link "core team", and additionally from upstream folks concerned with the proxy. Hope this is useful for folks using email or GH notification filters to highlight attention-worthy things in the flood of incoming patches.