### PR TITLE
Verify & Testify

### DIFF
--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -142,46 +142,18 @@ pub enum VerificationStatus {
 }
 
 impl VerificationStatus {
-    pub fn verified(&self) -> bool {
-        if let VerificationStatus::Verified = self {
-            true
+    pub fn verification_failed(&self) -> Option<&Error> {
+        if let VerificationStatus::VerificationFailed(err) = self {
+            Some(err)
         } else {
-            false
+            None
         }
     }
-    pub fn signed(&self) -> bool {
-        if let VerificationStatus::Signed = self {
-            true
+    pub fn history_verification_failed(&self) -> Option<&HistoryVerificationError> {
+        if let VerificationStatus::HistoryVerificationFailed(err) = self {
+            Some(err)
         } else {
-            false
-        }
-    }
-    pub fn signatures_missing(&self) -> bool {
-        if let VerificationStatus::SignaturesMissing = self {
-            true
-        } else {
-            false
-        }
-    }
-    pub fn verification_failed(&self) -> bool {
-        if let VerificationStatus::VerificationFailed(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-    pub fn history_verification_failed(&self) -> bool {
-        if let VerificationStatus::HistoryVerificationFailed(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-    pub fn unknown(&self) -> bool {
-        if let VerificationStatus::Unknown = self {
-            true
-        } else {
-            false
+            None
         }
     }
 }
@@ -636,7 +608,7 @@ where
                 return Err(err);
             }
             // Also check that no signature is missing
-            if current.status.signatures_missing() {
+            if current.status == VerificationStatus::SignaturesMissing {
                 let err = HistoryVerificationError::ErrorAtRevision {
                     revision,
                     error: Error::SignatureMissing,

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -311,7 +311,7 @@ where
 
     /// Turn the entity in to its raw data
     /// (first step of serialization and reverse of [`Entity::from_data`])
-    pub fn to_data(&self) -> data::EntityData<T> {
+    pub fn to_data(&self) -> EntityData<T> {
         let mut signatures = HashMap::new();
         for (k, s) in self.signatures() {
             signatures.insert(
@@ -329,7 +329,7 @@ where
         let keys = HashSet::from_iter(self.keys().iter().map(|k| k.to_bs58()));
         let certifiers = HashSet::from_iter(self.certifiers().iter().map(|c| c.to_string()));
 
-        data::EntityData {
+        EntityData {
             name: Some(self.name.to_owned()),
             revision: Some(self.revision),
             rad_version: self.rad_version,
@@ -345,7 +345,7 @@ where
 
     /// Helper to build a new entity cloning the current one
     /// (signatures are cleared because they would be invalid anyway)
-    pub fn to_builder(&self) -> data::EntityData<T> {
+    pub fn to_builder(&self) -> EntityData<T> {
         self.to_data().clear_hash().clear_signatures()
     }
 
@@ -661,7 +661,7 @@ where
 {
     /// Build an `Entity` from its data (the second step of deserialization)
     /// It guarantees that the `hash` is correct
-    pub fn from_data(data: data::EntityData<T>) -> Result<Self, Error> {
+    pub fn from_data(data: EntityData<T>) -> Result<Self, Error> {
         // FIXME[ENTITY]: do we want this? it makes `default` harder to get right...
         if data.name.is_none() {
             return Err(Error::InvalidData("Missing name".to_owned()));

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -721,18 +721,13 @@ where
             }
         }
 
-        let parent_hash = match data.parent_hash {
-            Some(s) => Some(Hash::from_str(&s)?),
-            None => None,
-        };
+        let parent_hash = data.parent_hash.map(|s| Hash::from_str(&s)).transpose()?;
+        let root_hash = data.root_hash.map(|s| Hash::from_str(&s)).transpose()?;
 
-        let root_hash = match data.root_hash {
-            Some(s) => Some(Hash::from_str(&s)?),
-            None => None,
-        };
         let root_hash = match root_hash {
             Some(h) => h,
             None => {
+                // TODO: error handling for unwrap on revision
                 if parent_hash.is_none() && data.revision.unwrap() == 1 {
                     actual_hash.clone()
                 } else {

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -619,6 +619,7 @@ where
 
             // End at root revision
             if revision == 1 {
+                self.status = VerificationStatus::Verified;
                 return Ok(());
             }
 

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -117,6 +117,10 @@ impl UserHistory {
             None => Err(HistoryVerificationError::EmptyHistory),
         }
     }
+
+    fn verification_status(&self) -> Option<VerificationStatus> {
+        self.revisions.last().map(|user| user.status().clone())
+    }
 }
 
 #[async_trait]
@@ -322,6 +326,10 @@ async fn test_project_update() {
         .await
         .unwrap();
     assert!(matches!(history.check().await, Ok(())));
+    assert_eq!(
+        history.verification_status(),
+        Some(VerificationStatus::Verified)
+    );
 
     // Having a parent but no parent hash is not ok
     let mut user = history
@@ -388,6 +396,10 @@ async fn test_project_update() {
         .unwrap();
     history.revisions.push(user);
     assert!(matches!(history.check().await, Ok(())));
+    assert_eq!(
+        history.verification_status(),
+        Some(VerificationStatus::Verified)
+    );
 
     // Adding two keys starting from one is not ok
     history.revisions.pop();
@@ -438,6 +450,10 @@ async fn test_project_update() {
         .unwrap();
     history.revisions.push(user);
     assert!(matches!(history.check().await, Ok(())));
+    assert_eq!(
+        history.verification_status(),
+        Some(VerificationStatus::Verified)
+    );
     let mut user = history
         .revisions
         .last()
@@ -458,6 +474,10 @@ async fn test_project_update() {
         .unwrap();
     history.revisions.push(user);
     assert!(matches!(history.check().await, Ok(())));
+    assert_eq!(
+        history.verification_status(),
+        Some(VerificationStatus::Verified)
+    );
 
     // Changing two devices out of three is not ok
     let mut user = history

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -98,6 +98,7 @@ impl Resolver<User> for EmptyResolver {
 
 static EMPTY_RESOLVER: EmptyResolver = EmptyResolver {};
 
+#[derive(Debug, Clone)]
 struct UserHistory {
     pub revisions: Vec<User>,
 }
@@ -107,13 +108,10 @@ impl UserHistory {
         Self { revisions: vec![] }
     }
 
-    async fn check(&self) -> Result<(), HistoryVerificationError> {
-        match self.revisions.last() {
-            Some(user) => {
-                user.clone()
-                    .compute_history_status(self, &EMPTY_RESOLVER)
-                    .await
-            },
+    async fn check(&mut self) -> Result<(), HistoryVerificationError> {
+        let history = self.clone();
+        match self.revisions.last_mut() {
+            Some(user) => user.compute_history_status(&history, &EMPTY_RESOLVER).await,
             None => Err(HistoryVerificationError::EmptyHistory),
         }
     }

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -118,8 +118,8 @@ impl UserHistory {
         }
     }
 
-    fn verification_status(&self) -> Option<VerificationStatus> {
-        self.revisions.last().map(|user| user.status().clone())
+    fn status(&self) -> Option<&VerificationStatus> {
+        self.revisions.last().map(|user| user.status())
     }
 }
 
@@ -326,10 +326,7 @@ async fn test_project_update() {
         .await
         .unwrap();
     assert!(matches!(history.check().await, Ok(())));
-    assert_eq!(
-        history.verification_status(),
-        Some(VerificationStatus::Verified)
-    );
+    assert_eq!(history.status(), Some(&VerificationStatus::Verified));
 
     // Having a parent but no parent hash is not ok
     let mut user = history
@@ -396,10 +393,7 @@ async fn test_project_update() {
         .unwrap();
     history.revisions.push(user);
     assert!(matches!(history.check().await, Ok(())));
-    assert_eq!(
-        history.verification_status(),
-        Some(VerificationStatus::Verified)
-    );
+    assert_eq!(history.status(), Some(&VerificationStatus::Verified));
 
     // Adding two keys starting from one is not ok
     history.revisions.pop();
@@ -450,10 +444,7 @@ async fn test_project_update() {
         .unwrap();
     history.revisions.push(user);
     assert!(matches!(history.check().await, Ok(())));
-    assert_eq!(
-        history.verification_status(),
-        Some(VerificationStatus::Verified)
-    );
+    assert_eq!(history.status(), Some(&VerificationStatus::Verified));
     let mut user = history
         .revisions
         .last()
@@ -474,10 +465,7 @@ async fn test_project_update() {
         .unwrap();
     history.revisions.push(user);
     assert!(matches!(history.check().await, Ok(())));
-    assert_eq!(
-        history.verification_status(),
-        Some(VerificationStatus::Verified)
-    );
+    assert_eq!(history.status(), Some(&VerificationStatus::Verified));
 
     // Changing two devices out of three is not ok
     let mut user = history


### PR DESCRIPTION
Fixes #119 

Added `Verified` when we are exiting the loop for `compute_history_status`. This needed to change the test code slightly, so as not to `clone` the `user` so we could mutate it.

Also added some refactoring code as I was passing through.