### PR TITLE
Data structures for identities and verification.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-await-test"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0d3d05bce73a572ba581e4f4a7f20164c18150169c3a67f406aada3e48c7e8"
+dependencies = [
+ "futures-await-test-macro",
+ "futures-executor",
+]
+
+[[package]]
+name = "futures-await-test-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f150175e6832600500334550e00e4dc563a0b32f58a9d1ad407f6473378c839"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1068,7 @@ dependencies = [
  "env_logger",
  "failure",
  "futures",
+ "futures-await-test",
  "futures-timer 3.0.2",
  "futures_codec",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
+
+[[package]]
 name = "buffered-reader"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1041,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bit-vec 0.6.1",
+ "bs58",
  "bytes",
  "directories",
  "env_logger",

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -59,4 +59,5 @@ multihash = "0.10.1"
 env_logger = "0.7"
 matches = "0.1"
 proptest = "0.9"
+futures-await-test = "0.3.0"
 

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -52,7 +52,8 @@ url = { version = "2.1", features = ["serde"] }
 urltemplate = "0.1"
 webpki = "0.21"
 yasna = { version = "0.3", features = ["bit-vec"] }
-
+bs58 = "0.3.0"
+multihash = "0.10.1"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -52,12 +52,11 @@ url = { version = "2.1", features = ["serde"] }
 urltemplate = "0.1"
 webpki = "0.21"
 yasna = { version = "0.3", features = ["bit-vec"] }
-bs58 = "0.3.0"
-multihash = "0.10.1"
+bs58 = "0.3"
+multihash = "0.10"
 
 [dev-dependencies]
 env_logger = "0.7"
 matches = "0.1"
 proptest = "0.9"
-futures-await-test = "0.3.0"
-
+futures-await-test = "0.3"

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -53,7 +53,6 @@ urltemplate = "0.1"
 webpki = "0.21"
 yasna = { version = "0.3", features = ["bit-vec"] }
 bs58 = "0.3"
-multihash = "0.10"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/librad/src/id.rs
+++ b/librad/src/id.rs
@@ -15,29 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![feature(str_strip)]
-
-extern crate radicle_keystore as keystore;
-extern crate sequoia_openpgp as pgp;
-extern crate sodiumoxide;
-#[macro_use]
-extern crate lazy_static;
-
-pub use radicle_surf as surf;
-
-pub mod git;
-pub mod id;
-pub mod keys;
-pub mod meta;
-pub mod net;
-pub mod paths;
-pub mod peer;
+pub mod entity;
 pub mod project;
-pub mod sync;
 pub mod uri;
+pub mod user;
 
-pub(crate) mod channel;
-
-pub fn init() -> bool {
-    sodiumoxide::init().is_ok()
-}
+#[cfg(test)]
+pub mod test;

--- a/librad/src/id/entity.rs
+++ b/librad/src/id/entity.rs
@@ -304,7 +304,7 @@ where
     }
 
     pub fn canonical_data(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.to_data().canonical_data()?)
+        self.to_data().canonical_data()
     }
     pub fn to_json_writer<W>(&self, writer: W) -> Result<(), Error>
     where
@@ -314,21 +314,17 @@ where
         Ok(())
     }
     pub fn to_json_string(&self) -> Result<String, Error> {
-        Ok(self.to_data().to_json_string()?)
+        self.to_data().to_json_string()
     }
 
     pub fn from_json_reader<R>(r: R) -> Result<Self, Error>
     where
         R: std::io::Read,
     {
-        Ok(Self::from_data(
-            data::EntityData::from_json_reader(r)?.to_owned(),
-        )?)
+        Self::from_data(data::EntityData::from_json_reader(r)?.to_owned())
     }
     pub fn from_json_str(s: &str) -> Result<Self, Error> {
-        Ok(Self::from_data(
-            data::EntityData::from_json_str(s)?.to_owned(),
-        )?)
+        Self::from_data(data::EntityData::from_json_str(s)?.to_owned())
     }
 
     pub fn compute_hash(&self) -> Result<Multihash, Error> {

--- a/librad/src/id/entity.rs
+++ b/librad/src/id/entity.rs
@@ -335,25 +335,6 @@ where
         Ok(Sha2_256::digest(&self.canonical_data()?))
     }
 
-    pub async fn check_user_key(
-        &self,
-        user_uri: &RadicleUri,
-        key: &PublicKey,
-        resolver: &impl Resolver<User>,
-    ) -> Result<(), Error> {
-        if !self.has_key(key) {
-            return Err(Error::KeyNotPresent(key.to_owned()));
-        }
-        let user = resolver.resolve(user_uri).await?;
-        if !user.has_key(key) {
-            return Err(Error::UserKeyNotPresentWIP(
-                user_uri.to_owned(),
-                key.to_owned(),
-            ));
-        }
-        Ok(())
-    }
-
     pub async fn check_key(
         &self,
         key: &PublicKey,

--- a/librad/src/id/entity.rs
+++ b/librad/src/id/entity.rs
@@ -170,13 +170,12 @@ impl VerificationStatus {
     }
 }
 
-/// A type expressing *who* is signing an `Entity`:
-///
-///  * either a specific user (identified by their URN),
-///  * or the entity itself (with an owned key).
+/// A type expressing *who* is signing an `Entity`
 #[derive(Clone, Debug)]
 pub enum Signatory {
+    /// A specific user (identified by their URN)
     User(RadicleUri),
+    /// The entity itself (with an owned key)
     OwnedKey,
 }
 
@@ -206,7 +205,7 @@ pub trait Resolver<T> {
 /// - Their identity is stable (it does not change over time), and it is the
 ///   hash of their initial revision.
 /// - Each revision contains the hash of the previous revision, which is also
-///   hashed, so that the sequence of revisions is a Merkel tree (actually just
+///   hashed, so that the sequence of revisions is a Merkle tree (actually just
 ///   a list).
 /// - They can be signed, either with a key they own, or using a key belonging
 ///   to a different entity (the certifier); note that when applying multiple
@@ -262,7 +261,7 @@ where
         self.revision
     }
 
-    /// Build and `Entity` from its data (the second step of deserialization)
+    /// Build an `Entity` from its data (the second step of deserialization)
     /// It guarantees that the `hash` is correct
     pub fn from_data(data: data::EntityData<T>) -> Result<Self, Error> {
         if data.name.is_none() {
@@ -377,7 +376,7 @@ where
     }
 
     /// Turn the entity in to its raw data
-    /// (first step of serialization and reverse of `from_data`)
+    /// (first step of serialization and reverse of [`Entity::from_data`])
     pub fn to_data(&self) -> data::EntityData<T> {
         let mut signatures = HashMap::new();
         for (k, s) in self.signatures() {

--- a/librad/src/id/entity.rs
+++ b/librad/src/id/entity.rs
@@ -283,6 +283,10 @@ where
         RadicleUri::new(self.hash.to_owned())
     }
 
+    pub fn parent_hash(&self) -> &Option<Multihash> {
+        &self.parent_hash
+    }
+
     pub fn signatures(&self) -> &HashMap<PublicKey, EntitySignature> {
         &self.signatures
     }
@@ -424,6 +428,17 @@ where
     pub fn check_update(&self, previous: &Self) -> Result<(), UpdateVerificationError> {
         if self.revision() <= previous.revision() {
             return Err(UpdateVerificationError::NonMonotonicRevision);
+        }
+
+        match &self.parent_hash {
+            Some(parent_hash) => {
+                if &previous.hash != parent_hash {
+                    return Err(UpdateVerificationError::WrongParentHash);
+                }
+            },
+            None => {
+                return Err(UpdateVerificationError::WrongParentHash);
+            },
         }
 
         let retained_keys = self.keys().iter().filter(|k| previous.has_key(k)).count();

--- a/librad/src/id/entity.rs
+++ b/librad/src/id/entity.rs
@@ -33,31 +33,34 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Serialization failed")]
+    #[error("Serialization failed ({0})")]
     SerializationFailed(serde_json::error::Error),
 
-    #[error("Invalid UTF8")]
+    #[error("Invalid UTF8 ({0})")]
     InvalidUtf8(std::string::FromUtf8Error),
 
-    #[error("Invalid buffer encoding")]
+    #[error("Invalid buffer encoding ({0})")]
     InvalidBufferEncoding(String),
 
-    #[error("Invalid hash")]
+    #[error("Invalid hash ({0})")]
     InvalidHash(String),
 
-    #[error("Signature already present")]
+    #[error("Invalid URI ({0})")]
+    InvalidUri(String),
+
+    #[error("Signature already present ({0})")]
     SignatureAlreadyPresent(PublicKey),
 
-    #[error("Invalid data")]
+    #[error("Invalid data ({0})")]
     InvalidData(String),
 
-    #[error("Key not present")]
+    #[error("Key not present ({0})")]
     KeyNotPresent(PublicKey),
 
-    #[error("User not present")]
+    #[error("User not present ({0})")]
     UserNotPresent(RadicleUri),
 
-    #[error("User key not present")]
+    #[error("User key not present (uri {0}, key {1})")]
     UserKeyNotPresent(RadicleUri, PublicKey),
 
     #[error("User key not present")]
@@ -72,7 +75,7 @@ pub enum Error {
     #[error("Signature verification failed")]
     SignatureVerificationFailed,
 
-    #[error("Resolution failed")]
+    #[error("Resolution failed (uri {0})")]
     ResolutionFailed(String),
 }
 
@@ -96,10 +99,10 @@ pub enum HistoryVerificationError {
     #[error("Empty history")]
     EmptyHistory,
 
-    #[error("Error at revsion")]
+    #[error("Error at revsion (rev {revision:?}, err {error:?})")]
     ErrorAtRevision { revision: u64, error: Error },
 
-    #[error("Update error")]
+    #[error("Update error (rev {revision:?}, err {error:?})")]
     UpdateError {
         revision: u64,
         error: UpdateVerificationError,

--- a/librad/src/id/entity.rs
+++ b/librad/src/id/entity.rs
@@ -1,0 +1,518 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pub mod data;
+
+use crate::{
+    id::{uri::RadicleUri, user::User},
+    keys::device::{Key, PublicKey, Signature},
+};
+use multihash::{Multihash, Sha2_256};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    iter::FromIterator,
+};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Serialization failed")]
+    SerializationFailed(serde_json::error::Error),
+
+    #[error("Invalid UTF8")]
+    InvalidUtf8(std::string::FromUtf8Error),
+
+    #[error("Invalid buffer encoding")]
+    InvalidBufferEncoding(String),
+
+    #[error("Invalid hash")]
+    InvalidHash(String),
+
+    #[error("Signature already present")]
+    SignatureAlreadyPresent(PublicKey),
+
+    #[error("Invalid data")]
+    InvalidData(String),
+
+    #[error("Key not present")]
+    KeyNotPresent(PublicKey),
+
+    #[error("User not present")]
+    UserNotPresent(RadicleUri),
+
+    #[error("User key not present")]
+    UserKeyNotPresent(RadicleUri, PublicKey),
+
+    #[error("User key not present")]
+    UserKeyNotPresentWIP(RadicleUri, PublicKey),
+
+    #[error("Signature missing")]
+    SignatureMissing,
+
+    #[error("Signature decoding failed")]
+    SignatureDecodingFailed,
+
+    #[error("Signature verification failed")]
+    SignatureVerificationFailed,
+
+    #[error("Resolution failed")]
+    ResolutionFailed(String),
+}
+
+#[derive(Debug, Error)]
+pub enum UpdateVerificationError {
+    #[error("Non monotonic revision")]
+    NonMonotonicRevision,
+
+    #[error("Wrong parent hash")]
+    WrongParentHash,
+
+    #[error("Update without previous quorum")]
+    NoPreviousQuorum,
+
+    #[error("Update without current quorum")]
+    NoCurrentQuorum,
+}
+
+#[derive(Debug, Error)]
+pub enum HistoryVerificationError {
+    #[error("Empty history")]
+    EmptyHistory,
+
+    #[error("Error at revsion")]
+    ErrorAtRevision { revision: u64, error: Error },
+
+    #[error("Update error")]
+    UpdateError {
+        revision: u64,
+        error: UpdateVerificationError,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub enum Signatory {
+    User(RadicleUri),
+    OwnedKey,
+}
+
+#[derive(Clone, Debug)]
+pub struct EntitySignature {
+    pub by: Signatory,
+    pub sig: Signature,
+}
+
+pub trait Resolver<T> {
+    fn resolve(&self, uri: &RadicleUri) -> Result<T, Error>;
+}
+
+pub trait RevisionsResolver<T, I, II>
+where
+    I: Iterator<Item = T>,
+    II: IntoIterator<Item = T, IntoIter = I> + Sized,
+{
+    fn resolve_revisions(&self, uri: &RadicleUri) -> Box<II>;
+}
+
+// Sized
+#[derive(Clone)]
+pub struct Entity<T> {
+    name: String,
+    revision: u64,
+    hash: Multihash,
+    parent_hash: Option<Multihash>,
+    signatures: HashMap<PublicKey, EntitySignature>,
+    keys: HashSet<PublicKey>,
+    certifiers: HashSet<RadicleUri>,
+    info: T,
+}
+
+impl<T> Entity<T>
+where
+    T: Serialize + DeserializeOwned + Clone + Default,
+{
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn from_data(data: data::EntityData<T>) -> Result<Self, Error> {
+        if let None = data.name {
+            return Err(Error::InvalidData("Missing name".to_owned()));
+        }
+        if let None = data.revision {
+            return Err(Error::InvalidData("Missing revision".to_owned()));
+        }
+        if data.keys.len() == 0 {
+            return Err(Error::InvalidData("Missing keys".to_owned()));
+        }
+
+        let mut keys = HashSet::new();
+        for k in data.keys.iter() {
+            keys.insert(PublicKey::from_bs58(k).ok_or(Error::InvalidData(format!("key: {}", k)))?);
+        }
+
+        let mut certifiers = HashSet::new();
+        for c in data.certifiers.iter() {
+            certifiers.insert(
+                RadicleUri::from_str(c)
+                    .map_err(|_| Error::InvalidData(format!("certifier: {}", c)))?,
+            );
+        }
+
+        let mut signatures = HashMap::new();
+        if let Some(s) = &data.signatures {
+            for (k, sig) in s.iter() {
+                let key = PublicKey::from_bs58(k)
+                    .ok_or(Error::InvalidData(format!("signature key: {}", k)))?;
+                let signature = EntitySignature {
+                    by: match &sig.user {
+                        Some(uri) => Signatory::User(RadicleUri::from_str(&uri)?),
+                        None => Signatory::OwnedKey,
+                    },
+                    sig: Signature::from_bs58(&sig.sig)
+                        .ok_or(Error::InvalidData(format!("signature data: {}", &sig.sig)))?,
+                };
+                signatures.insert(key, signature);
+            }
+        }
+
+        let actual_hash = data.compute_hash()?;
+        if let Some(s) = &data.hash {
+            let claimed_hash = {
+                let bytes = bs58::decode(s.as_bytes())
+                    .with_alphabet(bs58::alphabet::BITCOIN)
+                    .into_vec()
+                    .map_err(|_| Error::InvalidBufferEncoding(s.to_owned()))?;
+                Multihash::from_bytes(bytes).map_err(|_| Error::InvalidHash(s.to_owned()))?
+            };
+            if claimed_hash != actual_hash {
+                return Err(Error::InvalidHash(s.to_owned()));
+            }
+        }
+
+        let parent_hash = match data.parent_hash {
+            Some(s) => {
+                let bytes = bs58::decode(s.as_bytes())
+                    .with_alphabet(bs58::alphabet::BITCOIN)
+                    .into_vec()
+                    .map_err(|_| Error::InvalidBufferEncoding(s.to_owned()))?;
+                let hash =
+                    Multihash::from_bytes(bytes).map_err(|_| Error::InvalidHash(s.to_owned()))?;
+                Some(hash)
+            },
+            None => None,
+        };
+
+        Ok(Self {
+            name: data.name.unwrap().to_owned(),
+            revision: data.revision.unwrap().to_owned(),
+            hash: actual_hash,
+            parent_hash,
+            keys,
+            certifiers,
+            signatures,
+            info: data.info,
+        })
+    }
+
+    pub fn to_data(&self) -> data::EntityData<T> {
+        let mut signatures = HashMap::new();
+        for (k, s) in self.signatures() {
+            signatures.insert(
+                k.to_bs58(),
+                data::EntitySignatureData {
+                    user: match &s.by {
+                        Signatory::User(uri) => Some(uri.to_string()),
+                        Signatory::OwnedKey => None,
+                    },
+                    sig: s.sig.to_bs58(),
+                },
+            );
+        }
+
+        let keys = HashSet::from_iter(self.keys().iter().map(|k| k.to_bs58()));
+        let certifiers = HashSet::from_iter(self.certifiers().iter().map(|c| c.to_string()));
+
+        data::EntityData {
+            name: Some(self.name.to_owned()),
+            revision: Some(self.revision),
+            hash: Some(
+                bs58::encode(&self.hash)
+                    .with_alphabet(bs58::alphabet::BITCOIN)
+                    .into_string(),
+            ),
+            parent_hash: self.parent_hash.to_owned().map(|h| {
+                bs58::encode(h)
+                    .with_alphabet(bs58::alphabet::BITCOIN)
+                    .into_string()
+            }),
+            signatures: Some(signatures),
+            keys,
+            certifiers,
+            info: self.info.to_owned(),
+        }
+    }
+
+    pub fn to_builder(&self) -> data::EntityData<T> {
+        self.to_data().clear_hash().clear_signatures()
+    }
+
+    pub fn hash(&self) -> &Multihash {
+        &self.hash
+    }
+    pub fn uri(&self) -> RadicleUri {
+        RadicleUri::new(self.hash.to_owned())
+    }
+
+    pub fn signatures(&self) -> &HashMap<PublicKey, EntitySignature> {
+        &self.signatures
+    }
+
+    pub fn keys(&self) -> &HashSet<PublicKey> {
+        &self.keys
+    }
+    fn keys_count(&self) -> usize {
+        self.keys.len()
+    }
+    fn has_key(&self, key: &PublicKey) -> bool {
+        self.keys.contains(key)
+    }
+
+    pub fn certifiers(&self) -> &HashSet<RadicleUri> {
+        &self.certifiers
+    }
+    fn certifiers_count(&self) -> usize {
+        self.certifiers.len()
+    }
+    fn has_certifier(&self, c: &RadicleUri) -> bool {
+        self.certifiers.contains(c)
+    }
+
+    pub fn canonical_data(&self) -> Result<Vec<u8>, Error> {
+        Ok(self.to_data().canonical_data()?)
+    }
+    pub fn to_json_writer<W>(&self, writer: W) -> Result<(), Error>
+    where
+        W: std::io::Write,
+    {
+        self.to_data().to_json_writer(writer)?;
+        Ok(())
+    }
+    pub fn to_json_string(&self) -> Result<String, Error> {
+        Ok(self.to_data().to_json_string()?)
+    }
+
+    pub fn from_json_reader<R>(r: R) -> Result<Self, Error>
+    where
+        R: std::io::Read,
+    {
+        Ok(Self::from_data(
+            data::EntityData::from_json_reader(r)?.to_owned(),
+        )?)
+    }
+    pub fn from_json_str(s: &str) -> Result<Self, Error> {
+        Ok(Self::from_data(
+            data::EntityData::from_json_str(s)?.to_owned(),
+        )?)
+    }
+
+    pub fn compute_hash(&self) -> Result<Multihash, Error> {
+        Ok(Sha2_256::digest(&self.canonical_data()?))
+    }
+
+    pub fn check_user_key(
+        &self,
+        user_uri: &RadicleUri,
+        key: &PublicKey,
+        resolver: &impl Resolver<User>,
+    ) -> Result<(), Error> {
+        if !self.has_key(key) {
+            return Err(Error::KeyNotPresent(key.to_owned()));
+        }
+        let user = resolver.resolve(user_uri)?;
+        if !user.has_key(key) {
+            return Err(Error::UserKeyNotPresentWIP(
+                user_uri.to_owned(),
+                key.to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn check_key(
+        &self,
+        key: &PublicKey,
+        by: &Signatory,
+        resolver: &impl Resolver<User>,
+    ) -> Result<(), Error> {
+        match by {
+            Signatory::OwnedKey => {
+                if !self.has_key(key) {
+                    return Err(Error::KeyNotPresent(key.to_owned()));
+                }
+            },
+            Signatory::User(uri) => {
+                let user = resolver.resolve(&uri)?;
+                if !user.has_key(key) {
+                    return Err(Error::UserKeyNotPresentWIP(uri.to_owned(), key.to_owned()));
+                }
+            },
+        }
+        Ok(())
+    }
+
+    pub fn compute_signature(&self, key: &Key) -> Result<Signature, Error> {
+        Ok(key.sign(&self.canonical_data()?))
+    }
+
+    pub fn sign(
+        &mut self,
+        key: &Key,
+        by: &Signatory,
+        resolver: &impl Resolver<User>,
+    ) -> Result<(), Error> {
+        let public_key = key.public();
+        if self.signatures().contains_key(&public_key) {
+            return Err(Error::SignatureAlreadyPresent(public_key.to_owned()));
+        }
+        self.check_key(&public_key, by, resolver)?;
+        let signature = EntitySignature {
+            by: by.to_owned(),
+            sig: self.compute_signature(key)?,
+        };
+        self.signatures.insert(public_key, signature);
+        Ok(())
+    }
+
+    pub fn check_signature(
+        &self,
+        key: &PublicKey,
+        by: &Signatory,
+        signature: &Signature,
+        resolver: &impl Resolver<User>,
+    ) -> Result<(), Error> {
+        self.check_key(key, by, resolver)?;
+        if signature.verify(&self.canonical_data()?, key) {
+            Ok(())
+        } else {
+            Err(Error::SignatureVerificationFailed)
+        }
+    }
+
+    pub fn check_validity(&self, resolver: &impl Resolver<User>) -> Result<(), Error> {
+        let mut keys = HashSet::<PublicKey>::from_iter(self.keys().iter().cloned());
+        let mut users = HashSet::<RadicleUri>::from_iter(self.certifiers().iter().cloned());
+
+        for (k, s) in self.signatures() {
+            self.check_signature(k, &s.by, &s.sig, resolver)?;
+            match &s.by {
+                Signatory::OwnedKey => {
+                    keys.remove(k);
+                },
+                Signatory::User(user) => {
+                    users.remove(&user);
+                },
+            }
+        }
+        if keys.len() > 0 || users.len() > 0 {
+            Err(Error::SignatureMissing)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn is_valid(&self, resolver: &impl Resolver<User>) -> bool {
+        self.check_validity(resolver).is_ok()
+    }
+
+    pub fn check_update(&self, previous: &Self) -> Result<(), UpdateVerificationError> {
+        if self.revision() <= previous.revision() {
+            return Err(UpdateVerificationError::NonMonotonicRevision);
+        }
+
+        let retained_keys = self.keys().iter().filter(|k| previous.has_key(k)).count();
+        let total_keys = self.keys_count();
+        let added_keys = total_keys - retained_keys;
+        let removed_keys = previous.keys_count() - retained_keys;
+        let quorum_keys = total_keys / 2;
+
+        if added_keys > quorum_keys {
+            return Err(UpdateVerificationError::NoCurrentQuorum);
+        } else if removed_keys > quorum_keys {
+            return Err(UpdateVerificationError::NoPreviousQuorum);
+        }
+
+        let retained_certifiers = self
+            .certifiers()
+            .iter()
+            .filter(|c| previous.has_certifier(c))
+            .count();
+        let total_certifiers = self.certifiers_count();
+        let added_certifiers = total_certifiers - retained_certifiers;
+        let removed_certifiers = previous.certifiers_count() - retained_certifiers;
+        let quorum_certifiers = total_certifiers / 2;
+
+        if added_certifiers > quorum_certifiers {
+            return Err(UpdateVerificationError::NoCurrentQuorum);
+        } else if removed_certifiers > quorum_certifiers {
+            return Err(UpdateVerificationError::NoPreviousQuorum);
+        }
+
+        Ok(())
+    }
+
+    pub fn check_history<I, II>(
+        uri: &RadicleUri,
+        resolver: &impl Resolver<User>,
+        revisions_resolver: &impl RevisionsResolver<Entity<T>, I, II>,
+    ) -> Result<(), HistoryVerificationError>
+    where
+        I: Iterator<Item = Entity<T>>,
+        II: IntoIterator<Item = Entity<T>, IntoIter = I> + Sized,
+    {
+        let mut revisions = revisions_resolver.resolve_revisions(uri).into_iter();
+
+        let current = revisions.next();
+        let mut current = match current {
+            None => {
+                return Err(HistoryVerificationError::EmptyHistory);
+            },
+            Some(entity) => entity,
+        };
+
+        let revision = current.revision();
+        current
+            .check_validity(resolver)
+            .map_err(|error| HistoryVerificationError::ErrorAtRevision { revision, error })?;
+
+        for previous in revisions {
+            let revision = current.revision();
+            previous
+                .check_validity(resolver)
+                .map_err(|error| HistoryVerificationError::ErrorAtRevision { revision, error })?;
+            current
+                .check_update(&previous)
+                .map_err(|error| HistoryVerificationError::UpdateError { revision, error })?;
+            current = previous;
+        }
+
+        Ok(())
+    }
+}

--- a/librad/src/id/entity.rs
+++ b/librad/src/id/entity.rs
@@ -64,9 +64,6 @@ pub enum Error {
     #[error("User key not present (uri {0}, key {1})")]
     UserKeyNotPresent(RadicleUri, PublicKey),
 
-    #[error("User key not present")]
-    UserKeyNotPresentWIP(RadicleUri, PublicKey),
-
     #[error("Signature missing")]
     SignatureMissing,
 
@@ -354,7 +351,7 @@ where
             Signatory::User(uri) => {
                 let user = resolver.resolve(&uri).await?;
                 if !user.has_key(key) {
-                    return Err(Error::UserKeyNotPresentWIP(uri.to_owned(), key.to_owned()));
+                    return Err(Error::UserKeyNotPresent(uri.to_owned(), key.to_owned()));
                 }
             },
         }

--- a/librad/src/id/entity/data.rs
+++ b/librad/src/id/entity/data.rs
@@ -84,10 +84,10 @@ where
     where
         R: std::io::Read,
     {
-        Ok(serde_json::from_reader(r).map_err(Error::SerializationFailed)?)
+        serde_json::from_reader(r).map_err(Error::SerializationFailed)
     }
     pub fn from_json_str(s: &str) -> Result<Self, Error> {
-        Ok(serde_json::from_str(s).map_err(Error::SerializationFailed)?)
+        serde_json::from_str(s).map_err(Error::SerializationFailed)
     }
 
     pub fn canonical_data(&self) -> Result<Vec<u8>, Error> {

--- a/librad/src/id/entity/data.rs
+++ b/librad/src/id/entity/data.rs
@@ -1,0 +1,209 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::id::entity::{Entity, Error};
+use multihash::{Multihash, Sha2_256};
+use olpc_cjson::CanonicalFormatter;
+use serde::{de::DeserializeOwned, Deserialize, Serialize, Serializer};
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
+pub struct EntitySignatureData {
+    pub user: Option<String>,
+    pub sig: String,
+}
+
+fn ordered_set<S>(value: &HashSet<String>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let ordered: BTreeSet<String> = value.iter().cloned().collect();
+    ordered.serialize(serializer)
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, Default)]
+pub struct EntityData<T> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_hash: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signatures: Option<HashMap<String, EntitySignatureData>>,
+
+    #[serde(
+        skip_serializing_if = "HashSet::is_empty",
+        serialize_with = "ordered_set",
+        default
+    )]
+    pub keys: HashSet<String>,
+    #[serde(
+        skip_serializing_if = "HashSet::is_empty",
+        serialize_with = "ordered_set",
+        default
+    )]
+    pub certifiers: HashSet<String>,
+
+    pub info: T,
+}
+
+impl<T> EntityData<T>
+where
+    T: Serialize + DeserializeOwned + Clone + Default,
+{
+    pub fn to_json_writer<W>(&self, writer: W) -> Result<(), Error>
+    where
+        W: std::io::Write,
+    {
+        serde_json::to_writer(writer, self).map_err(Error::SerializationFailed)?;
+        Ok(())
+    }
+    pub fn to_json_string(&self) -> Result<String, Error> {
+        Ok(serde_json::to_string(self).map_err(Error::SerializationFailed)?)
+    }
+
+    pub fn from_json_reader<R>(r: R) -> Result<Self, Error>
+    where
+        R: std::io::Read,
+    {
+        Ok(serde_json::from_reader(r).map_err(Error::SerializationFailed)?)
+    }
+    pub fn from_json_str(s: &str) -> Result<Self, Error> {
+        Ok(serde_json::from_str(s).map_err(Error::SerializationFailed)?)
+    }
+
+    pub fn canonical_data(&self) -> Result<Vec<u8>, Error> {
+        let mut cleaned = EntityData::<T>::default();
+        cleaned.name = self.name.to_owned();
+        cleaned.revision = self.revision.to_owned();
+        cleaned.hash = self.hash.to_owned();
+        cleaned.keys = self.keys.to_owned();
+        cleaned.certifiers = self.certifiers.to_owned();
+        cleaned.info = self.info.to_owned();
+
+        let mut buffer: Vec<u8> = vec![];
+        let mut ser =
+            serde_json::Serializer::with_formatter(&mut buffer, CanonicalFormatter::new());
+        cleaned
+            .serialize(&mut ser)
+            .map_err(Error::SerializationFailed)?;
+        Ok(buffer)
+    }
+
+    pub fn compute_hash(&self) -> Result<Multihash, Error> {
+        Ok(Sha2_256::digest(&self.canonical_data()?))
+    }
+
+    pub fn new(name: String, revision: u64) -> Self {
+        let mut result = Self::default();
+        result.name = Some(name);
+        result.revision = Some(revision);
+        result
+    }
+
+    pub fn set_name(mut self, name: String) -> Self {
+        self.name = Some(name);
+        self
+    }
+    pub fn clear_name(mut self) -> Self {
+        self.name = None;
+        self
+    }
+
+    pub fn set_revision(mut self, revision: u64) -> Self {
+        self.revision = Some(revision);
+        self
+    }
+    pub fn clear_revision(mut self) -> Self {
+        self.revision = None;
+        self
+    }
+
+    pub fn clear_hash(mut self) -> Self {
+        self.hash = None;
+        self
+    }
+
+    pub fn set_parent_hash(mut self, parent_hash: String) -> Self {
+        self.parent_hash = Some(parent_hash);
+        self
+    }
+    pub fn clear_parent_hash(mut self) -> Self {
+        self.parent_hash = None;
+        self
+    }
+
+    pub fn set_parent(mut self, parent: &Entity<T>) -> Self {
+        let hash_text = bs58::encode(parent.hash())
+            .with_alphabet(bs58::alphabet::BITCOIN)
+            .into_string();
+        self.parent_hash = Some(hash_text);
+        self.revision = Some(parent.revision() + 1);
+        self
+    }
+
+    pub fn clear_signatures(mut self) -> Self {
+        self.signatures = None;
+        self
+    }
+
+    pub fn add_key(mut self, key: String) -> Self {
+        self.keys.insert(key);
+        self
+    }
+    pub fn remove_key(mut self, key: &str) -> Self {
+        self.keys.remove(key);
+        self
+    }
+    pub fn clear_keys(mut self) -> Self {
+        self.keys.clear();
+        self
+    }
+    pub fn add_keys(mut self, keys: impl IntoIterator<Item = String>) -> Self {
+        for s in keys.into_iter() {
+            self.keys.insert(s);
+        }
+        self
+    }
+
+    pub fn add_certifier(mut self, certifier: String) -> Self {
+        self.certifiers.insert(certifier);
+        self
+    }
+    pub fn remove_certifier(mut self, certifier: &str) -> Self {
+        self.certifiers.remove(certifier);
+        self
+    }
+    pub fn clear_certifiers(mut self) -> Self {
+        self.certifiers.clear();
+        self
+    }
+    pub fn add_certifiers(mut self, certifiers: impl IntoIterator<Item = String>) -> Self {
+        for s in certifiers.into_iter() {
+            self.certifiers.insert(s);
+        }
+        self
+    }
+
+    pub fn map(self, f: impl FnOnce(Self) -> Self) -> Self {
+        f(self)
+    }
+}

--- a/librad/src/id/entity/data.rs
+++ b/librad/src/id/entity/data.rs
@@ -95,6 +95,7 @@ where
         cleaned.name = self.name.to_owned();
         cleaned.revision = self.revision.to_owned();
         cleaned.hash = self.hash.to_owned();
+        cleaned.parent_hash = self.parent_hash.to_owned();
         cleaned.keys = self.keys.to_owned();
         cleaned.certifiers = self.certifiers.to_owned();
         cleaned.info = self.info.to_owned();

--- a/librad/src/id/entity/data.rs
+++ b/librad/src/id/entity/data.rs
@@ -21,12 +21,16 @@ use olpc_cjson::CanonicalFormatter;
 use serde::{de::DeserializeOwned, Deserialize, Serialize, Serializer};
 use std::collections::{BTreeSet, HashMap, HashSet};
 
+/// Raw data for an entity signature
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
 pub struct EntitySignatureData {
+    /// `None` for signatures by owned keys, otherwise the certifier URN
     pub user: Option<String>,
+    /// The signature data
     pub sig: String,
 }
 
+/// Helper to serialize `HashSet` in a canonical way
 fn ordered_set<S>(value: &HashSet<String>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -35,6 +39,15 @@ where
     ordered.serialize(serializer)
 }
 
+/// Raw data for an `Entity
+///
+/// This is used in two ways:
+///
+/// - as an intermediate step in deserialization so that invariants can be
+///   enforced more explicitly
+/// - as a "builder" when creating new entities (or entity revisions), again so
+///   that invariants can be enforced at `build` time when all the data has been
+///   collected
 #[derive(Clone, Deserialize, Serialize, Debug, Default)]
 pub struct EntityData<T> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/librad/src/id/project.rs
+++ b/librad/src/id/project.rs
@@ -15,29 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![feature(str_strip)]
+use crate::id::entity::Entity;
+use serde::{Deserialize, Serialize};
 
-extern crate radicle_keystore as keystore;
-extern crate sequoia_openpgp as pgp;
-extern crate sodiumoxide;
-#[macro_use]
-extern crate lazy_static;
-
-pub use radicle_surf as surf;
-
-pub mod git;
-pub mod id;
-pub mod keys;
-pub mod meta;
-pub mod net;
-pub mod paths;
-pub mod peer;
-pub mod project;
-pub mod sync;
-pub mod uri;
-
-pub(crate) mod channel;
-
-pub fn init() -> bool {
-    sodiumoxide::init().is_ok()
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct ProjectInfo {
+    pub description: String,
 }
+
+pub type Project = Entity<ProjectInfo>;

--- a/librad/src/id/test.rs
+++ b/librad/src/id/test.rs
@@ -1,0 +1,405 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::{
+    entity::*,
+    uri::{RadicleUri, EMPTY_URI},
+    user::{User, UserData},
+};
+use crate::{keys::device::Key, peer::PeerId};
+use lazy_static::lazy_static;
+use sodiumoxide::crypto::sign::ed25519::Seed;
+
+const SEED: Seed = Seed([
+    20, 21, 6, 102, 102, 57, 20, 67, 219, 198, 236, 108, 148, 15, 182, 52, 167, 27, 29, 81, 181,
+    134, 74, 88, 174, 254, 78, 69, 84, 149, 84, 167,
+]);
+const CREATED_AT: u64 = 1_576_843_598;
+
+fn new_key_from_seed(seed_value: u8) -> Key {
+    let mut seed = SEED;
+    seed.0[0] = seed_value;
+    let created_at = std::time::SystemTime::UNIX_EPOCH
+        .checked_add(std::time::Duration::from_secs(CREATED_AT))
+        .expect("SystemTime overflow o.O");
+    Key::from_seed(&seed, created_at)
+}
+
+fn peer_from_key(key: &Key) -> PeerId {
+    PeerId::from(key.public())
+}
+
+lazy_static! {
+    static ref K1: Key = new_key_from_seed(1);
+    static ref K2: Key = new_key_from_seed(2);
+    static ref K3: Key = new_key_from_seed(3);
+    static ref K4: Key = new_key_from_seed(4);
+    static ref K5: Key = new_key_from_seed(5);
+}
+
+lazy_static! {
+    pub static ref D1: PeerId = peer_from_key(&K1);
+    pub static ref D2: PeerId = peer_from_key(&K2);
+    pub static ref D3: PeerId = peer_from_key(&K3);
+    pub static ref D4: PeerId = peer_from_key(&K4);
+    pub static ref D5: PeerId = peer_from_key(&K5);
+}
+
+fn peer_key_string(peer: &PeerId) -> String {
+    peer.device_key().to_bs58()
+}
+
+lazy_static! {
+    pub static ref D1K: String = peer_key_string(&D1);
+    pub static ref D2K: String = peer_key_string(&D2);
+    pub static ref D3K: String = peer_key_string(&D3);
+    pub static ref D4K: String = peer_key_string(&D4);
+    pub static ref D5K: String = peer_key_string(&D5);
+}
+
+struct EmptyResolver {}
+
+impl Resolver<User> for EmptyResolver {
+    fn resolve(&self, uri: &RadicleUri) -> Result<User, Error> {
+        Err(Error::UserNotPresent(uri.to_owned()))
+    }
+}
+
+static EMPTY_RESOLVER: EmptyResolver = EmptyResolver {};
+
+struct UserHistory {
+    pub revisions: Vec<User>,
+}
+
+impl UserHistory {
+    fn new() -> Self {
+        Self { revisions: vec![] }
+    }
+}
+
+impl RevisionsResolver<User, <std::vec::Vec<User> as IntoIterator>::IntoIter, Vec<User>>
+    for UserHistory
+{
+    fn resolve_revisions(&self, _uri: &RadicleUri) -> std::boxed::Box<Vec<User>> {
+        Box::new(self.revisions.iter().rev().cloned().collect())
+    }
+}
+
+fn new_user(name: &str, revision: u64, devices: &[&'static str]) -> Result<User, Error> {
+    let mut data = UserData::default()
+        .set_name(name.to_owned())
+        .set_revision(revision);
+    for s in devices.into_iter() {
+        data = data.add_key((*s).to_owned());
+    }
+    data.build()
+}
+
+#[test]
+fn test_user_signatures() {
+    // Keep signing the user while adding devices
+    let mut user = new_user("foo", 1, &[&*D1K]).unwrap();
+
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    let sig1 = user.compute_signature(&K1).unwrap();
+
+    let mut user = user.to_builder().add_key((*D2K).clone()).build().unwrap();
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    let sig2 = user.compute_signature(&K1).unwrap();
+
+    assert_ne!(&sig1, &sig2);
+}
+
+#[test]
+fn test_adding_user_signatures() {
+    let user = new_user("foo", 1, &[&*D1K]).unwrap();
+
+    // Check that canonical data changes while adding devices
+    let data1 = user.canonical_data().unwrap();
+    let user = user.to_builder().add_key((*D2K).clone()).build().unwrap();
+    let data2 = user.canonical_data().unwrap();
+    let mut user = user.to_builder().add_key((*D3K).clone()).build().unwrap();
+    let data3 = user.canonical_data().unwrap();
+    assert_ne!(&data1, &data2);
+    assert_ne!(&data1, &data3);
+    assert_ne!(&data2, &data3);
+
+    // Check that canonical data does not change manipulating signatures
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    let data4 = user.canonical_data().unwrap();
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    let data5 = user.canonical_data().unwrap();
+    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    let data6 = user.canonical_data().unwrap();
+
+    assert_eq!(&data3, &data4);
+    assert_eq!(&data3, &data5);
+    assert_eq!(&data3, &data6);
+
+    // Check signatures collection contents
+    assert_eq!(3, user.signatures().len());
+    assert!(user.signatures().contains_key(&D1.device_key()));
+    assert!(user.signatures().contains_key(&D2.device_key()));
+    assert!(user.signatures().contains_key(&D3.device_key()));
+
+    // Check signature verification
+    let data = user.canonical_data().unwrap();
+    for (k, s) in user.signatures().iter() {
+        assert!(s.sig.verify(&data, k));
+    }
+}
+
+#[test]
+fn test_user_verification() {
+    // A new user is not valid because no key has signed it
+    let mut user = new_user("foo", 1, &[&*D1K]).unwrap();
+    assert!(matches!(
+        user.check_validity(&EMPTY_RESOLVER),
+        Err(Error::SignatureMissing)
+    ));
+    assert!(!user.is_valid(&EMPTY_RESOLVER));
+    // Adding the signature fixes it
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    assert!(matches!(user.check_validity(&EMPTY_RESOLVER), Ok(())));
+    assert!(user.is_valid(&EMPTY_RESOLVER));
+    // Adding keys without signatures invalidates it
+    let mut user = user
+        .to_data()
+        .clear_hash()
+        .add_key((*D2K).clone())
+        .add_key((*D3K).clone())
+        .build()
+        .unwrap();
+    assert!(matches!(user.check_validity(&EMPTY_RESOLVER), Err(_)));
+    // Adding the missing signatures does not fix it: D1 signed a previous
+    // revision
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    assert!(matches!(
+        user.check_validity(&EMPTY_RESOLVER),
+        Err(Error::SignatureVerificationFailed)
+    ));
+    // Cannot sign a project twice with the same key
+    assert!(matches!(
+        user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER),
+        Err(Error::SignatureAlreadyPresent(_))
+    ));
+    // Removing the signature and re adding it fixes the project
+    let mut user = user
+        .to_data()
+        .clear_hash()
+        .map(|mut u| {
+            if let Some(s) = &mut u.signatures {
+                s.remove(&*D1K);
+            }
+            u
+        })
+        .build()
+        .unwrap();
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    assert!(user.is_valid(&EMPTY_RESOLVER));
+    // Removing a maintainer invalidates it again
+    let user = user
+        .to_data()
+        .clear_hash()
+        .remove_key(&*D1K)
+        .build()
+        .unwrap();
+    assert!(matches!(user.check_validity(&EMPTY_RESOLVER), Err(_)));
+}
+
+#[test]
+fn test_project_update() {
+    // Empty history is invalid
+    let mut history = UserHistory::new();
+    assert!(matches!(
+        User::check_history(&EMPTY_URI, &EMPTY_RESOLVER, &history),
+        Err(HistoryVerificationError::EmptyHistory)
+    ));
+
+    // History with invalid user is invalid
+    let user = new_user("foo", 1, &[&*D1K]).unwrap();
+    history.revisions.push(user);
+
+    assert!(matches!(
+        User::check_history(&EMPTY_URI, &EMPTY_RESOLVER, &history),
+        Err(HistoryVerificationError::ErrorAtRevision {
+            revision: 1,
+            error: Error::SignatureMissing,
+        })
+    ));
+
+    // History with single valid user is valid
+    history
+        .revisions
+        .last_mut()
+        .unwrap()
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    assert!(matches!(
+        User::check_history(&EMPTY_URI, &EMPTY_RESOLVER, &history),
+        Ok(())
+    ));
+
+    // Adding one key is ok
+    let mut user = history
+        .revisions
+        .last()
+        .unwrap()
+        .to_builder()
+        .add_key((*D2K).clone())
+        .set_parent(history.revisions.last().unwrap())
+        .build()
+        .unwrap();
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    history.revisions.push(user);
+    assert!(matches!(
+        User::check_history(&EMPTY_URI, &EMPTY_RESOLVER, &history),
+        Ok(())
+    ));
+
+    // Adding two keys starting from one is not ok
+    history.revisions.pop();
+    let mut user = history
+        .revisions
+        .last()
+        .unwrap()
+        .to_builder()
+        .add_key((*D2K).clone())
+        .add_key((*D3K).clone())
+        .set_parent(history.revisions.last().unwrap())
+        .build()
+        .unwrap();
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    history.revisions.push(user);
+    assert!(matches!(
+        User::check_history(&EMPTY_URI, &EMPTY_RESOLVER, &history),
+        Err(HistoryVerificationError::UpdateError {
+            revision: 2,
+            error: UpdateVerificationError::NoCurrentQuorum,
+        })
+    ));
+
+    // Adding two keys one by one is ok
+    history.revisions.pop();
+    let mut user = history
+        .revisions
+        .last()
+        .unwrap()
+        .to_builder()
+        .add_key((*D2K).clone())
+        .set_parent(history.revisions.last().unwrap())
+        .build()
+        .unwrap();
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    history.revisions.push(user);
+    assert!(matches!(
+        User::check_history(&EMPTY_URI, &EMPTY_RESOLVER, &history),
+        Ok(())
+    ));
+    let mut user = history
+        .revisions
+        .last()
+        .unwrap()
+        .to_builder()
+        .add_key((*D3K).clone())
+        .set_parent(history.revisions.last().unwrap())
+        .build()
+        .unwrap();
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    history.revisions.push(user);
+    assert!(matches!(
+        User::check_history(&EMPTY_URI, &EMPTY_RESOLVER, &history),
+        Ok(())
+    ));
+
+    // Changing two devices out of three is not ok
+    let mut user = history
+        .revisions
+        .last()
+        .unwrap()
+        .to_builder()
+        .remove_key(&*D2K)
+        .remove_key(&*D3K)
+        .add_key((*D4K).clone())
+        .add_key((*D5K).clone())
+        .set_parent(history.revisions.last().unwrap())
+        .build()
+        .unwrap();
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    user.sign(&K4, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    user.sign(&K5, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    history.revisions.push(user);
+    assert!(matches!(
+        User::check_history(&EMPTY_URI, &EMPTY_RESOLVER, &history),
+        Err(HistoryVerificationError::UpdateError {
+            revision: 4,
+            error: UpdateVerificationError::NoCurrentQuorum,
+        })
+    ));
+
+    // Removing two devices out of three is not ok
+    history.revisions.pop();
+    let mut user = history
+        .revisions
+        .last()
+        .unwrap()
+        .to_builder()
+        .remove_key(&*D2K)
+        .remove_key(&*D3K)
+        .set_parent(history.revisions.last().unwrap())
+        .build()
+        .unwrap();
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+        .unwrap();
+    history.revisions.push(user);
+    assert!(matches!(
+        User::check_history(&EMPTY_URI, &EMPTY_RESOLVER, &history),
+        Err(HistoryVerificationError::UpdateError {
+            revision: 4,
+            error: UpdateVerificationError::NoPreviousQuorum,
+        })
+    ));
+}

--- a/librad/src/id/test.rs
+++ b/librad/src/id/test.rs
@@ -297,10 +297,7 @@ async fn test_user_verification() {
         .remove_key(&*D1K)
         .build()
         .unwrap();
-    assert!(matches!(
-        user.compute_status(&EMPTY_RESOLVER).await,
-        Err(Error::SignatureVerificationFailed)
-    ));
+    assert!(matches!(user.compute_status(&EMPTY_RESOLVER).await, Err(_)));
     assert!(user.status().verification_failed());
 }
 

--- a/librad/src/id/test.rs
+++ b/librad/src/id/test.rs
@@ -17,7 +17,7 @@
 
 use super::{
     entity::*,
-    uri::RadicleUri,
+    uri::{RadicleUri, EMPTY_HASH},
     user::{User, UserData},
 };
 use crate::{keys::device::Key, peer::PeerId};
@@ -100,15 +100,33 @@ impl UserHistory {
     }
 }
 
-/*
-impl RevisionsResolver<User, <std::vec::Vec<User> as IntoIterator>::IntoIter, Vec<User>>
-    for UserHistory
-{
-    fn resolve_revisions(&self, _uri: &RadicleUri) -> std::boxed::Box<Vec<User>> {
-        Box::new(self.revisions.iter().rev().cloned().collect())
-    }
+#[test]
+fn test_invalid_uri() {
+    assert!(matches!(
+        RadicleUri::from_str("foo"),
+        Err(Error::InvalidUri(_))
+    ));
+    assert!(matches!(
+        RadicleUri::from_str("http://radicle.xyz"),
+        Err(Error::InvalidUri(_))
+    ));
+    assert!(matches!(
+        RadicleUri::from_str("rad:"),
+        Err(Error::InvalidUri(_))
+    ));
+    assert!(matches!(
+        RadicleUri::from_str("rad:ABC"),
+        Err(Error::InvalidUri(_))
+    ));
 }
-*/
+
+#[test]
+fn test_valid_uri() {
+    let u1 = RadicleUri::new((*EMPTY_HASH).to_owned());
+    let s = u1.to_string();
+    let u2 = RadicleUri::from_str(&s).unwrap();
+    assert_eq!(u1, u2);
+}
 
 fn new_user(name: &str, revision: u64, devices: &[&'static str]) -> Result<User, Error> {
     let mut data = UserData::default()

--- a/librad/src/id/test.rs
+++ b/librad/src/id/test.rs
@@ -26,6 +26,7 @@ use futures::stream::{iter, Iter};
 use futures_await_test::async_test;
 use lazy_static::lazy_static;
 use sodiumoxide::crypto::sign::ed25519::Seed;
+use std::str::FromStr;
 
 const SEED: Seed = Seed([
     20, 21, 6, 102, 102, 57, 20, 67, 219, 198, 236, 108, 148, 15, 182, 52, 167, 27, 29, 81, 181,
@@ -132,7 +133,7 @@ fn new_user(name: &str, revision: u64, devices: &[&'static str]) -> Result<User,
     let mut data = UserData::default()
         .set_name(name.to_owned())
         .set_revision(revision);
-    for s in devices.into_iter() {
+    for s in devices.iter() {
         data = data.add_key((*s).to_owned());
     }
     data.build()

--- a/librad/src/id/uri.rs
+++ b/librad/src/id/uri.rs
@@ -30,8 +30,11 @@ impl RadicleUri {
     pub fn hash(&self) -> &Multihash {
         &self.hash
     }
+}
 
-    pub fn from_str(s: &str) -> Result<Self, Error> {
+impl std::str::FromStr for RadicleUri {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Error> {
         if s.len() < 4 {
             return Err(Error::InvalidUri(s.to_owned()));
         }
@@ -43,8 +46,7 @@ impl RadicleUri {
             .with_alphabet(bs58::alphabet::BITCOIN)
             .into_vec()
             .map_err(|_| Error::InvalidBufferEncoding(s.to_owned()))?;
-        let hash =
-            Multihash::from_bytes(bytes.to_owned()).map_err(|_| Error::InvalidUri(s.to_owned()))?;
+        let hash = Multihash::from_bytes(bytes).map_err(|_| Error::InvalidUri(s.to_owned()))?;
         Ok(Self { hash })
     }
 }

--- a/librad/src/id/uri.rs
+++ b/librad/src/id/uri.rs
@@ -32,24 +32,37 @@ impl RadicleUri {
     }
 
     pub fn from_str(s: &str) -> Result<Self, Error> {
-        let bytes = bs58::decode(s.as_bytes())
+        if s.len() < 4 {
+            return Err(Error::InvalidUri(s.to_owned()));
+        }
+        let prefix = &s[0..4];
+        if prefix != "rad:" {
+            return Err(Error::InvalidUri(s.to_owned()));
+        }
+        let bytes = bs58::decode((&s[4..]).as_bytes())
             .with_alphabet(bs58::alphabet::BITCOIN)
             .into_vec()
             .map_err(|_| Error::InvalidBufferEncoding(s.to_owned()))?;
-        let hash = Multihash::from_bytes(bytes).map_err(|_| Error::InvalidHash(s.to_owned()))?;
+        let hash =
+            Multihash::from_bytes(bytes.to_owned()).map_err(|_| Error::InvalidUri(s.to_owned()))?;
         Ok(Self { hash })
+    }
+}
+
+impl std::fmt::Display for RadicleUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("rad:")?;
+        f.write_str(
+            bs58::encode(&self.hash)
+                .with_alphabet(bs58::alphabet::BITCOIN)
+                .into_string()
+                .as_ref(),
+        )?;
+        Ok(())
     }
 }
 
 lazy_static! {
     pub static ref EMPTY_HASH: Multihash = Sha2_256::digest(&[]);
     pub static ref EMPTY_URI: RadicleUri = RadicleUri::new(EMPTY_HASH.to_owned());
-}
-
-impl ToString for RadicleUri {
-    fn to_string(&self) -> String {
-        bs58::encode(&self.hash)
-            .with_alphabet(bs58::alphabet::BITCOIN)
-            .into_string()
-    }
 }

--- a/librad/src/id/uri.rs
+++ b/librad/src/id/uri.rs
@@ -1,0 +1,55 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::id::entity::Error;
+use multihash::{Multihash, Sha2_256};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RadicleUri {
+    hash: Multihash,
+}
+
+impl RadicleUri {
+    pub fn new(hash: Multihash) -> Self {
+        Self { hash }
+    }
+    pub fn hash(&self) -> &Multihash {
+        &self.hash
+    }
+
+    pub fn from_str(s: &str) -> Result<Self, Error> {
+        let bytes = bs58::decode(s.as_bytes())
+            .with_alphabet(bs58::alphabet::BITCOIN)
+            .into_vec()
+            .map_err(|_| Error::InvalidBufferEncoding(s.to_owned()))?;
+        let hash = Multihash::from_bytes(bytes).map_err(|_| Error::InvalidHash(s.to_owned()))?;
+        Ok(Self { hash })
+    }
+}
+
+lazy_static! {
+    pub static ref EMPTY_HASH: Multihash = Sha2_256::digest(&[]);
+    pub static ref EMPTY_URI: RadicleUri = RadicleUri::new(EMPTY_HASH.to_owned());
+}
+
+impl ToString for RadicleUri {
+    fn to_string(&self) -> String {
+        bs58::encode(&self.hash)
+            .with_alphabet(bs58::alphabet::BITCOIN)
+            .into_string()
+    }
+}

--- a/librad/src/id/user.rs
+++ b/librad/src/id/user.rs
@@ -15,29 +15,25 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![feature(str_strip)]
+use crate::id::entity::{data::EntityData, Entity, Error};
+use serde::{Deserialize, Serialize};
 
-extern crate radicle_keystore as keystore;
-extern crate sequoia_openpgp as pgp;
-extern crate sodiumoxide;
-#[macro_use]
-extern crate lazy_static;
-
-pub use radicle_surf as surf;
-
-pub mod git;
-pub mod id;
-pub mod keys;
-pub mod meta;
-pub mod net;
-pub mod paths;
-pub mod peer;
-pub mod project;
-pub mod sync;
-pub mod uri;
-
-pub(crate) mod channel;
-
-pub fn init() -> bool {
-    sodiumoxide::init().is_ok()
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct UserInfo {
+    pub email: String,
 }
+
+pub type UserData = EntityData<UserInfo>;
+
+impl UserData {
+    pub fn set_email(mut self, email: String) -> Self {
+        self.info.email = email;
+        self
+    }
+
+    pub fn build(self) -> Result<User, Error> {
+        User::from_data(self)
+    }
+}
+
+pub type User = Entity<UserInfo>;

--- a/librad/src/keys/device.rs
+++ b/librad/src/keys/device.rs
@@ -278,7 +278,7 @@ impl Signature {
             Ok(v) => v,
             Err(_) => return None,
         };
-        sodiumoxide::crypto::sign::Signature::from_slice(&bytes).map(|sig| Self(sig))
+        sodiumoxide::crypto::sign::Signature::from_slice(&bytes).map(Self)
     }
 
     pub fn to_bs58(&self) -> String {

--- a/librad/src/keys/device.rs
+++ b/librad/src/keys/device.rs
@@ -278,16 +278,7 @@ impl Signature {
             Ok(v) => v,
             Err(_) => return None,
         };
-        let buffer = if bytes.len() == ed25519::SIGNATUREBYTES {
-            let mut buffer = [0u8; ed25519::SIGNATUREBYTES];
-            for (i, v) in bytes.iter().enumerate() {
-                buffer[i] = *v;
-            }
-            buffer
-        } else {
-            return None;
-        };
-        Some(Self(sodiumoxide::crypto::sign::Signature(buffer)))
+        sodiumoxide::crypto::sign::Signature::from_slice(&bytes).map(|sig| Self(sig))
     }
 
     pub fn to_bs58(&self) -> String {

--- a/librad/src/keys/device.rs
+++ b/librad/src/keys/device.rs
@@ -183,6 +183,23 @@ impl PublicKey {
     pub fn from_slice(bs: &[u8]) -> Option<PublicKey> {
         ed25519::PublicKey::from_slice(&bs).map(PublicKey)
     }
+
+    pub fn from_bs58(s: &str) -> Option<Self> {
+        let bytes = match bs58::decode(s.as_bytes())
+            .with_alphabet(bs58::alphabet::BITCOIN)
+            .into_vec()
+        {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        ed25519::PublicKey::from_slice(&bytes).map(PublicKey)
+    }
+
+    pub fn to_bs58(&self) -> String {
+        bs58::encode(self.0)
+            .with_alphabet(bs58::alphabet::BITCOIN)
+            .into_string()
+    }
 }
 
 impl From<ed25519::PublicKey> for PublicKey {
@@ -251,6 +268,32 @@ impl Signature {
             });
         };
         Ok(Self(ed25519::Signature(buffer)))
+    }
+
+    pub fn from_bs58(s: &str) -> Option<Self> {
+        let bytes = match bs58::decode(s.as_bytes())
+            .with_alphabet(bs58::alphabet::BITCOIN)
+            .into_vec()
+        {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        let buffer = if bytes.len() == ed25519::SIGNATUREBYTES {
+            let mut buffer = [0u8; ed25519::SIGNATUREBYTES];
+            for (i, v) in bytes.iter().enumerate() {
+                buffer[i] = *v;
+            }
+            buffer
+        } else {
+            return None;
+        };
+        Some(Self(sodiumoxide::crypto::sign::Signature(buffer)))
+    }
+
+    pub fn to_bs58(&self) -> String {
+        bs58::encode(self.0)
+            .with_alphabet(bs58::alphabet::BITCOIN)
+            .into_string()
     }
 }
 


### PR DESCRIPTION
I have reimplemented User and Project as type instances of a generic `Entity<T`>, where Entity supports TUF verification using URI resolution where needed.

There is an `EntityData` struct that has two main roles:

* a "builder" pattern intermediate object, and
* an intermediate step for [de]serialization.

This because Entity (and therefore User and Project) are essentially immutable.
They have the invariant that their hash must always be correct, therefore it is not possible to mutate them without either breaking the invariant or recomputing the hash.

The only thing that can be changed are signatures, which can be added with the `sign` function.

This means that the invariants should be checked on deserialization (when passing from EntityData to Entity).

There is a `Resolver` async trait that is a placeholder for the resolution machinery, and revision histories are consumed as an async Stream during verification.

There is a small open point about the use of `bs58` for keys and hashes representation, it could be changed for another kind of encoding.