### PR TITLE
Parallel Build Checks

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,17 +1,28 @@
 steps:
-  - label: "Build, test, lint, clip, doc"
+  - label: "Build, test, doc"
     commands:
       - "ci/build-test"
       - wait
-      - "ci/advisory"
-      - "ci/clippy"
       - "ci/docs"
-    agents:
+    agents: &build-agent
       production: "true"
       platform: "linux"
-    env:
+    env: &build-docker
       DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-link-seedling-build@sha256:f53c35f65541d91b7665003a6362be48d6b2687a5a9e46adaadccaf3129da51f"
       DOCKER_FILE: .buildkite/docker/rust-nightly/Dockerfile
+
+  - label: "Lint and clip"
+    commands:
+      - "ci/clippy"
+    agents: *build-agent
+    env: *build-docker
+
+  - label: "Deny"
+    commands:
+      - "ci/advisory"
+    agents: *build-agent
+    env: *build-docker
+
 
   - label: "Render Spec"
     commands:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,7 +1,11 @@
 steps:
-  - label: "Build, lint, test"
+  - label: "Build, test, lint, clip, doc"
     commands:
-      - "ci/run"
+      - "ci/build-test"
+      - wait
+      - "ci/advisory"
+      - "ci/clippy"
+      - "ci/docs"
     agents:
       production: "true"
       platform: "linux"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,7 +2,6 @@ steps:
   - label: "Build, test, doc"
     commands:
       - "ci/build-test"
-      - wait
       - "ci/docs"
     agents: &build-agent
       production: "true"

--- a/ci/advisory
+++ b/ci/advisory
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-echo '--- Formatting'
-cargo fmt -- --check
-
-echo '--- Clippy'
-cargo clippy --all-targets --all-features -- -D warnings
-
 if [[ "${CI:-false}" = "true" ]]
 then
     sed -i -e 's|db-path.*|db-path = "/cache/cargo/advisory-db"|' deny.toml
@@ -23,6 +17,3 @@ cargo deny check bans
 
 echo '--- deny: Sources'
 cargo deny check sources
-
-echo '--- Tests'
-cargo test --all

--- a/ci/build-test
+++ b/ci/build-test
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+echo '--- Build & Test'
+cargo test --all

--- a/ci/clippy
+++ b/ci/clippy
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+echo '--- Formatting'
+cargo fmt -- --check
+
+echo '--- Clippy'
+cargo clippy --all-targets --all-features -- -D warnings
+

--- a/ci/docs
+++ b/ci/docs
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+echo "--- Docs"
+cargo doc --no-deps --workspace

--- a/ci/run
+++ b/ci/run
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+./ci/build-test
+./ci/advisory
+./ci/clippy
+./ci/docs


### PR DESCRIPTION
Fixes #120 

I split the commands out into multiple files. Each one of these, I think, can be run in parallel.
I added a `- wait` for the build and test step because I think this might make sense. We mostly care about building and testing initially, the rest can be done during a cleanup. I think it would also mean we have the build cache set up from the build and test too.