### PR TITLE
Tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,6 +1105,9 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
  "url 2.1.1",
  "urltemplate",
  "webpki",
@@ -1180,6 +1183,15 @@ name = "mach_o_sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e854583a83f20cf329bb9283366335387f7db59d640d1412167e05fedb98826"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matches"
@@ -1998,6 +2010,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2277,15 @@ dependencies = [
  "digest",
  "keccak",
  "opaque-debug",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae75d0445b5d3778c9da3d1f840faa16d0627c8607f78a74daf69e5b988c39a1"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2603,6 +2634,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b0b7fd92dc7b71f29623cc6836dd7200f32161a2313dd78be233a8405694f6"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dedebcf5813b02261d6bab3a12c6a8ae702580c0405a2e8ec16c3713caf14c20"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013a6e0a2cbe3d20f9c60b65458f7a7f7a5e636c5d0f45a5a6aee5d4b1f01785"
+checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 
 [[package]]
 name = "arc-swap"
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.26"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a03abb7c9b93ae229356151a083d26218c0358866a2a59d4280c856e9482e6"
+checksum = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "3.7.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010ef3f25ed5bb93505a3238d19957622190268640526aab07174c66ccf5d611"
+checksum = "002042a65ff32569ea25dfe1deb5b82903b19ed7d9a621e45d0bf18d2daa947c"
 dependencies = [
  "ahash 0.3.2",
  "cfg-if",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "err-derive"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f46c91bbed409ee74495549acbfcc7fae856e712e1df15afe75d0775eedc6c"
+checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -595,9 +595,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "filetime"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+checksum = "f59efc38004c988e4201d11d263b8171f49a2e7ec0bdbb71773433f271504a5e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 dependencies = [
  "libc",
 ]
@@ -954,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
+checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1016,9 +1016,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 
 [[package]]
 name = "libflate"
@@ -1162,9 +1162,9 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "lock_api"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
 ]
@@ -1467,9 +1467,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.54"
+version = "0.9.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
+checksum = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
@@ -1486,9 +1486,9 @@ checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 
 [[package]]
 name = "parking_lot"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1496,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
+checksum = "0e136c1904604defe99ce5fd71a28d473fa60a12255d511aa78a9ddf11237aeb"
 dependencies = [
  "cfg-if",
  "cloudabi",
@@ -1569,18 +1569,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
+checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
+checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1619,9 +1619,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.12"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -1632,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.12"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcfdefadc3d57ca21cf17990a28ef4c0f7c61383a28cb7604cf4a18e6ede1420"
+checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
 
 [[package]]
 name = "proc-macro-nested"
@@ -1657,18 +1657,18 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "proptest"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6147d103a7c9d7598f4105cf049b15c99e2ecd93179bf024f0fd349be5ada4"
+checksum = "01c477819b845fe023d33583ebf10c9f62518c8d79a0960ba5c36d6ac8a55a5b"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -1712,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea81de5e0f97f552239ce4eff6fa8e8b0e3ec0ba5a8f1d84fb2096f4ba2ad41"
+checksum = "88de58d76d8f82fb28e5c89302119c102bb5b9ce57b034186b559b63ba147a0f"
 dependencies = [
  "bytes",
  "err-derive",
@@ -1730,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70cb5efbbd520ef4a5361fb0ec64360dcd873cfb76c1be2f1d2594729d7b5a"
+checksum = "f0ea0a358c179c6b7af34805c675d1664a9c6a234a7acd7efdbb32d2f39d3d2a"
 dependencies = [
  "bytes",
  "err-derive",
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.11"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
+checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
 dependencies = [
  "cc",
  "lazy_static",
@@ -2179,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
+checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 dependencies = [
  "serde_derive",
 ]
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
+checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2210,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.48"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
 dependencies = [
  "itoa",
  "ryu",
@@ -2318,15 +2318,15 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
 
 [[package]]
 name = "socket2"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2399,9 +2399,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8faa2719539bbe9d77869bfb15d4ee769f99525e707931452c97b693b3f159d"
+checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2410,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
+checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2518,18 +2518,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3711fd1c4e75b3eff12ba5c40dba762b6b65c5476e8174c1a664772060c49bf"
+checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2b85ba4c9aa32dd3343bd80eb8d22e9b54b7688c17ea3907f236885353b233"
+checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2558,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.13"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
+checksum = "34ef16d072d2b6dc8b4a56c70f5c5ced1a37752116f8e7c1e80c659aa7cb6713"
 dependencies = [
  "bytes",
  "fnv",
@@ -2669,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dedebcf5813b02261d6bab3a12c6a8ae702580c0405a2e8ec16c3713caf14c20"
+checksum = "cfc50df245be6f0adf35c399cb16dea60e2c7d6cc83ff5dc22d727df06dd6f0c"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -2689,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-bidi"
@@ -2737,9 +2737,9 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38e01ad4b98f042e166c1bf9a13f9873a99d79eaa171ce7ca81e6dd0f895d8a"
+checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
 
 [[package]]
 name = "untrusted"
@@ -2820,9 +2820,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
+checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2830,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
+checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2845,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
+checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2855,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
+checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2868,15 +2868,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
+checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
 
 [[package]]
 name = "web-sys"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"
+checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2922,9 +2922,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
+checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,25 @@
+# copied expressions from https://nixos.wiki/wiki/Rust
+# and Mozilla's nix overlay README
+# https://www.scala-native.org/en/latest/user/setup.html
+let
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
+in
+  with pkgs;
+  stdenv.mkDerivation {
+    name = "clang-env-with-nightly-rust";
+    buildInputs = [
+      (pkgs.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust
+      clang
+      llvmPackages.libclang
+      olm
+      pkgconfig
+      openssl
+      gmp
+      m4
+    ];
+    # why do we need to set the library path manually?
+    shellHook = ''
+      export LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
+    '';
+  }

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -48,6 +48,8 @@ tempfile = "3.1"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["full"] }
 tokio-util = { version = "0.3.0", features = ["compat"] }
+tracing = "0.1"
+tracing-futures = "0.2"
 url = { version = "2.1", features = ["serde"] }
 urltemplate = "0.1"
 webpki = "0.21"
@@ -56,6 +58,7 @@ bs58 = "0.3"
 
 [dev-dependencies]
 env_logger = "0.7"
+futures-await-test = "0.3"
 matches = "0.1"
 proptest = "0.9"
-futures-await-test = "0.3"
+tracing-subscriber = "0.2"

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 async-trait = "0.1"
 bit-vec = "0.6"
+bs58 = "0.3"
 bytes = "0.5"
 directories = "2.0"
 failure = { version = "0.1", features = ["backtrace"] }
@@ -54,7 +55,6 @@ url = { version = "2.1", features = ["serde"] }
 urltemplate = "0.1"
 webpki = "0.21"
 yasna = { version = "0.3", features = ["bit-vec"] }
-bs58 = "0.3"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/librad/src/git/server.rs
+++ b/librad/src/git/server.rs
@@ -52,6 +52,9 @@ impl GitServer {
         R: AsyncRead + Unpin,
         W: AsyncWrite + Unpin,
     {
+        let span = tracing::trace_span!("GitServer::invoke_service", git.server.path = %self.export.display());
+        let _guard = span.enter();
+
         let mut recv = BufReader::new(recv);
         let mut header = String::with_capacity(512);
         if let Err(e) = recv.read_line(&mut header).await {

--- a/librad/src/git/transport.rs
+++ b/librad/src/git/transport.rs
@@ -59,7 +59,7 @@ use futures::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
 };
 use git2::transport::{Service, SmartSubtransport, SmartSubtransportStream, Transport};
-use log::error;
+use tracing;
 use url::Url;
 
 use crate::peer::PeerId;
@@ -240,7 +240,7 @@ impl Write for RadSubTransport {
 fn git_error<E: Display>(err: E) -> git2::Error {
     // libgit will always tell us "an unknown error occurred", so log them out
     // here
-    error!("git transport error: {}", err);
+    tracing::error!("git transport error: {}", err);
     git2::Error::from_str(&err.to_string())
 }
 

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -283,7 +283,7 @@ where
             Run::Gossip { event } => match event {
                 gossip::ProtocolEvent::Control(ctrl) => match ctrl {
                     gossip::Control::SendAdhoc { to, rpc } => {
-                        tracing::trace!("Run::Rad(SendAdhoc): {}", to.peer_id);
+                        tracing::trace!("Run::Rad(SendAdhoc)");
                         let conn = match self.connections.lock().await.get(&to.peer_id) {
                             Some(conn) => Some(conn.clone()),
                             None => connect_peer_info(&endpoint, to).await.map(|(conn, _)| conn),

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -27,10 +27,11 @@ use futures::{
     stream::{BoxStream, StreamExt, TryStreamExt},
 };
 use futures_codec::{CborCodec, CborCodecError, FramedRead, FramedWrite};
-use log::{debug, error, info, trace, warn};
+// use log::{debug, error, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use thiserror::Error;
+use tracing;
 
 use crate::{
     channel::Fanout,
@@ -176,6 +177,9 @@ where
         Disco: futures::stream::Stream<Item = (PeerId, Vec<SocketAddr>)>,
         Shutdown: Future<Output = ()> + Send,
     {
+        let span = tracing::trace_span!("Protocol::run");
+        let _guard = span.enter();
+
         let incoming = incoming.map(|(conn, i)| Ok(Run::Incoming { conn, incoming: i }));
         let shutdown = futures::stream::once(shutdown).map(|()| Ok(Run::Shutdown));
         let bootstrap = disco.map(|(peer, addrs)| Ok(Run::Discovered { peer, addrs }));
@@ -185,7 +189,7 @@ where
             .await
             .map(|event| Ok(Run::Gossip { event }));
 
-        info!("Listening on {:?}", endpoint.local_addr());
+        tracing::info!(msg = "Listening", local.addr = ?endpoint.local_addr());
 
         futures::stream::select(
             shutdown,
@@ -197,7 +201,7 @@ where
             async move { this.eval_run(endpoint, run).await }
         })
         .await
-        .unwrap_or_else(|()| warn!("Shutting down"))
+        .unwrap_or_else(|()| tracing::warn!("Shutting down"))
     }
 
     /// Subscribe to an infinite stream of [`ProtocolEvent`]s.
@@ -234,16 +238,16 @@ where
 
     /// Open a QUIC stream which is upgraded to expect the git protocol
     pub async fn open_git(&self, to: &PeerId) -> Option<quic::Stream> {
-        trace!("Opening git stream to {}", to);
+        tracing::trace!("Opening git stream");
         if let Some(conn) = self.connections.lock().await.get(to) {
             conn.open_stream()
                 .map_err(|e| e.into())
                 .and_then(|stream| upgrade(stream, Upgrade::Git))
                 .await
-                .map_err(|e| error!("{}", e))
+                .map_err(|e| tracing::error!("{}", e))
                 .ok()
         } else {
-            warn!("Error opening git stream: not connected to {}", to);
+            tracing::warn!("Error opening git stream: not connected to {}", to);
             None
         }
     }
@@ -251,7 +255,13 @@ where
     async fn eval_run(&mut self, endpoint: quic::Endpoint, run: Run<'_, A>) -> Result<(), ()> {
         match run {
             Run::Discovered { peer, addrs } => {
-                trace!("Run::Discovered: {}@{:?}", peer, addrs);
+                let span = tracing::trace_span!(
+                    "Run::Discovered",
+                    peer.id = %peer,
+                    peer.addrs = ?addrs
+                );
+                let _guard = span.enter();
+
                 if !self.connections.lock().await.contains_key(&peer) {
                     if let Some((conn, incoming)) = connect(&endpoint, &peer, addrs).await {
                         self.handle_connect(conn, incoming.boxed(), None).await;
@@ -262,16 +272,18 @@ where
             },
 
             Run::Incoming { conn, incoming } => {
-                trace!("Run::Incoming: {}", conn.remote_addr());
+                let span = tracing::trace_span!("Run::Incoming", peer.id = %conn.remote_peer_id(), peer.addrs = %conn.remote_addr());
+                let _guard = span.enter();
+
                 self.handle_incoming(conn, incoming)
                     .await
-                    .map_err(|e| warn!("Error processing incoming connection: {}", e))
+                    .map_err(|e| tracing::warn!("Error processing incoming connection: {}", e))
             },
 
             Run::Gossip { event } => match event {
                 gossip::ProtocolEvent::Control(ctrl) => match ctrl {
                     gossip::Control::SendAdhoc { to, rpc } => {
-                        trace!("Run::Rad(SendAdhoc): {}", to.peer_id);
+                        tracing::trace!("Run::Rad(SendAdhoc): {}", to.peer_id);
                         let conn = match self.connections.lock().await.get(&to.peer_id) {
                             Some(conn) => Some(conn.clone()),
                             None => connect_peer_info(&endpoint, to).await.map(|(conn, _)| conn),
@@ -279,24 +291,23 @@ where
 
                         if let Some(conn) = conn {
                             let stream = conn.open_stream().await.map_err(|e| {
-                                warn!(
+                                tracing::warn!(
                                     "Could not open stream on connection to {}: {}",
                                     conn.remote_addr(),
                                     e
                                 )
                             })?;
 
-                            return self
-                                .outgoing(stream, rpc)
-                                .await
-                                .map_err(|e| warn!("Error processing outgoing stream: {}", e));
+                            return self.outgoing(stream, rpc).await.map_err(|e| {
+                                tracing::warn!("Error processing outgoing stream: {}", e)
+                            });
                         }
 
                         Ok(())
                     },
 
                     gossip::Control::Connect { to, hello } => {
-                        trace!("Run::Rad(Connect): {}", to.peer_id);
+                        tracing::trace!("Run::Rad(Connect)");
                         if !self.connections.lock().await.contains_key(&to.peer_id) {
                             let conn = connect_peer_info(&endpoint, to).await;
                             if let Some((conn, incoming)) = conn {
@@ -309,7 +320,7 @@ where
                     },
 
                     gossip::Control::Disconnect(peer) => {
-                        trace!("Run::Rad(Disconnect): {}", peer);
+                        tracing::trace!("Run::Rad(Disconnect)");
                         self.handle_disconnect(peer).await;
                         Ok(())
                     },
@@ -319,7 +330,7 @@ where
             },
 
             Run::Shutdown => {
-                debug!("Run::Shutdown");
+                tracing::debug!("Run::Shutdown");
                 Err(())
             },
         }
@@ -331,10 +342,8 @@ where
         mut incoming: BoxStream<'_, quic::Result<quic::Stream>>,
         hello: impl Into<Option<gossip::Rpc<A>>>,
     ) {
+        tracing::info!("New outgoing connection");
         let remote_id = conn.remote_peer_id().clone();
-        let remote_addr = conn.remote_addr();
-
-        info!("New outgoing connection: {}@{}", remote_id, remote_addr,);
 
         {
             self.connections
@@ -364,14 +373,14 @@ where
         );
 
         if let Err(e) = res {
-            warn!("Closing connection with {}, because: {}", remote_id, e);
+            tracing::warn!("Closing connection with {}, because: {}", remote_id, e);
             conn.close(CloseReason::InternalError);
         };
     }
 
     async fn handle_disconnect(&self, peer: PeerId) {
         if let Some(conn) = self.connections.lock().await.remove(&peer) {
-            info!("Disconnecting: {}", conn.remote_addr());
+            tracing::info!(msg = "Disconnecting", remote.addr = %conn.remote_addr());
             // FIXME: make this more graceful
             conn.close(CloseReason::ProtocolDisconnect);
             self.subscribers
@@ -389,9 +398,8 @@ where
         Incoming: futures::Stream<Item = quic::Result<quic::Stream>> + Unpin,
     {
         let remote_id = conn.remote_peer_id().clone();
-        let remote_addr = conn.remote_addr();
 
-        info!("New incoming connection: {}@{}", remote_id, remote_addr);
+        tracing::info!("New incoming connection");
 
         {
             self.connections
@@ -404,11 +412,11 @@ where
         }
 
         while let Some(stream) = incoming.try_next().await? {
-            trace!("New incoming stream");
+            tracing::trace!("New incoming stream");
             let this = self.clone();
             tokio::spawn(async move {
                 if let Err(e) = this.incoming(stream).await {
-                    warn!("Incoming stream error: {}", e);
+                    tracing::warn!("Incoming stream error: {}", e);
                 }
             });
         }
@@ -442,7 +450,7 @@ where
                         .send(UpgradeResponse::SwitchingProtocols(upgrade.clone()))
                         .await?;
 
-                    trace!("Incoming stream upgraded to {:?}", upgrade);
+                    tracing::trace!(msg = "Incoming stream upgraded", upgrade = ?upgrade);
 
                     // remove framing
                     let stream = stream.release().0;
@@ -486,6 +494,9 @@ where
     for<'de> A: Serialize + Deserialize<'de> + Clone + Debug + Send + Sync + 'static,
 {
     async fn open_stream(&self, to: &PeerId) -> Option<Box<dyn GitStream>> {
+        let span = tracing::trace_span!("GitStreamFactory::open_stream", peer.id = %to);
+        let _guard = span.enter();
+
         // Nb.: type inference fails if this is not a pattern match (ie. `map`)
         match self.open_git(to).await {
             Some(s) => Some(Box::new(s)),
@@ -519,12 +530,12 @@ where
     futures::stream::iter(addrs)
         .filter_map(|addr| {
             let mut endpoint = endpoint.clone();
-            info!("Connecting to: {}@{}", peer_id, addr);
+            tracing::info!("Establishing connection");
             Box::pin(async move {
                 match endpoint.connect(peer_id, &addr).await {
                     Ok(conn) => Some(conn),
                     Err(e) => {
-                        warn!("Could not connect to {} at {}: {}", peer_id, addr, e);
+                        tracing::warn!("Could not connect to {} at {}: {}", peer_id, addr, e);
                         None
                     },
                 }
@@ -535,7 +546,7 @@ where
 }
 
 async fn upgrade(stream: quic::Stream, upgrade: Upgrade) -> Result<quic::Stream, Error> {
-    trace!("Upgrade to {:?}", upgrade);
+    tracing::trace!(msg = "Upgrade", upgrade = ?upgrade);
 
     let mut stream = stream.framed(CborCodec::<Upgrade, UpgradeResponse>::new());
     stream.send(upgrade.clone()).await?;

--- a/librad/src/peer.rs
+++ b/librad/src/peer.rs
@@ -17,9 +17,9 @@
 
 use std::{convert::TryFrom, fmt, str::FromStr};
 
-use log::trace;
 use multibase::Base::Base32Z;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use tracing;
 
 use crate::keys::device;
 
@@ -163,7 +163,7 @@ impl<'a> TryFrom<webpki::DNSNameRef<'a>> for PeerId {
     fn try_from(dns_name: webpki::DNSNameRef) -> Result<Self, Self::Error> {
         let dns_name: &str = dns_name.into();
         PeerId::from_str(dns_name).map_err(|e| {
-            trace!("PeerId::from_str({}) failed: {}", dns_name, e);
+            tracing::trace!(msg = "PeerId::from_str failed", dns.name = %dns_name, error = %e);
             webpki::Error::NameConstraintViolation
         })
     }


### PR DESCRIPTION
Fixes #81 

This introduces tracing into librad to replace log.
We import it qualified so that it makes it easy to use any of the
functionality from the lib with updating the imports.

tracing allows us to introduce spans at a top-level so that common
information can percolate down.

The extra benefit to tracing is that we can pass in key, value pairs to
trace statements for structured logging purposes.