### PR TITLE
Eliminate explicit library  init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,12 +1407,14 @@ dependencies = [
 name = "radicle-keystore"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "rpassword",
  "secstr",
  "serde",
  "serde_cbor",
  "sodiumoxide",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -34,7 +34,3 @@ pub mod net;
 pub mod paths;
 pub mod peer;
 pub mod uri;
-
-pub fn init() -> bool {
-    sodiumoxide::init().is_ok()
-}

--- a/radicle-keystore/Cargo.toml
+++ b/radicle-keystore/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [dependencies]
+lazy_static = "1.4"
+rpassword = "4.0"
 secstr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
 sodiumoxide = "0.2"
-rpassword = "4.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/radicle-keystore/src/memory.rs
+++ b/radicle-keystore/src/memory.rs
@@ -161,6 +161,7 @@ mod tests {
     where
         F: FnOnce(MemoryStorage<Pwhash<P>, PublicKey, SecretKey, ()>) -> (),
         P: Pinentry,
+        P::Error: std::error::Error + 'static,
     {
         f(MemoryStorage::new(Pwhash::new(pin)))
     }


### PR DESCRIPTION
We initialise `sodiumoxide` lazily. This eliminates the need to initialise
`librad` explicitly (which is easy to forget, and awkward to enforce on the
type level).

The choice of using `lazy_static` avoids memory barriers incurred by either
calling `sodiumoxide::init()` repeatedly, or using `std::sync::Once`.


On top of #137 for merging convenience (renames made there).