### PR TITLE
Box away the git transport stream.

### DIFF
--- a/librad/src/git/transport.rs
+++ b/librad/src/git/transport.rs
@@ -56,13 +56,13 @@ use std::{
 use async_trait::async_trait;
 use futures::{
     executor::block_on,
-    io::{AsyncReadExt, AsyncWriteExt},
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
 };
 use git2::transport::{Service, SmartSubtransport, SmartSubtransportStream, Transport};
 use log::error;
 use url::Url;
 
-use crate::{net::quic, peer::PeerId};
+use crate::peer::PeerId;
 
 type Factories = Arc<RwLock<HashMap<PeerId, Box<dyn GitStreamFactory>>>>;
 
@@ -70,11 +70,17 @@ lazy_static! {
     static ref FACTORIES: Factories = Arc::new(RwLock::new(HashMap::with_capacity(1)));
 }
 
-/// Trait for types which can provide a [`quic::Stream`] over which we can send
+/// The underlying [`AsyncRead`] + [`AsyncRead`] of a [`RadSubTransport`]
+///
+/// We need this as a trait because we can't write `Box<dyn AsyncRead +
+/// AsyncWrite + Unpin + Send>` directly.
+pub trait GitStream: AsyncRead + AsyncWrite + Unpin + Send {}
+
+/// Trait for types which can provide a [`GitStream`] over which we can send
 /// / receive bytes to / from the specified peer.
 #[async_trait]
 pub trait GitStreamFactory: Sync + Send {
-    async fn open_stream(&self, to: &PeerId) -> Option<quic::Stream>;
+    async fn open_stream(&self, to: &PeerId) -> Option<Box<dyn GitStream>>;
 }
 
 /// Register the `rad://` transport with `libgit`.
@@ -122,7 +128,7 @@ impl RadTransport {
         self.fac.write().unwrap().insert(peer_id.clone(), fac);
     }
 
-    fn open_stream(&self, from: &PeerId, to: &PeerId) -> Option<quic::Stream> {
+    fn open_stream(&self, from: &PeerId, to: &PeerId) -> Option<Box<dyn GitStream>> {
         self.fac
             .read()
             .unwrap()
@@ -169,7 +175,7 @@ struct RadSubTransport {
     remote_peer: PeerId,
     remote_repo: String,
     service: Service,
-    stream: quic::Stream,
+    stream: Box<dyn GitStream>,
 }
 
 impl RadSubTransport {

--- a/librad/src/net/quic.rs
+++ b/librad/src/net/quic.rs
@@ -27,6 +27,7 @@ use quinn::{self, NewConnection, VarInt};
 use thiserror::Error;
 
 use crate::{
+    git::transport::GitStream,
     keys::device,
     net::{
         connection::{self, CloseReason, LocalInfo, RemoteInfo},
@@ -227,6 +228,8 @@ impl RemoteInfo for Stream {
         self.conn.remote_addr()
     }
 }
+
+impl GitStream for Stream {}
 
 impl connection::Stream for Stream {
     type Read = RecvStream;


### PR DESCRIPTION
Previous attempts failed due to poor type inference (see comment of
`impl GitStreamFactory for Protocol`).