### PR TITLE
Generalise IO for gossip

### DIFF
--- a/librad/examples/mesh.rs
+++ b/librad/examples/mesh.rs
@@ -34,10 +34,11 @@ use librad::{
     keys::device,
     meta,
     net::{
-        connection::{BoundEndpoint, Endpoint, LocalInfo},
+        connection::LocalInfo,
         discovery,
         gossip,
         protocol::Protocol,
+        quic::{BoundEndpoint, Endpoint},
     },
     paths::Paths,
     peer::PeerId,

--- a/librad/src/net/connection.rs
+++ b/librad/src/net/connection.rs
@@ -15,177 +15,26 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Wrappers for QUIC primitives
-//!
-//! # Note
-//!
-//! Should eventually be replaced by traits, but current circumstances require
-//! concrete types.
+use std::{io, net::SocketAddr};
 
-use std::{io, net::SocketAddr, pin::Pin};
-
-use futures::{
-    io::{AsyncRead, AsyncWrite},
-    stream::{BoxStream, StreamExt, TryStreamExt},
-    task::{Context, Poll},
-};
-use futures_codec::{Decoder, Encoder, Framed};
-use quinn::{NewConnection, VarInt};
-use thiserror::Error;
-
-use crate::{
-    keys::device,
-    net::{quic, tls},
-    peer::PeerId,
-};
+use crate::peer::PeerId;
+use futures::io::{AsyncRead, AsyncWrite};
 
 pub trait LocalInfo {
+    fn local_peer_id(&self) -> &PeerId;
     fn local_addr(&self) -> io::Result<SocketAddr>;
 }
 
 pub trait RemoteInfo {
-    fn peer_id(&self) -> &PeerId;
+    fn remote_peer_id(&self) -> &PeerId;
     fn remote_addr(&self) -> SocketAddr;
 }
 
-#[derive(Debug, Error)]
-pub enum EndpointError {
-    #[error(transparent)]
-    Endpoint(#[from] quinn::EndpointError),
-    #[error(transparent)]
-    Connect(#[from] quinn::ConnectError),
-    #[error(transparent)]
-    Connection(#[from] quinn::ConnectionError),
-}
+pub trait Stream: RemoteInfo + AsyncRead + AsyncWrite + Unpin + Send + Sync + Sized {
+    type Read;
+    type Write;
 
-#[derive(Clone)]
-pub struct Endpoint {
-    endpoint: quinn::Endpoint,
-}
-
-impl Endpoint {
-    pub async fn bind<'a>(
-        local_key: &device::Key,
-        listen_addr: SocketAddr,
-    ) -> Result<BoundEndpoint<'a>, EndpointError> {
-        let (endpoint, incoming) = quic::make_endpoint(local_key, listen_addr).await?;
-        let endpoint = Endpoint { endpoint };
-        let incoming = incoming
-            .filter_map(|connecting| async move { connecting.await.ok().map(new_connection) })
-            .boxed();
-
-        Ok(BoundEndpoint { endpoint, incoming })
-    }
-
-    pub async fn connect<'a>(
-        &mut self,
-        peer: &PeerId,
-        addr: &SocketAddr,
-    ) -> Result<(Connection, BoxStream<'a, Result<Stream, ConnectionError>>), EndpointError> {
-        let conn = self
-            .endpoint
-            .connect(addr, peer.as_dns_name().as_ref().into())?
-            .await?;
-
-        Ok(new_connection(conn))
-    }
-}
-
-impl LocalInfo for Endpoint {
-    fn local_addr(&self) -> io::Result<SocketAddr> {
-        self.endpoint.local_addr()
-    }
-}
-
-pub struct BoundEndpoint<'a> {
-    pub endpoint: Endpoint,
-    pub incoming: BoxStream<'a, (Connection, BoxStream<'a, Result<Stream, ConnectionError>>)>,
-}
-
-impl<'a> LocalInfo for BoundEndpoint<'a> {
-    fn local_addr(&self) -> io::Result<SocketAddr> {
-        self.endpoint.local_addr()
-    }
-}
-
-fn new_connection<'a>(
-    NewConnection {
-        connection,
-        bi_streams,
-        ..
-    }: NewConnection,
-) -> (Connection, BoxStream<'a, Result<Stream, ConnectionError>>) {
-    let peer_id = tls::extract_peer_id(
-        connection
-            .authentication_data()
-            .peer_certificates
-            .expect("Certificates must be presented. qed")
-            .iter()
-            .next()
-            .expect("One certificate must have been presented. qed")
-            .as_ref(),
-    )
-    .expect("TLS layer ensures the cert contains a PeerId. qed");
-
-    let conn = Connection::new(&peer_id, connection);
-
-    (
-        conn.clone(),
-        Box::pin(
-            bi_streams
-                .map_ok(move |(send, recv)| Stream {
-                    conn: conn.clone(),
-                    send,
-                    recv,
-                })
-                .map_err(|e| e.into()),
-        ),
-    )
-}
-
-#[derive(Debug, Error)]
-pub enum ConnectionError {
-    #[error(transparent)]
-    Connection(#[from] quinn::ConnectionError),
-}
-
-#[derive(Clone)]
-pub struct Connection {
-    peer: PeerId,
-    conn: quinn::Connection,
-}
-
-impl Connection {
-    pub fn new(peer: &PeerId, conn: quinn::Connection) -> Self {
-        Self {
-            peer: peer.clone(),
-            conn,
-        }
-    }
-
-    pub async fn open_stream(&self) -> Result<Stream, ConnectionError> {
-        let (send, recv) = self.conn.open_bi().await?;
-        Ok(Stream {
-            conn: self.clone(),
-            recv,
-            send,
-        })
-    }
-
-    pub fn close(self, reason: CloseReason) {
-        let code = VarInt::from_u32(reason.clone() as u32);
-        self.conn.close(code, reason.reason().as_bytes())
-    }
-}
-
-impl RemoteInfo for Connection {
-    fn peer_id(&self) -> &PeerId {
-        &self.peer
-    }
-
-    fn remote_addr(&self) -> SocketAddr {
-        self.conn.remote_address()
-    }
+    fn split(self) -> (Self::Read, Self::Write);
 }
 
 #[derive(Clone)]
@@ -197,136 +46,12 @@ pub enum CloseReason {
 }
 
 impl CloseReason {
-    fn reason(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match self {
             Self::DuplicateConnection => "duplicate connection",
             Self::ProtocolDisconnect => "bye!",
             Self::ConnectionError => "connection error",
             Self::InternalError => "internal server error",
         }
-    }
-}
-
-pub struct Stream {
-    conn: Connection,
-    recv: quinn::RecvStream,
-    send: quinn::SendStream,
-}
-
-impl Stream {
-    pub fn framed<C>(self, codec: C) -> Framed<Self, C>
-    where
-        C: Decoder + Encoder,
-    {
-        Framed::new(self, codec)
-    }
-
-    pub fn split(self) -> (RecvStream, SendStream) {
-        (
-            RecvStream {
-                conn: self.conn.clone(),
-                recv: self.recv,
-            },
-            SendStream {
-                conn: self.conn,
-                send: self.send,
-            },
-        )
-    }
-}
-
-impl RemoteInfo for Stream {
-    fn peer_id(&self) -> &PeerId {
-        &self.conn.peer_id()
-    }
-
-    fn remote_addr(&self) -> SocketAddr {
-        self.conn.remote_addr()
-    }
-}
-
-impl AsyncRead for Stream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<Result<usize, io::Error>> {
-        quinn::RecvStream::poll_read(Pin::new(&mut self.get_mut().recv), cx, buf)
-    }
-}
-
-impl AsyncWrite for Stream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &[u8],
-    ) -> Poll<Result<usize, io::Error>> {
-        quinn::SendStream::poll_write(Pin::new(&mut self.get_mut().send), cx, buf)
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
-        quinn::SendStream::poll_flush(Pin::new(&mut self.get_mut().send), cx)
-    }
-
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
-        quinn::SendStream::poll_close(Pin::new(&mut self.get_mut().send), cx)
-    }
-}
-
-pub struct RecvStream {
-    conn: Connection,
-    recv: quinn::RecvStream,
-}
-
-impl RemoteInfo for RecvStream {
-    fn peer_id(&self) -> &PeerId {
-        &self.conn.peer_id()
-    }
-
-    fn remote_addr(&self) -> SocketAddr {
-        self.conn.remote_addr()
-    }
-}
-
-impl AsyncRead for RecvStream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<Result<usize, io::Error>> {
-        quinn::RecvStream::poll_read(Pin::new(&mut self.get_mut().recv), cx, buf)
-    }
-}
-
-pub struct SendStream {
-    conn: Connection,
-    send: quinn::SendStream,
-}
-
-impl RemoteInfo for SendStream {
-    fn peer_id(&self) -> &PeerId {
-        &self.conn.peer_id()
-    }
-
-    fn remote_addr(&self) -> SocketAddr {
-        self.conn.remote_addr()
-    }
-}
-
-impl AsyncWrite for SendStream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &[u8],
-    ) -> Poll<Result<usize, io::Error>> {
-        quinn::SendStream::poll_write(Pin::new(&mut self.get_mut().send), cx, buf)
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
-        quinn::SendStream::poll_flush(Pin::new(&mut self.get_mut().send), cx)
-    }
-
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
-        quinn::SendStream::poll_close(Pin::new(&mut self.get_mut().send), cx)
     }
 }

--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -244,7 +244,9 @@ pub struct Protocol<S, R, W> {
     _marker: PhantomData<R>,
 }
 
-// Inexplicably, Clone cannot be auto-derived
+// `Clone` cannot be auto-derived, because the compiler can't see that `R` is
+// only `PhantomData`, and `W` is behind an `Arc`. It places `Clone` constraints
+// on `R` and `W`, which we can't (and don't want to) satisfy.
 impl<S: Clone, R, W> Clone for Protocol<S, R, W> {
     fn clone(&self) -> Self {
         Self {

--- a/librad/src/net/quic.rs
+++ b/librad/src/net/quic.rs
@@ -15,24 +15,317 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{io, net::SocketAddr, pin::Pin, sync::Arc};
 
-use quinn::{self, Endpoint, EndpointError, Incoming};
+use futures::{
+    io::{AsyncRead, AsyncWrite},
+    stream::{BoxStream, StreamExt, TryStreamExt},
+    task::{Context, Poll},
+};
+use futures_codec::{Decoder, Encoder, Framed};
+use quinn::{self, NewConnection, VarInt};
+use thiserror::Error;
 
-use crate::{keys::device, net::tls};
+use crate::{
+    keys::device,
+    net::{
+        connection::{self, CloseReason, LocalInfo, RemoteInfo},
+        tls,
+    },
+    peer::PeerId,
+};
 
-pub async fn make_endpoint(
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Endpoint(#[from] quinn::EndpointError),
+    #[error(transparent)]
+    Connect(#[from] quinn::ConnectError),
+    #[error(transparent)]
+    Connection(#[from] quinn::ConnectionError),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Clone)]
+pub struct Endpoint {
+    peer_id: PeerId,
+    endpoint: quinn::Endpoint,
+}
+
+impl Endpoint {
+    pub async fn bind<'a>(
+        local_key: &device::Key,
+        listen_addr: SocketAddr,
+    ) -> Result<BoundEndpoint<'a>> {
+        let (endpoint, incoming) = make_endpoint(local_key, listen_addr).await?;
+        let endpoint = Endpoint {
+            peer_id: PeerId::from(local_key),
+            endpoint,
+        };
+        let incoming = incoming
+            .filter_map(|connecting| async move { connecting.await.ok().map(new_connection) })
+            .boxed();
+
+        Ok(BoundEndpoint { endpoint, incoming })
+    }
+
+    pub async fn connect<'a>(
+        &mut self,
+        peer: &PeerId,
+        addr: &SocketAddr,
+    ) -> Result<(Connection, BoxStream<'a, Result<Stream>>)> {
+        let conn = self
+            .endpoint
+            .connect(addr, peer.as_dns_name().as_ref().into())?
+            .await?;
+
+        Ok(new_connection(conn))
+    }
+}
+
+impl LocalInfo for Endpoint {
+    fn local_peer_id(&self) -> &PeerId {
+        &self.peer_id
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.endpoint.local_addr()
+    }
+}
+
+pub type Incoming<'a> = BoxStream<'a, Result<Stream>>;
+
+pub struct BoundEndpoint<'a> {
+    pub endpoint: Endpoint,
+    pub incoming: BoxStream<'a, (Connection, Incoming<'a>)>,
+}
+
+impl<'a> LocalInfo for BoundEndpoint<'a> {
+    fn local_peer_id(&self) -> &PeerId {
+        self.endpoint.local_peer_id()
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.endpoint.local_addr()
+    }
+}
+
+fn new_connection<'a>(
+    NewConnection {
+        connection,
+        bi_streams,
+        ..
+    }: NewConnection,
+) -> (Connection, Incoming<'a>) {
+    let peer_id = tls::extract_peer_id(
+        connection
+            .authentication_data()
+            .peer_certificates
+            .expect("Certificates must be presented. qed")
+            .iter()
+            .next()
+            .expect("One certificate must have been presented. qed")
+            .as_ref(),
+    )
+    .expect("TLS layer ensures the cert contains a PeerId. qed");
+
+    let conn = Connection::new(&peer_id, connection);
+
+    (
+        conn.clone(),
+        Box::pin(
+            bi_streams
+                .map_ok(move |(send, recv)| Stream {
+                    conn: conn.clone(),
+                    send: SendStream {
+                        conn: conn.clone(),
+                        send,
+                    },
+                    recv: RecvStream {
+                        conn: conn.clone(),
+                        recv,
+                    },
+                })
+                .map_err(|e| e.into()),
+        ),
+    )
+}
+
+#[derive(Debug, Error)]
+pub enum ConnectionError {
+    #[error(transparent)]
+    Connection(#[from] quinn::ConnectionError),
+}
+
+#[derive(Clone)]
+pub struct Connection {
+    peer: PeerId,
+    conn: quinn::Connection,
+}
+
+impl Connection {
+    pub fn new(peer: &PeerId, conn: quinn::Connection) -> Self {
+        Self {
+            peer: peer.clone(),
+            conn,
+        }
+    }
+
+    pub async fn open_stream(&self) -> Result<Stream> {
+        let (send, recv) = self.conn.open_bi().await?;
+        Ok(Stream {
+            conn: self.clone(),
+            recv: RecvStream {
+                conn: self.clone(),
+                recv,
+            },
+            send: SendStream {
+                conn: self.clone(),
+                send,
+            },
+        })
+    }
+
+    pub fn close(self, reason: CloseReason) {
+        let code = VarInt::from_u32(reason.clone() as u32);
+        self.conn.close(code, reason.as_str().as_bytes())
+    }
+}
+
+impl RemoteInfo for Connection {
+    fn remote_peer_id(&self) -> &PeerId {
+        &self.peer
+    }
+
+    fn remote_addr(&self) -> SocketAddr {
+        self.conn.remote_address()
+    }
+}
+
+pub struct Stream {
+    conn: Connection,
+    recv: RecvStream,
+    send: SendStream,
+}
+
+impl Stream {
+    pub fn framed<C>(self, codec: C) -> Framed<Self, C>
+    where
+        C: Decoder + Encoder,
+    {
+        Framed::new(self, codec)
+    }
+}
+
+impl RemoteInfo for Stream {
+    fn remote_peer_id(&self) -> &PeerId {
+        &self.conn.remote_peer_id()
+    }
+
+    fn remote_addr(&self) -> SocketAddr {
+        self.conn.remote_addr()
+    }
+}
+
+impl connection::Stream for Stream {
+    type Read = RecvStream;
+    type Write = SendStream;
+
+    fn split(self) -> (Self::Read, Self::Write) {
+        (self.recv, self.send)
+    }
+}
+
+impl AsyncRead for Stream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<std::result::Result<usize, io::Error>> {
+        AsyncRead::poll_read(Pin::new(&mut self.get_mut().recv), cx, buf)
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
+        AsyncWrite::poll_write(Pin::new(&mut self.get_mut().send), cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_flush(Pin::new(&mut self.get_mut().send), cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_close(Pin::new(&mut self.get_mut().send), cx)
+    }
+}
+
+pub struct RecvStream {
+    conn: Connection,
+    recv: quinn::RecvStream,
+}
+
+impl RemoteInfo for RecvStream {
+    fn remote_peer_id(&self) -> &PeerId {
+        &self.conn.remote_peer_id()
+    }
+
+    fn remote_addr(&self) -> SocketAddr {
+        self.conn.remote_addr()
+    }
+}
+
+impl AsyncRead for RecvStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncRead::poll_read(Pin::new(&mut self.get_mut().recv), cx, buf)
+    }
+}
+
+pub struct SendStream {
+    conn: Connection,
+    send: quinn::SendStream,
+}
+
+impl RemoteInfo for SendStream {
+    fn remote_peer_id(&self) -> &PeerId {
+        &self.conn.remote_peer_id()
+    }
+
+    fn remote_addr(&self) -> SocketAddr {
+        self.conn.remote_addr()
+    }
+}
+
+impl AsyncWrite for SendStream {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
+        AsyncWrite::poll_write(Pin::new(&mut self.get_mut().send), cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_flush(Pin::new(&mut self.get_mut().send), cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_close(Pin::new(&mut self.get_mut().send), cx)
+    }
+}
+async fn make_endpoint(
     key: &device::Key,
     listen_addr: SocketAddr,
-) -> Result<(Endpoint, Incoming), EndpointError> {
-    let mut builder = Endpoint::builder();
+) -> std::result::Result<(quinn::Endpoint, quinn::Incoming), quinn::EndpointError> {
+    let mut builder = quinn::Endpoint::builder();
     builder.default_client_config(make_client_config(key));
     builder.listen(make_server_config(key));
 
     builder.bind(&listen_addr)
 }
 
-pub fn make_client_config(key: &device::Key) -> quinn::ClientConfig {
+fn make_client_config(key: &device::Key) -> quinn::ClientConfig {
     let mut quic_config = quinn::ClientConfigBuilder::default().build();
     let tls_config = Arc::new(tls::make_client_config(key));
     quic_config.crypto = tls_config;
@@ -40,7 +333,7 @@ pub fn make_client_config(key: &device::Key) -> quinn::ClientConfig {
     quic_config
 }
 
-pub fn make_server_config(key: &device::Key) -> quinn::ServerConfig {
+fn make_server_config(key: &device::Key) -> quinn::ServerConfig {
     let mut quic_config = quinn::ServerConfigBuilder::default().build();
     let tls_config = Arc::new(tls::make_server_config(key));
     quic_config.crypto = tls_config;

--- a/librad/src/peer.rs
+++ b/librad/src/peer.rs
@@ -83,6 +83,12 @@ impl From<device::Key> for PeerId {
     }
 }
 
+impl From<&device::Key> for PeerId {
+    fn from(k: &device::Key) -> Self {
+        Self(k.public())
+    }
+}
+
 impl Serialize for PeerId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
This manages to generalise the IO types for the gossip protocol to basically `AsyncRead + AsyncWrite`. Due to the lack of existential quantification in Rust (and other inexcusable quirks with trait objects), this is not possible for the git transport, and consequently the main protocol loop.

Fixes #60 