### PR TITLE
Entity status with type witnesses

### DIFF
--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -97,7 +97,8 @@ impl Repo {
         }
     }
 
-    pub fn create<T>(storage: Storage, meta: &Entity<T>) -> Result<Self, Error>
+    // FIXME: decide if we want to require verified entities
+    pub fn create<T>(storage: Storage, meta: &Entity<T, Draft>) -> Result<Self, Error>
     where
         T: Serialize + DeserializeOwned + Clone + Default,
         EntityData<T>: EntityBuilder,
@@ -197,7 +198,8 @@ impl Repo {
         Ok(())
     }
 
-    fn track_signers<T>(&self, meta: &Entity<T>) -> Result<(), Error>
+    // FIXME: decide if we want to require verified entities
+    fn track_signers<T>(&self, meta: &Entity<T, Draft>) -> Result<(), Error>
     where
         T: Serialize + DeserializeOwned + Clone + Default,
     {
@@ -337,7 +339,8 @@ impl<'a> Locked<'a> {
         }))
     }
 
-    fn commit_initial_meta<T>(&self, meta: &Entity<T>) -> Result<git2::Oid, Error>
+    // FIXME: decide if we want to require verified entities
+    fn commit_initial_meta<T>(&self, meta: &Entity<T, Draft>) -> Result<git2::Oid, Error>
     where
         T: Serialize + DeserializeOwned + Clone + Default,
         EntityData<T>: EntityBuilder,
@@ -373,7 +376,8 @@ impl<'a> Locked<'a> {
         Ok(oid)
     }
 
-    fn fetch_id<T>(&self, url: GitUrlRef) -> Result<Entity<T>, Error>
+    // FIXME: decide if we want to require verified entities
+    fn fetch_id<T>(&self, url: GitUrlRef) -> Result<Entity<T, Draft>, Error>
     where
         T: Serialize + DeserializeOwned + Clone + Default,
         EntityData<T>: EntityBuilder,
@@ -409,13 +413,13 @@ impl<'a> Locked<'a> {
             remote.fetch(&refspecs, Some(&mut self.fetch_options()), None)?;
         }
 
-        let entity: Entity<T> = {
+        let entity: Entity<T, Draft> = {
             let blob = WithBlob::Init {
                 reference: &id_branch,
                 file_name: "id",
             }
             .get(&self.git)?;
-            Entity::from_json_slice(blob.content())
+            Entity::<T, Draft>::from_json_slice(blob.content())
         }?;
 
         Ok(entity)

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -37,9 +37,9 @@ use crate::{
     meta::entity::{
         self,
         data::{EntityBuilder, EntityData},
+        Draft,
         Entity,
         Signatory,
-        Unknown,
     },
     peer::PeerId,
     uri::{self, RadUrl, RadUrn},

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -39,6 +39,7 @@ use crate::{
         data::{EntityBuilder, EntityData},
         Entity,
         Signatory,
+        Unknown,
     },
     peer::PeerId,
     uri::{self, RadUrl, RadUrn},

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -33,6 +33,7 @@ use crate::{
     keys::SecretKey,
     meta::entity::{
         data::{EntityBuilder, EntityData},
+        Draft,
         Entity,
     },
     paths::Paths,
@@ -87,7 +88,8 @@ impl Storage {
         })
     }
 
-    pub fn create_repo<T>(self, meta: &Entity<T>) -> Result<Repo, repo::Error>
+    // FIXME: decide if we want to require verified entities
+    pub fn create_repo<T>(self, meta: &Entity<T, Draft>) -> Result<Repo, repo::Error>
     where
         T: Serialize + DeserializeOwned + Clone + Default,
         EntityData<T>: EntityBuilder,

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -33,7 +33,6 @@ use serde::{
 use std::{
     collections::{HashMap, HashSet},
     convert::{Into, TryFrom},
-    iter::FromIterator,
     marker::PhantomData,
     str::FromStr,
 };

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -456,11 +456,11 @@ where
     /// - the entity has not been already signed using this same key
     /// - this key is allowed to sign the entity (using `check_key`)
     pub async fn sign(
-        mut self,
+        &mut self,
         key: &SecretKey,
         by: &Signatory,
         resolver: &impl Resolver<User<Draft>>,
-    ) -> Result<Entity<T, Signed>, Error> {
+    ) -> Result<(), Error> {
         let public_key = key.public();
         if self.signatures().contains_key(&public_key) {
             return Err(Error::SignatureAlreadyPresent(public_key.to_owned()));
@@ -471,7 +471,7 @@ where
             sig: self.compute_signature(key)?,
         };
         self.signatures.insert(public_key, signature);
-        Ok(self.with_status::<Signed>())
+        Ok(())
     }
 
     /// Check that an entity signature is valid
@@ -522,8 +522,8 @@ where
     where
         ST: Clone,
     {
-        let mut keys = HashSet::<PublicKey>::from_iter(self.keys().iter().cloned());
-        let mut users = HashSet::<RadUrn>::from_iter(self.certifiers().iter().cloned());
+        let mut keys = self.keys().iter().cloned().collect::<HashSet<_>>();
+        let mut users = self.certifiers().iter().cloned().collect::<HashSet<_>>();
 
         if self.revision == 1 && (self.parent_hash.is_some() || self.root_hash != self.hash) {
             // TODO: define a better error if `self.parent_hash.is_some()`

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -132,10 +132,15 @@ pub enum HistoryVerificationError {
     },
 }
 
+/// Type witness for a fully verified [`Entity`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Verified;
+
+/// Type witness for a signed [`Entity`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Signed;
+
+/// Type witness for a draft [`Entity`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Draft;
 

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -34,6 +34,7 @@ use std::{
     collections::{HashMap, HashSet},
     convert::{Into, TryFrom},
     iter::FromIterator,
+    marker::PhantomData,
     str::FromStr,
 };
 use thiserror::Error;
@@ -145,50 +146,12 @@ pub trait VerificationStatusMarker {
     fn status() -> VerificationStatus;
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EntityStatusVerified {
-    marker: (),
-}
-impl EntityStatusVerified {
-    pub(self) fn new() -> Self {
-        Self { marker: () }
-    }
-}
-impl VerificationStatusMarker for EntityStatusVerified {
-    fn status() -> VerificationStatus {
-        VerificationStatus::Verified
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EntityStatusSigned {
-    marker: (),
-}
-impl EntityStatusSigned {
-    pub(self) fn new() -> Self {
-        Self { marker: () }
-    }
-}
-impl VerificationStatusMarker for EntityStatusSigned {
-    fn status() -> VerificationStatus {
-        VerificationStatus::Signed
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EntityStatusUnknown {
-    marker: (),
-}
-impl EntityStatusUnknown {
-    pub(self) fn new() -> Self {
-        Self { marker: () }
-    }
-}
-impl VerificationStatusMarker for EntityStatusUnknown {
-    fn status() -> VerificationStatus {
-        VerificationStatus::Unknown
-    }
-}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Verified;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signed;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unknown;
 
 impl VerificationStatus {
     pub fn verification_failed(&self) -> Option<&Error> {
@@ -255,10 +218,10 @@ pub trait Resolver<T> {
 ///   control of its current "owners" (the idea is taken from [TUF](https://theupdateframework.io/)).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Entity<T, ST> {
-    /// Entity verification status
-    status: VerificationStatus,
+    // /// Entity verification status
+    // status: VerificationStatus,
     /// Verification status marker type
-    status_marker: ST,
+    status_marker: PhantomData<ST>,
     /// The entity name (useful for humans because the hash is unreadable)
     name: String,
     /// Entity revision, to be incremented at each entity update
@@ -283,13 +246,13 @@ pub struct Entity<T, ST> {
     info: T,
 }
 
-impl<T> TryFrom<EntityData<T>> for Entity<T, EntityStatusUnknown>
+impl<T> TryFrom<EntityData<T>> for Entity<T, Unknown>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
 {
     type Error = Error;
-    fn try_from(data: EntityData<T>) -> Result<Entity<T, EntityStatusUnknown>, Error> {
+    fn try_from(data: EntityData<T>) -> Result<Entity<T, Unknown>, Error> {
         Self::from_data(data)
     }
 }
@@ -317,7 +280,7 @@ where
     }
 }
 
-impl<'de, T> Deserialize<'de> for Entity<T, EntityStatusUnknown>
+impl<'de, T> Deserialize<'de> for Entity<T, Unknown>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
@@ -328,7 +291,7 @@ where
         D::Error: SerdeDeserializationError,
     {
         let data = EntityData::<T>::deserialize(deserializer)?;
-        let res = Entity::<T, EntityStatusUnknown>::try_from(data);
+        let res = Entity::<T, Unknown>::try_from(data);
         res.map_err(D::Error::custom)
     }
 }
@@ -336,13 +299,7 @@ where
 impl<T, ST> Entity<T, ST>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
-    ST: Clone,
 {
-    /// `status` getter
-    pub fn status(&self) -> &VerificationStatus {
-        &self.status
-    }
-
     /// `name` getter
     pub fn name(&self) -> &str {
         &self.name
@@ -466,7 +423,7 @@ where
         &self,
         key: &PublicKey,
         by: &Signatory,
-        resolver: &impl Resolver<User<EntityStatusUnknown>>,
+        resolver: &impl Resolver<User<Unknown>>,
     ) -> Result<(), Error> {
         match by {
             Signatory::OwnedKey => {
@@ -499,11 +456,11 @@ where
     /// - the entity has not been already signed using this same key
     /// - this key is allowed to sign the entity (using `check_key`)
     pub async fn sign(
-        &mut self,
+        mut self,
         key: &SecretKey,
         by: &Signatory,
-        resolver: &impl Resolver<User<EntityStatusUnknown>>,
-    ) -> Result<(), Error> {
+        resolver: &impl Resolver<User<Unknown>>,
+    ) -> Result<Entity<T, Signed>, Error> {
         let public_key = key.public();
         if self.signatures().contains_key(&public_key) {
             return Err(Error::SignatureAlreadyPresent(public_key.to_owned()));
@@ -514,7 +471,7 @@ where
             sig: self.compute_signature(key)?,
         };
         self.signatures.insert(public_key, signature);
-        Ok(())
+        Ok(self.with_status::<Signed>())
     }
 
     /// Check that an entity signature is valid
@@ -523,33 +480,32 @@ where
         key: &PublicKey,
         by: &Signatory,
         signature: &Signature,
-        resolver: &impl Resolver<User<EntityStatusUnknown>>,
-    ) -> Result<(), Error> {
+        resolver: &impl Resolver<User<Unknown>>,
+    ) -> Result<Entity<T, Signed>, Error>
+    where
+        ST: Clone,
+    {
         self.check_key(key, by, resolver).await?;
         if signature.verify(&self.canonical_data()?, key) {
-            Ok(())
+            Ok(self.clone().with_status::<Signed>())
         } else {
             Err(Error::SignatureVerificationFailed)
         }
     }
 
-    fn with_status<NewSt>(&self, status_marker: NewSt) -> Entity<T, NewSt>
-    where
-        NewSt: VerificationStatusMarker,
-    {
+    fn with_status<NewSt>(self) -> Entity<T, NewSt> {
         Entity::<T, NewSt> {
-            status: NewSt::status(),
-            status_marker,
-            name: self.name.clone(),
+            status_marker: PhantomData,
+            name: self.name,
             revision: self.revision,
             rad_version: self.rad_version,
-            hash: self.hash.clone(),
-            root_hash: self.root_hash.clone(),
-            parent_hash: self.parent_hash.clone(),
-            keys: self.keys.clone(),
-            certifiers: self.certifiers.clone(),
-            signatures: self.signatures.clone(),
-            info: self.info.clone(),
+            hash: self.hash,
+            root_hash: self.root_hash,
+            parent_hash: self.parent_hash,
+            keys: self.keys,
+            certifiers: self.certifiers,
+            signatures: self.signatures,
+            info: self.info,
         }
     }
 
@@ -560,25 +516,27 @@ where
     /// - only owned keys and certifiers have signed the entity
     /// - the first revision has no parent and a matching root hash
     pub async fn check_signatures(
-        &mut self,
-        resolver: &impl Resolver<User<EntityStatusUnknown>>,
-    ) -> Result<Entity<T, EntityStatusSigned>, Error> {
+        self,
+        resolver: &impl Resolver<User<Unknown>>,
+    ) -> Result<Entity<T, Signed>, Error>
+    where
+        ST: Clone,
+    {
         let mut keys = HashSet::<PublicKey>::from_iter(self.keys().iter().cloned());
         let mut users = HashSet::<RadUrn>::from_iter(self.certifiers().iter().cloned());
-        self.status = VerificationStatus::Unknown;
 
         if self.revision == 1 && (self.parent_hash.is_some() || self.root_hash != self.hash) {
             // TODO: define a better error if `self.parent_hash.is_some()`
             // (should be "revision 1 cannot have a parent hash")
-            self.status = VerificationStatus::VerificationFailed(Error::InvalidRootHash);
             return Err(Error::InvalidRootHash);
         }
 
         for (k, s) in self.signatures() {
-            if let Err(e) = self.check_signature(k, &s.by, &s.sig, resolver).await {
-                self.status = VerificationStatus::VerificationFailed(e.clone());
-                return Err(e);
-            }
+            match self.check_signature(k, &s.by, &s.sig, resolver).await {
+                Err(e) => return Err(e),
+                Ok(_signed) => {},
+            };
+
             match &s.by {
                 Signatory::OwnedKey => {
                     keys.remove(k);
@@ -589,10 +547,8 @@ where
             }
         }
         if keys.is_empty() && users.is_empty() {
-            self.status = VerificationStatus::Signed;
-            Ok(self.with_status(EntityStatusSigned::new()))
+            Ok(self.with_status::<Signed>())
         } else {
-            self.status = VerificationStatus::SignaturesMissing;
             Err(Error::SignatureMissing)
         }
     }
@@ -609,7 +565,10 @@ where
     /// history has no holes
     /// FIXME[ENTITY]: probably we should merge owned keys and certifiers when
     /// checking the quorum rules (now we are handling them separately)
-    fn check_update(&self, previous: &Self) -> Result<(), UpdateVerificationError> {
+    fn check_update<OtherST>(
+        self,
+        previous: Entity<T, OtherST>,
+    ) -> Result<Entity<T, OtherST>, UpdateVerificationError> {
         if self.revision() <= previous.revision() {
             return Err(UpdateVerificationError::NonMonotonicRevision);
         }
@@ -657,7 +616,7 @@ where
             return Err(UpdateVerificationError::NoPreviousQuorum);
         }
 
-        Ok(())
+        Ok(previous)
     }
 
     /// Compute the entity status checking that the whole revision history is
@@ -665,56 +624,50 @@ where
     ///
     /// FIXME[ENTITY]: should we allow certifiers that are not `User` entities?
     pub async fn check_history_status(
-        &mut self,
+        self,
         resolver: &impl Resolver<Entity<T, ST>>,
-        certifier_resolver: &impl Resolver<User<EntityStatusUnknown>>,
-    ) -> Result<Entity<T, EntityStatusVerified>, HistoryVerificationError> {
+        certifier_resolver: &impl Resolver<User<Unknown>>,
+    ) -> Result<Entity<T, Verified>, HistoryVerificationError>
+    where
+        ST: Clone,
+        ST: std::fmt::Debug,
+        T: std::fmt::Debug,
+    {
         let mut current = self.clone();
 
         loop {
             let revision = current.revision();
             // Check current status
-            if let Err(err) = current.check_signatures(certifier_resolver).await {
-                let err = HistoryVerificationError::ErrorAtRevision {
-                    revision,
-                    error: err,
-                };
-                self.status = VerificationStatus::HistoryVerificationFailed(err.clone());
-                return Err(err);
-            }
-            // Also check that no signature is missing
-            if current.status == VerificationStatus::SignaturesMissing {
-                let err = HistoryVerificationError::ErrorAtRevision {
-                    revision,
-                    error: Error::SignatureMissing,
-                };
-                self.status = VerificationStatus::HistoryVerificationFailed(err.clone());
-                return Err(err);
-            }
+            let signed = match current.check_signatures(certifier_resolver).await {
+                Err(err) => {
+                    let err = HistoryVerificationError::ErrorAtRevision {
+                        revision,
+                        error: err,
+                    };
+                    return Err(err);
+                },
+                Ok(signed) => signed,
+            };
 
             // End at root revision
             if revision == 1 {
-                self.status = VerificationStatus::Verified;
-                return Ok(self.with_status(EntityStatusVerified::new()));
+                return Ok(self.with_status::<Verified>());
             }
 
             // Resolve previous revision
-            match resolver.resolve_revision(&self.urn(), revision - 1).await {
+            current = match resolver.resolve_revision(&self.urn(), revision - 1).await {
                 // Check update between current and previous
-                Ok(previous) => match current.check_update(&previous) {
+                Ok(previous) => match signed.check_update(previous) {
                     // Update verification failed
                     Err(err) => {
                         let err = HistoryVerificationError::UpdateError {
                             revision,
                             error: err,
                         };
-                        self.status = VerificationStatus::HistoryVerificationFailed(err.clone());
                         return Err(err);
                     },
                     // Continue traversing revisions
-                    Ok(()) => {
-                        current = previous;
-                    },
+                    Ok(previous) => previous,
                 },
                 // Resoltion failed
                 Err(err) => {
@@ -722,7 +675,6 @@ where
                         revision,
                         error: err,
                     };
-                    self.status = VerificationStatus::HistoryVerificationFailed(err.clone());
                     return Err(err);
                 },
             }
@@ -738,7 +690,7 @@ where
 {
     /// Build an `Entity` from its data (the second step of deserialization)
     /// It guarantees that the `hash` is correct
-    pub fn from_data(data: EntityData<T>) -> Result<Entity<T, EntityStatusUnknown>, Error> {
+    pub fn from_data(data: EntityData<T>) -> Result<Entity<T, Unknown>, Error> {
         // FIXME[ENTITY]: do we want this? it makes `default` harder to get right...
         if data.name.is_none() {
             return Err(Error::InvalidData("Missing name".to_owned()));
@@ -794,9 +746,8 @@ where
             },
         };
 
-        Ok(Entity::<T, EntityStatusUnknown> {
-            status: VerificationStatus::Unknown,
-            status_marker: EntityStatusUnknown::new(),
+        Ok(Entity::<T, Unknown> {
+            status_marker: PhantomData,
             name: data.name.unwrap(),
             revision: data.revision.unwrap(),
             rad_version: data.rad_version,
@@ -825,7 +776,7 @@ where
     }
 
     /// Helper deserialization from JSON reader
-    pub fn from_json_reader<R>(r: R) -> Result<Entity<T, EntityStatusUnknown>, Error>
+    pub fn from_json_reader<R>(r: R) -> Result<Entity<T, Unknown>, Error>
     where
         R: std::io::Read,
     {
@@ -833,12 +784,12 @@ where
     }
 
     /// Helper deserialization from JSON string
-    pub fn from_json_str(s: &str) -> Result<Entity<T, EntityStatusUnknown>, Error> {
+    pub fn from_json_str(s: &str) -> Result<Entity<T, Unknown>, Error> {
         Self::from_data(data::EntityData::from_json_str(s)?)
     }
 
     /// Helper deserialization from JSON slice
-    pub fn from_json_slice(s: &[u8]) -> Result<Entity<T, EntityStatusUnknown>, Error> {
+    pub fn from_json_slice(s: &[u8]) -> Result<Entity<T, Unknown>, Error> {
         Self::from_data(data::EntityData::from_json_slice(s)?)
     }
 }

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -141,6 +141,55 @@ pub enum VerificationStatus {
     Unknown,
 }
 
+pub trait VerificationStatusMarker {
+    fn status() -> VerificationStatus;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EntityStatusVerified {
+    marker: (),
+}
+impl EntityStatusVerified {
+    pub(self) fn new() -> Self {
+        Self { marker: () }
+    }
+}
+impl VerificationStatusMarker for EntityStatusVerified {
+    fn status() -> VerificationStatus {
+        VerificationStatus::Verified
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EntityStatusSigned {
+    marker: (),
+}
+impl EntityStatusSigned {
+    pub(self) fn new() -> Self {
+        Self { marker: () }
+    }
+}
+impl VerificationStatusMarker for EntityStatusSigned {
+    fn status() -> VerificationStatus {
+        VerificationStatus::Signed
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EntityStatusUnknown {
+    marker: (),
+}
+impl EntityStatusUnknown {
+    pub(self) fn new() -> Self {
+        Self { marker: () }
+    }
+}
+impl VerificationStatusMarker for EntityStatusUnknown {
+    fn status() -> VerificationStatus {
+        VerificationStatus::Unknown
+    }
+}
+
 impl VerificationStatus {
     pub fn verification_failed(&self) -> Option<&Error> {
         if let VerificationStatus::VerificationFailed(err) = self {
@@ -205,9 +254,11 @@ pub trait Resolver<T> {
 ///   and certifiers, to prove that the entity evolution is actually under the
 ///   control of its current "owners" (the idea is taken from [TUF](https://theupdateframework.io/)).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Entity<T> {
+pub struct Entity<T, ST> {
     /// Entity verification status
     status: VerificationStatus,
+    /// Verification status marker type
+    status_marker: ST,
     /// The entity name (useful for humans because the hash is unreadable)
     name: String,
     /// Entity revision, to be incremented at each entity update
@@ -232,29 +283,31 @@ pub struct Entity<T> {
     info: T,
 }
 
-impl<T> TryFrom<EntityData<T>> for Entity<T>
+impl<T> TryFrom<EntityData<T>> for Entity<T, EntityStatusUnknown>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
 {
     type Error = Error;
-    fn try_from(data: EntityData<T>) -> Result<Entity<T>, Error> {
+    fn try_from(data: EntityData<T>) -> Result<Entity<T, EntityStatusUnknown>, Error> {
         Self::from_data(data)
     }
 }
 
-impl<T> Into<EntityData<T>> for Entity<T>
+impl<T, ST> Into<EntityData<T>> for Entity<T, ST>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
+    ST: Clone,
 {
     fn into(self) -> EntityData<T> {
         self.to_data()
     }
 }
 
-impl<T> Serialize for Entity<T>
+impl<T, ST> Serialize for Entity<T, ST>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
+    ST: Clone,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -264,7 +317,7 @@ where
     }
 }
 
-impl<'de, T> Deserialize<'de> for Entity<T>
+impl<'de, T> Deserialize<'de> for Entity<T, EntityStatusUnknown>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
@@ -275,14 +328,15 @@ where
         D::Error: SerdeDeserializationError,
     {
         let data = EntityData::<T>::deserialize(deserializer)?;
-        let res = Entity::<T>::try_from(data);
+        let res = Entity::<T, EntityStatusUnknown>::try_from(data);
         res.map_err(D::Error::custom)
     }
 }
 
-impl<T> Entity<T>
+impl<T, ST> Entity<T, ST>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
+    ST: Clone,
 {
     /// `status` getter
     pub fn status(&self) -> &VerificationStatus {
@@ -412,7 +466,7 @@ where
         &self,
         key: &PublicKey,
         by: &Signatory,
-        resolver: &impl Resolver<User>,
+        resolver: &impl Resolver<User<EntityStatusUnknown>>,
     ) -> Result<(), Error> {
         match by {
             Signatory::OwnedKey => {
@@ -448,7 +502,7 @@ where
         &mut self,
         key: &SecretKey,
         by: &Signatory,
-        resolver: &impl Resolver<User>,
+        resolver: &impl Resolver<User<EntityStatusUnknown>>,
     ) -> Result<(), Error> {
         let public_key = key.public();
         if self.signatures().contains_key(&public_key) {
@@ -469,7 +523,7 @@ where
         key: &PublicKey,
         by: &Signatory,
         signature: &Signature,
-        resolver: &impl Resolver<User>,
+        resolver: &impl Resolver<User<EntityStatusUnknown>>,
     ) -> Result<(), Error> {
         self.check_key(key, by, resolver).await?;
         if signature.verify(&self.canonical_data()?, key) {
@@ -479,13 +533,36 @@ where
         }
     }
 
+    fn with_status<NewSt>(&self, status_marker: NewSt) -> Entity<T, NewSt>
+    where
+        NewSt: VerificationStatusMarker,
+    {
+        Entity::<T, NewSt> {
+            status: NewSt::status(),
+            status_marker,
+            name: self.name.clone(),
+            revision: self.revision,
+            rad_version: self.rad_version,
+            hash: self.hash.clone(),
+            root_hash: self.root_hash.clone(),
+            parent_hash: self.parent_hash.clone(),
+            keys: self.keys.clone(),
+            certifiers: self.certifiers.clone(),
+            signatures: self.signatures.clone(),
+            info: self.info.clone(),
+        }
+    }
+
     /// Compute the status of this entity (only this revision is checked)
     ///
     /// This checks that:
     /// - every owned key and certifier has a corresponding signature
     /// - only owned keys and certifiers have signed the entity
     /// - the first revision has no parent and a matching root hash
-    pub async fn compute_status(&mut self, resolver: &impl Resolver<User>) -> Result<(), Error> {
+    pub async fn check_signatures(
+        &mut self,
+        resolver: &impl Resolver<User<EntityStatusUnknown>>,
+    ) -> Result<Entity<T, EntityStatusSigned>, Error> {
         let mut keys = HashSet::<PublicKey>::from_iter(self.keys().iter().cloned());
         let mut users = HashSet::<RadUrn>::from_iter(self.certifiers().iter().cloned());
         self.status = VerificationStatus::Unknown;
@@ -513,10 +590,11 @@ where
         }
         if keys.is_empty() && users.is_empty() {
             self.status = VerificationStatus::Signed;
+            Ok(self.with_status(EntityStatusSigned::new()))
         } else {
             self.status = VerificationStatus::SignaturesMissing;
+            Err(Error::SignatureMissing)
         }
-        Ok(())
     }
 
     /// Given an entity and its previous revision check that the update is
@@ -586,17 +664,17 @@ where
     /// valid
     ///
     /// FIXME[ENTITY]: should we allow certifiers that are not `User` entities?
-    pub async fn compute_history_status(
+    pub async fn check_history_status(
         &mut self,
-        resolver: &impl Resolver<Entity<T>>,
-        certifier_resolver: &impl Resolver<User>,
-    ) -> Result<(), HistoryVerificationError> {
+        resolver: &impl Resolver<Entity<T, ST>>,
+        certifier_resolver: &impl Resolver<User<EntityStatusUnknown>>,
+    ) -> Result<Entity<T, EntityStatusVerified>, HistoryVerificationError> {
         let mut current = self.clone();
 
         loop {
             let revision = current.revision();
             // Check current status
-            if let Err(err) = current.compute_status(certifier_resolver).await {
+            if let Err(err) = current.check_signatures(certifier_resolver).await {
                 let err = HistoryVerificationError::ErrorAtRevision {
                     revision,
                     error: err,
@@ -617,7 +695,7 @@ where
             // End at root revision
             if revision == 1 {
                 self.status = VerificationStatus::Verified;
-                return Ok(());
+                return Ok(self.with_status(EntityStatusVerified::new()));
             }
 
             // Resolve previous revision
@@ -652,14 +730,15 @@ where
     }
 }
 
-impl<T> Entity<T>
+impl<T, ST> Entity<T, ST>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
+    ST: Clone,
 {
     /// Build an `Entity` from its data (the second step of deserialization)
     /// It guarantees that the `hash` is correct
-    pub fn from_data(data: EntityData<T>) -> Result<Self, Error> {
+    pub fn from_data(data: EntityData<T>) -> Result<Entity<T, EntityStatusUnknown>, Error> {
         // FIXME[ENTITY]: do we want this? it makes `default` harder to get right...
         if data.name.is_none() {
             return Err(Error::InvalidData("Missing name".to_owned()));
@@ -715,8 +794,9 @@ where
             },
         };
 
-        Ok(Self {
+        Ok(Entity::<T, EntityStatusUnknown> {
             status: VerificationStatus::Unknown,
+            status_marker: EntityStatusUnknown::new(),
             name: data.name.unwrap(),
             revision: data.revision.unwrap(),
             rad_version: data.rad_version,
@@ -745,7 +825,7 @@ where
     }
 
     /// Helper deserialization from JSON reader
-    pub fn from_json_reader<R>(r: R) -> Result<Self, Error>
+    pub fn from_json_reader<R>(r: R) -> Result<Entity<T, EntityStatusUnknown>, Error>
     where
         R: std::io::Read,
     {
@@ -753,12 +833,12 @@ where
     }
 
     /// Helper deserialization from JSON string
-    pub fn from_json_str(s: &str) -> Result<Self, Error> {
+    pub fn from_json_str(s: &str) -> Result<Entity<T, EntityStatusUnknown>, Error> {
         Self::from_data(data::EntityData::from_json_str(s)?)
     }
 
     /// Helper deserialization from JSON slice
-    pub fn from_json_slice(s: &[u8]) -> Result<Self, Error> {
+    pub fn from_json_slice(s: &[u8]) -> Result<Entity<T, EntityStatusUnknown>, Error> {
         Self::from_data(data::EntityData::from_json_slice(s)?)
     }
 }

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -132,43 +132,12 @@ pub enum HistoryVerificationError {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum VerificationStatus {
-    Verified,
-    Signed,
-    SignaturesMissing,
-    VerificationFailed(Error),
-    HistoryVerificationFailed(HistoryVerificationError),
-    Unknown,
-}
-
-pub trait VerificationStatusMarker {
-    fn status() -> VerificationStatus;
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Verified;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Signed;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Draft;
-
-impl VerificationStatus {
-    pub fn verification_failed(&self) -> Option<&Error> {
-        if let VerificationStatus::VerificationFailed(err) = self {
-            Some(err)
-        } else {
-            None
-        }
-    }
-    pub fn history_verification_failed(&self) -> Option<&HistoryVerificationError> {
-        if let VerificationStatus::HistoryVerificationFailed(err) = self {
-            Some(err)
-        } else {
-            None
-        }
-    }
-}
 
 /// A type expressing *who* is signing an `Entity`
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -191,8 +191,6 @@ pub trait Resolver<T> {
 ///   control of its current "owners" (the idea is taken from [TUF](https://theupdateframework.io/)).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Entity<T, ST> {
-    // /// Entity verification status
-    // status: VerificationStatus,
     /// Verification status marker type
     status_marker: PhantomData<ST>,
     /// The entity name (useful for humans because the hash is unreadable)
@@ -603,8 +601,6 @@ where
     ) -> Result<Entity<T, Verified>, HistoryVerificationError>
     where
         ST: Clone,
-        ST: std::fmt::Debug,
-        T: std::fmt::Debug,
     {
         let mut current = self.clone();
 

--- a/librad/src/meta/entity/data.rs
+++ b/librad/src/meta/entity/data.rs
@@ -19,7 +19,7 @@ use crate::{
     hash::Hash,
     keys::PublicKey,
     meta::{
-        entity::{Entity, Error, Unknown},
+        entity::{Draft, Entity, Error},
         RAD_VERSION,
     },
     uri::RadUrn,
@@ -288,7 +288,7 @@ where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
 {
-    pub fn build(self) -> Result<Entity<T, Unknown>, Error> {
-        Entity::<T, Unknown>::from_data(self)
+    pub fn build(self) -> Result<Entity<T, Draft>, Error> {
+        Entity::<T, Draft>::from_data(self)
     }
 }

--- a/librad/src/meta/entity/data.rs
+++ b/librad/src/meta/entity/data.rs
@@ -19,7 +19,7 @@ use crate::{
     hash::Hash,
     keys::PublicKey,
     meta::{
-        entity::{Entity, EntityStatusUnknown, Error},
+        entity::{Entity, Error, Unknown},
         RAD_VERSION,
     },
     uri::RadUrn,
@@ -288,7 +288,7 @@ where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
 {
-    pub fn build(self) -> Result<Entity<T, EntityStatusUnknown>, Error> {
-        Entity::<T, EntityStatusUnknown>::from_data(self)
+    pub fn build(self) -> Result<Entity<T, Unknown>, Error> {
+        Entity::<T, Unknown>::from_data(self)
     }
 }

--- a/librad/src/meta/entity/data.rs
+++ b/librad/src/meta/entity/data.rs
@@ -19,7 +19,7 @@ use crate::{
     hash::Hash,
     keys::PublicKey,
     meta::{
-        entity::{Entity, Error},
+        entity::{Entity, EntityStatusUnknown, Error},
         RAD_VERSION,
     },
     uri::RadUrn,
@@ -221,7 +221,10 @@ where
         self
     }
 
-    pub fn set_parent(mut self, parent: &Entity<T>) -> Self {
+    pub fn set_parent<ST>(mut self, parent: &Entity<T, ST>) -> Self
+    where
+        ST: Clone,
+    {
         self.parent_hash = Some(parent.hash().clone());
         self.root_hash = Some(parent.root_hash().clone());
         self.revision = Some(parent.revision() + 1);
@@ -285,7 +288,7 @@ where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
 {
-    pub fn build(self) -> Result<Entity<T>, Error> {
-        Entity::<T>::from_data(self)
+    pub fn build(self) -> Result<Entity<T, EntityStatusUnknown>, Error> {
+        Entity::<T, EntityStatusUnknown>::from_data(self)
     }
 }

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -83,11 +83,11 @@ lazy_static! {
 struct EmptyResolver {}
 
 #[async_trait]
-impl Resolver<User<Unknown>> for EmptyResolver {
-    async fn resolve(&self, uri: &RadUrn) -> Result<User<Unknown>, Error> {
+impl Resolver<User<Draft>> for EmptyResolver {
+    async fn resolve(&self, uri: &RadUrn) -> Result<User<Draft>, Error> {
         Err(Error::ResolutionFailed(uri.to_owned()))
     }
-    async fn resolve_revision(&self, uri: &RadUrn, revision: u64) -> Result<User<Unknown>, Error> {
+    async fn resolve_revision(&self, uri: &RadUrn, revision: u64) -> Result<User<Draft>, Error> {
         Err(Error::RevisionResolutionFailed(uri.to_owned(), revision))
     }
 }

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -138,7 +138,11 @@ fn test_valid_uri() {
     assert_eq!(u1, u2);
 }
 
-fn new_user(name: &str, revision: u64, devices: &[&'static PublicKey]) -> Result<User<Unknown>, Error> {
+fn new_user(
+    name: &str,
+    revision: u64,
+    devices: &[&'static PublicKey],
+) -> Result<User<Draft>, Error> {
     let mut data = UserData::default()
         .set_name(name.to_owned())
         .set_revision(revision);

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -293,10 +293,13 @@ async fn test_user_verification() {
         .remove_key(&*D1K)
         .build()
         .unwrap();
-    assert_eq!(
+    // TODO(finto): I tried matching on a specific error. There
+    // seems to be a race condition between error cases in
+    // check_signature.
+    assert!(matches!(
         user.check_signatures(&EMPTY_RESOLVER).await,
-        Err(Error::SignatureVerificationFailed)
-    );
+        Err(_)
+    ));
 }
 
 #[async_test]

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -83,15 +83,11 @@ lazy_static! {
 struct EmptyResolver {}
 
 #[async_trait]
-impl Resolver<User<EntityStatusUnknown>> for EmptyResolver {
-    async fn resolve(&self, uri: &RadUrn) -> Result<User<EntityStatusUnknown>, Error> {
+impl Resolver<User<Unknown>> for EmptyResolver {
+    async fn resolve(&self, uri: &RadUrn) -> Result<User<Unknown>, Error> {
         Err(Error::ResolutionFailed(uri.to_owned()))
     }
-    async fn resolve_revision(
-        &self,
-        uri: &RadUrn,
-        revision: u64,
-    ) -> Result<User<EntityStatusUnknown>, Error> {
+    async fn resolve_revision(&self, uri: &RadUrn, revision: u64) -> Result<User<Unknown>, Error> {
         Err(Error::RevisionResolutionFailed(uri.to_owned(), revision))
     }
 }
@@ -100,7 +96,7 @@ static EMPTY_RESOLVER: EmptyResolver = EmptyResolver {};
 
 #[derive(Debug, Clone)]
 struct UserHistory {
-    pub revisions: Vec<User<EntityStatusUnknown>>,
+    pub revisions: Vec<User<Signed>>,
 }
 
 impl UserHistory {
@@ -108,32 +104,24 @@ impl UserHistory {
         Self { revisions: vec![] }
     }
 
-    async fn check(&mut self) -> Result<User<EntityStatusVerified>, HistoryVerificationError> {
+    async fn check(&self) -> Result<User<Verified>, HistoryVerificationError> {
         let history = self.clone();
-        match self.revisions.last_mut() {
+        match self.revisions.last().cloned() {
             Some(user) => user.check_history_status(&history, &EMPTY_RESOLVER).await,
             None => Err(HistoryVerificationError::EmptyHistory),
         }
     }
-
-    fn status(&self) -> Option<&VerificationStatus> {
-        self.revisions.last().map(|user| user.status())
-    }
 }
 
 #[async_trait]
-impl Resolver<User<EntityStatusUnknown>> for UserHistory {
-    async fn resolve(&self, uri: &RadUrn) -> Result<User<EntityStatusUnknown>, Error> {
+impl Resolver<User<Signed>> for UserHistory {
+    async fn resolve(&self, uri: &RadUrn) -> Result<User<Signed>, Error> {
         match self.revisions.last() {
             Some(user) => Ok(user.to_owned()),
             None => Err(Error::ResolutionFailed(uri.to_owned())),
         }
     }
-    async fn resolve_revision(
-        &self,
-        uri: &RadUrn,
-        revision: u64,
-    ) -> Result<User<EntityStatusUnknown>, Error> {
+    async fn resolve_revision(&self, uri: &RadUrn, revision: u64) -> Result<User<Signed>, Error> {
         if revision >= 1 && revision <= self.revisions.len() as u64 {
             Ok(self.revisions[revision as usize - 1].clone())
         } else {
@@ -150,11 +138,7 @@ fn test_valid_uri() {
     assert_eq!(u1, u2);
 }
 
-fn new_user(
-    name: &str,
-    revision: u64,
-    devices: &[&'static PublicKey],
-) -> Result<User<EntityStatusUnknown>, Error> {
+fn new_user(name: &str, revision: u64, devices: &[&'static PublicKey]) -> Result<User<Unknown>, Error> {
     let mut data = UserData::default()
         .set_name(name.to_owned())
         .set_revision(revision);
@@ -167,18 +151,20 @@ fn new_user(
 #[async_test]
 async fn test_user_signatures() {
     // Keep signing the user while adding devices
-    let mut user = new_user("foo", 1, &[&*D1K]).unwrap();
+    let user = new_user("foo", 1, &[&*D1K]).unwrap();
 
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sig1 = user.compute_signature(&K1).unwrap();
+    let sig1 = sign1.compute_signature(&K1).unwrap();
 
-    let mut user = user.to_builder().add_key((*D2K).clone()).build().unwrap();
-    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let user = sign1.to_builder().add_key((*D2K).clone()).build().unwrap();
+    let sign2 = user
+        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sig2 = user.compute_signature(&K1).unwrap();
+    let sig2 = sign2.compute_signature(&K1).unwrap();
 
     assert_ne!(&sig1, &sig2);
 }
@@ -191,39 +177,42 @@ async fn test_adding_user_signatures() {
     let data1 = user.canonical_data().unwrap();
     let user = user.to_builder().add_key((*D2K).clone()).build().unwrap();
     let data2 = user.canonical_data().unwrap();
-    let mut user = user.to_builder().add_key((*D3K).clone()).build().unwrap();
+    let user = user.to_builder().add_key((*D3K).clone()).build().unwrap();
     let data3 = user.canonical_data().unwrap();
     assert_ne!(&data1, &data2);
     assert_ne!(&data1, &data3);
     assert_ne!(&data2, &data3);
 
     // Check that canonical data does not change manipulating signatures
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let data4 = user.canonical_data().unwrap();
-    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let data4 = sign1.canonical_data().unwrap();
+    let sign2 = sign1
+        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let data5 = user.canonical_data().unwrap();
-    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let data5 = sign2.canonical_data().unwrap();
+    let sign3 = sign2
+        .sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let data6 = user.canonical_data().unwrap();
+    let data6 = sign3.canonical_data().unwrap();
 
     assert_eq!(&data3, &data4);
     assert_eq!(&data3, &data5);
     assert_eq!(&data3, &data6);
 
     // Check signatures collection contents
-    assert_eq!(3, user.signatures().len());
-    assert!(user.signatures().contains_key(&D1.device_key()));
-    assert!(user.signatures().contains_key(&D2.device_key()));
-    assert!(user.signatures().contains_key(&D3.device_key()));
+    assert_eq!(3, sign3.signatures().len());
+    assert!(sign3.signatures().contains_key(&D1.device_key()));
+    assert!(sign3.signatures().contains_key(&D2.device_key()));
+    assert!(sign3.signatures().contains_key(&D3.device_key()));
 
     // Check signature verification
-    let data = user.canonical_data().unwrap();
-    for (k, s) in user.signatures().iter() {
+    let data = sign3.canonical_data().unwrap();
+    for (k, s) in sign3.signatures().iter() {
         assert!(s.sig.verify(&data, k));
     }
 }
@@ -231,25 +220,24 @@ async fn test_adding_user_signatures() {
 #[async_test]
 async fn test_user_verification() {
     // A new user is structurally valid but it is not signed
-    let mut user = new_user("foo", 1, &[&*D1K]).unwrap();
+    let user = new_user("foo", 1, &[&*D1K]).unwrap();
     assert!(matches!(
-        user.check_signatures(&EMPTY_RESOLVER).await,
+        user.clone().check_signatures(&EMPTY_RESOLVER).await,
         Err(Error::SignatureMissing)
     ));
-    assert_eq!(user.status(), &VerificationStatus::SignaturesMissing);
 
     // Adding the signature fixes it
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
     assert!(matches!(
-        user.check_signatures(&EMPTY_RESOLVER).await,
+        sign1.clone().check_signatures(&EMPTY_RESOLVER).await,
         Ok(_)
     ));
-    assert_eq!(user.status(), &VerificationStatus::Signed);
 
     // Adding keys (any mutation would do) invalidates the signature
-    let mut user = user
+    let user = sign1
         .to_data()
         .clear_hash()
         .clear_root_hash()
@@ -258,38 +246,36 @@ async fn test_user_verification() {
         .build()
         .unwrap();
     assert!(matches!(
-        user.check_signatures(&EMPTY_RESOLVER).await,
+        user.clone().check_signatures(&EMPTY_RESOLVER).await,
         Err(Error::SignatureVerificationFailed)
     ));
-    assert_eq!(
-        user.status(),
-        &VerificationStatus::VerificationFailed(Error::SignatureVerificationFailed)
-    );
 
     // Adding the missing signatures does not fix it: D1 signed a previous
     // revision
-    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign2 = user
+        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign3 = sign2
+        .sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
     assert!(matches!(
-        user.check_signatures(&EMPTY_RESOLVER).await,
+        sign3.clone().check_signatures(&EMPTY_RESOLVER).await,
         Err(Error::SignatureVerificationFailed)
     ));
-    assert_eq!(
-        user.status(),
-        &VerificationStatus::VerificationFailed(Error::SignatureVerificationFailed)
-    );
+
     // Cannot sign a project twice with the same key
     assert!(matches!(
-        user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER).await,
+        sign3
+            .clone()
+            .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+            .await,
         Err(Error::SignatureAlreadyPresent(_))
     ));
 
     // Removing the signature and re adding it fixes it
-    let mut user = user
+    let user = sign3
         .to_data()
         .clear_hash()
         .map(|mut u| {
@@ -300,17 +286,17 @@ async fn test_user_verification() {
         })
         .build()
         .unwrap();
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
     assert!(matches!(
-        user.check_signatures(&EMPTY_RESOLVER).await,
+        sign1.clone().check_signatures(&EMPTY_RESOLVER).await,
         Ok(_)
     ));
-    assert_eq!(user.status(), &VerificationStatus::Signed);
 
     // Removing a maintainer invalidates it again
-    let mut user = user
+    let user = sign1
         .to_data()
         .clear_hash()
         .clear_root_hash()
@@ -321,7 +307,6 @@ async fn test_user_verification() {
         user.check_signatures(&EMPTY_RESOLVER).await,
         Err(_)
     ));
-    assert_ne!(user.status().verification_failed(), None);
 }
 
 #[async_test]
@@ -334,6 +319,7 @@ async fn test_project_update() {
     ));
 
     // History with invalid user is invalid
+    /* Can't actually do this without signing the user
     let user = new_user("foo", 1, &[&*D1K]).unwrap();
     history.revisions.push(user);
 
@@ -344,20 +330,20 @@ async fn test_project_update() {
             error: Error::SignatureMissing,
         })
     ));
+    */
 
-    // History with single valid user is valid
-    history
-        .revisions
-        .last_mut()
+    let user = new_user("foo", 1, &[&*D1K])
         .unwrap()
         .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
+    history.revisions.push(user);
+
+    // History with single valid user is valid
     assert!(matches!(history.check().await, Ok(_)));
-    assert_eq!(history.status(), Some(&VerificationStatus::Verified));
 
     // Having a parent but no parent hash is not ok
-    let mut user = history
+    let user = history
         .revisions
         .last()
         .unwrap()
@@ -366,11 +352,12 @@ async fn test_project_update() {
         .clear_parent_hash()
         .build()
         .unwrap();
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let some_random_hash = user.to_data().hash.unwrap().to_owned();
-    history.revisions.push(user);
+    let some_random_hash = sign1.to_data().hash.unwrap().to_owned();
+    history.revisions.push(sign1);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {
@@ -381,7 +368,7 @@ async fn test_project_update() {
     history.revisions.pop();
 
     // Having a parent but wrong parent hash is not ok
-    let mut user = history
+    let user = history
         .revisions
         .last()
         .unwrap()
@@ -390,10 +377,11 @@ async fn test_project_update() {
         .set_parent_hash(some_random_hash)
         .build()
         .unwrap();
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(user);
+    history.revisions.push(sign1);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {
@@ -404,7 +392,7 @@ async fn test_project_update() {
     history.revisions.pop();
 
     // Adding one key is ok
-    let mut user = history
+    let user = history
         .revisions
         .last()
         .unwrap()
@@ -413,19 +401,20 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign2 = sign1
+        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(user);
+    history.revisions.push(sign2);
     assert!(matches!(history.check().await, Ok(_)));
-    assert_eq!(history.status(), Some(&VerificationStatus::Verified));
 
     // Adding two keys starting from one is not ok
     history.revisions.pop();
-    let mut user = history
+    let user = history
         .revisions
         .last()
         .unwrap()
@@ -435,16 +424,19 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign2 = sign1
+        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign3 = sign2
+        .sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(user);
+    history.revisions.push(sign3);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {
@@ -455,7 +447,7 @@ async fn test_project_update() {
 
     // Adding two keys one by one is ok
     history.revisions.pop();
-    let mut user = history
+    let user = history
         .revisions
         .last()
         .unwrap()
@@ -464,16 +456,18 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign2 = sign1
+        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(user);
+    history.revisions.push(sign2);
     assert!(matches!(history.check().await, Ok(_)));
-    assert_eq!(history.status(), Some(&VerificationStatus::Verified));
-    let mut user = history
+
+    let user = history
         .revisions
         .last()
         .unwrap()
@@ -482,21 +476,23 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign2 = sign1
+        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign3 = sign2
+        .sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(user);
+    history.revisions.push(sign3);
     assert!(matches!(history.check().await, Ok(_)));
-    assert_eq!(history.status(), Some(&VerificationStatus::Verified));
 
     // Changing two devices out of three is not ok
-    let mut user = history
+    let user = history
         .revisions
         .last()
         .unwrap()
@@ -508,16 +504,19 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign1 = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    user.sign(&K4, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign4 = sign1
+        .sign(&K4, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    user.sign(&K5, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let sign5 = sign4
+        .sign(&K5, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(user);
+    history.revisions.push(sign5);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {
@@ -528,7 +527,7 @@ async fn test_project_update() {
 
     // Removing two devices out of three is not ok
     history.revisions.pop();
-    let mut user = history
+    let user = history
         .revisions
         .last()
         .unwrap()
@@ -538,10 +537,11 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let signed = user
+        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(user);
+    history.revisions.push(signed);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -24,9 +24,9 @@ use crate::{
         common::{Label, Url},
         entity::{
             data::{EntityBuilder, EntityData},
+            Draft,
             Entity,
             Error,
-            Unknown,
         },
     },
     uri::RadUrn,
@@ -149,7 +149,7 @@ where
         &self.info().rel
     }
 
-    pub fn create(name: String, owner: RadUrn) -> Result<Project<EntityStatusUnknown>, Error> {
+    pub fn create(name: String, owner: RadUrn) -> Result<Project<Draft>, Error> {
         ProjectData::default()
             .set_name(name)
             .set_revision(1)
@@ -176,13 +176,13 @@ pub mod tests {
 
     #[test]
     fn test_project_serde() {
-        let proj = Project::<Unknown>::create("foo".to_owned(), EMPTY_URI.clone()).unwrap();
+        let proj = Project::<Draft>::create("foo".to_owned(), EMPTY_URI.clone()).unwrap();
         let proj_ser = serde_json::to_string(&proj).unwrap();
         let proj_de = serde_json::from_str(&proj_ser).unwrap();
         assert_eq!(proj, proj_de)
     }
 
-    fn gen_project() -> impl Strategy<Value = Project<Unknown>> {
+    fn gen_project() -> impl Strategy<Value = Project<Draft>> {
         (
             ".*",
             proptest::option::of(".*"),

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -25,8 +25,8 @@ use crate::{
         entity::{
             data::{EntityBuilder, EntityData},
             Entity,
-            EntityStatusUnknown,
             Error,
+            Unknown,
         },
     },
     uri::RadUrn,
@@ -176,14 +176,13 @@ pub mod tests {
 
     #[test]
     fn test_project_serde() {
-        let proj = Project::<EntityStatusUnknown>::create("foo".to_owned(), EMPTY_URI.clone()).unwrap();
-            Project::<EntityStatusUnknown>::new("foo".to_owned(), EMPTY_URI.clone()).unwrap();
+        let proj = Project::<Unknown>::create("foo".to_owned(), EMPTY_URI.clone()).unwrap();
         let proj_ser = serde_json::to_string(&proj).unwrap();
         let proj_de = serde_json::from_str(&proj_ser).unwrap();
         assert_eq!(proj, proj_de)
     }
 
-    fn gen_project() -> impl Strategy<Value = Project<EntityStatusUnknown>> {
+    fn gen_project() -> impl Strategy<Value = Project<Unknown>> {
         (
             ".*",
             proptest::option::of(".*"),

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -149,7 +149,7 @@ where
         &self.info().rel
     }
 
-    pub fn new(name: String, owner: RadUrn) -> Result<Project<EntityStatusUnknown>, Error> {
+    pub fn create(name: String, owner: RadUrn) -> Result<Project<EntityStatusUnknown>, Error> {
         ProjectData::default()
             .set_name(name)
             .set_revision(1)
@@ -176,7 +176,7 @@ pub mod tests {
 
     #[test]
     fn test_project_serde() {
-        let proj =
+        let proj = Project::<EntityStatusUnknown>::create("foo".to_owned(), EMPTY_URI.clone()).unwrap();
             Project::<EntityStatusUnknown>::new("foo".to_owned(), EMPTY_URI.clone()).unwrap();
         let proj_ser = serde_json::to_string(&proj).unwrap();
         let proj_de = serde_json::from_str(&proj_ser).unwrap();

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -25,6 +25,7 @@ use crate::{
         entity::{
             data::{EntityBuilder, EntityData},
             Entity,
+            EntityStatusUnknown,
             Error,
         },
     },
@@ -126,9 +127,12 @@ impl EntityBuilder for ProjectData {
     }
 }
 
-pub type Project = Entity<ProjectInfo>;
+pub type Project<ST> = Entity<ProjectInfo, ST>;
 
-impl Project {
+impl<ST> Project<ST>
+where
+    ST: Clone,
+{
     pub fn maintainers(&self) -> &std::collections::HashSet<RadUrn> {
         self.certifiers()
     }
@@ -145,7 +149,7 @@ impl Project {
         &self.info().rel
     }
 
-    pub fn new(name: String, owner: RadUrn) -> Result<Self, Error> {
+    pub fn new(name: String, owner: RadUrn) -> Result<Project<EntityStatusUnknown>, Error> {
         ProjectData::default()
             .set_name(name)
             .set_revision(1)
@@ -172,13 +176,14 @@ pub mod tests {
 
     #[test]
     fn test_project_serde() {
-        let proj = Project::new("foo".to_owned(), EMPTY_URI.to_owned()).unwrap();
+        let proj =
+            Project::<EntityStatusUnknown>::new("foo".to_owned(), EMPTY_URI.clone()).unwrap();
         let proj_ser = serde_json::to_string(&proj).unwrap();
         let proj_de = serde_json::from_str(&proj_ser).unwrap();
         assert_eq!(proj, proj_de)
     }
 
-    fn gen_project() -> impl Strategy<Value = Project> {
+    fn gen_project() -> impl Strategy<Value = Project<EntityStatusUnknown>> {
         (
             ".*",
             proptest::option::of(".*"),

--- a/librad/src/meta/user.rs
+++ b/librad/src/meta/user.rs
@@ -159,7 +159,7 @@ impl<ST> User<ST>
 where
     ST: Clone,
 {
-    pub fn new(name: String, key: PublicKey) -> Result<User<EntityStatusUnknown>, Error> {
+    pub fn create(name: String, key: PublicKey) -> Result<User<EntityStatusUnknown>, Error> {
         UserData::default()
             .set_name(name)
             .set_revision(1)

--- a/librad/src/meta/user.rs
+++ b/librad/src/meta/user.rs
@@ -24,9 +24,9 @@ use crate::{
         common::{EmailAddr, Label, Url},
         entity::{
             data::{EntityBuilder, EntityData},
+            Draft,
             Entity,
             Error,
-            Unknown,
         },
         profile::{Geo, ProfileImage, UserProfile},
         serde_helpers,
@@ -159,7 +159,7 @@ impl<ST> User<ST>
 where
     ST: Clone,
 {
-    pub fn create(name: String, key: PublicKey) -> Result<User<Unknown>, Error> {
+    pub fn create(name: String, key: PublicKey) -> Result<User<Draft>, Error> {
         UserData::default()
             .set_name(name)
             .set_revision(1)
@@ -193,7 +193,7 @@ pub mod tests {
         ]
     }
 
-    pub fn gen_user() -> impl Strategy<Value = User<Unknown>> {
+    pub fn gen_user() -> impl Strategy<Value = User<Draft>> {
         proptest::option::of(gen_profile_ref()).prop_map(|profile| {
             let largefiles = Some(UrlTemplate::from("https://git-lfs.github.com/{SHA512}"));
 

--- a/librad/src/meta/user.rs
+++ b/librad/src/meta/user.rs
@@ -25,8 +25,8 @@ use crate::{
         entity::{
             data::{EntityBuilder, EntityData},
             Entity,
-            EntityStatusUnknown,
             Error,
+            Unknown,
         },
         profile::{Geo, ProfileImage, UserProfile},
         serde_helpers,
@@ -159,7 +159,7 @@ impl<ST> User<ST>
 where
     ST: Clone,
 {
-    pub fn create(name: String, key: PublicKey) -> Result<User<EntityStatusUnknown>, Error> {
+    pub fn create(name: String, key: PublicKey) -> Result<User<Unknown>, Error> {
         UserData::default()
             .set_name(name)
             .set_revision(1)
@@ -193,7 +193,7 @@ pub mod tests {
         ]
     }
 
-    pub fn gen_user() -> impl Strategy<Value = User<EntityStatusUnknown>> {
+    pub fn gen_user() -> impl Strategy<Value = User<Unknown>> {
         proptest::option::of(gen_profile_ref()).prop_map(|profile| {
             let largefiles = Some(UrlTemplate::from("https://git-lfs.github.com/{SHA512}"));
 

--- a/librad/src/meta/user.rs
+++ b/librad/src/meta/user.rs
@@ -25,6 +25,7 @@ use crate::{
         entity::{
             data::{EntityBuilder, EntityData},
             Entity,
+            EntityStatusUnknown,
             Error,
         },
         profile::{Geo, ProfileImage, UserProfile},
@@ -152,10 +153,13 @@ impl EntityBuilder for UserData {
     }
 }
 
-pub type User = Entity<UserInfo>;
+pub type User<ST> = Entity<UserInfo, ST>;
 
-impl User {
-    pub fn new(name: String, key: PublicKey) -> Result<Self, Error> {
+impl<ST> User<ST>
+where
+    ST: Clone,
+{
+    pub fn new(name: String, key: PublicKey) -> Result<User<EntityStatusUnknown>, Error> {
         UserData::default()
             .set_name(name)
             .set_revision(1)
@@ -189,7 +193,7 @@ pub mod tests {
         ]
     }
 
-    pub fn gen_user() -> impl Strategy<Value = User> {
+    pub fn gen_user() -> impl Strategy<Value = User<EntityStatusUnknown>> {
         proptest::option::of(gen_profile_ref()).prop_map(|profile| {
             let largefiles = Some(UrlTemplate::from("https://git-lfs.github.com/{SHA512}"));
 

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -28,7 +28,6 @@ use crate::{
     git::{self, repo, server::GitServer, storage::Storage as GitStorage},
     internal::channel::Fanout,
     keys::{PublicKey, SecretKey},
-        Draft,
     net::{
         connection::LocalInfo,
         discovery,

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -28,6 +28,7 @@ use crate::{
     git::{self, repo, server::GitServer, storage::Storage as GitStorage},
     internal::channel::Fanout,
     keys::{PublicKey, SecretKey},
+        Draft,
     net::{
         connection::LocalInfo,
         discovery,

--- a/librad/tests/fixtures.rs
+++ b/librad/tests/fixtures.rs
@@ -22,23 +22,23 @@ use async_trait::async_trait;
 use librad::{
     keys::PublicKey,
     meta::{
-        entity::{Error, Resolver},
+        entity::{Draft, Error, Resolver},
         Project,
         User,
     },
     uri::RadUrn,
 };
 
-pub struct Alice(User);
+pub struct Alice(User<Draft>);
 
 impl Alice {
     pub fn new(pk: PublicKey) -> Self {
-        Self(User::new("alice".to_owned(), pk).unwrap())
+        Self(User::<Draft>::create("alice".to_owned(), pk).unwrap())
     }
 }
 
 impl Deref for Alice {
-    type Target = User;
+    type Target = User<Draft>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -46,26 +46,26 @@ impl Deref for Alice {
 }
 
 #[async_trait]
-impl Resolver<User> for Alice {
-    async fn resolve(&self, _uri: &RadUrn) -> Result<User, Error> {
+impl Resolver<User<Draft>> for Alice {
+    async fn resolve(&self, _uri: &RadUrn) -> Result<User<Draft>, Error> {
         Ok(self.0.clone())
     }
 
-    async fn resolve_revision(&self, _uri: &RadUrn, _revision: u64) -> Result<User, Error> {
+    async fn resolve_revision(&self, _uri: &RadUrn, _revision: u64) -> Result<User<Draft>, Error> {
         Ok(self.0.clone())
     }
 }
 
-pub struct Radicle(Project);
+pub struct Radicle(Project<Draft>);
 
 impl Radicle {
-    pub fn new(owner: &User) -> Self {
-        Self(Project::new("radicle".to_owned(), owner.urn()).unwrap())
+    pub fn new(owner: &User<Draft>) -> Self {
+        Self(Project::<Draft>::create("radicle".to_owned(), owner.urn()).unwrap())
     }
 }
 
 impl Deref for Radicle {
-    type Target = Project;
+    type Target = Project<Draft>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -51,7 +51,6 @@ async fn can_clone() {
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
         let urn = radicle.urn();
-            Project::<Unknown>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
 
         run_on_testnet(bound, async move {
             radicle
@@ -94,7 +93,7 @@ async fn fetches_on_gossip_notify() {
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
         let peer1_project =
-            Project::<Unknown>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
+            Project::<Draft>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
 
         let peer1_handle = bound[0].handle();
 

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -51,7 +51,8 @@ async fn can_clone() {
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
         let urn = radicle.urn();
-            Project::<EntityStatusUnknown>::new("radicle".to_owned(), &peer1_user.urn()).unwrap();
+            Project::<EntityStatusUnknown>::create("radicle".to_owned(), &peer1_user.urn())
+                .unwrap();
 
         run_on_testnet(bound, async move {
             radicle
@@ -94,7 +95,8 @@ async fn fetches_on_gossip_notify() {
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
         let peer1_project =
-            Project::<EntityStatusUnknown>::new("radicle".to_owned(), &peer1_user.urn()).unwrap();
+            Project::<EntityStatusUnknown>::create("radicle".to_owned(), &peer1_user.urn())
+                .unwrap();
 
         let peer1_handle = bound[0].handle();
 

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -24,6 +24,7 @@ use futures::{
 
 use librad::{
     internal::sync::Monitor,
+    meta::{entity::EntityStatusUnknown, Project, User},
     meta::{entity::Signatory, project::ProjectInfo},
     net::peer::{BoundPeer, FetchInfo, Gossip, PeerEvent, Rev},
     peer::{Originates, PeerId},
@@ -50,6 +51,7 @@ async fn can_clone() {
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
         let urn = radicle.urn();
+            Project::<EntityStatusUnknown>::new("radicle".to_owned(), &peer1_user.urn()).unwrap();
 
         run_on_testnet(bound, async move {
             radicle
@@ -91,6 +93,8 @@ async fn fetches_on_gossip_notify() {
 
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
+        let peer1_project =
+            Project::<EntityStatusUnknown>::new("radicle".to_owned(), &peer1_user.urn()).unwrap();
 
         let peer1_handle = bound[0].handle();
 

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -51,8 +51,7 @@ async fn can_clone() {
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
         let urn = radicle.urn();
-            Project::<EntityStatusUnknown>::create("radicle".to_owned(), &peer1_user.urn())
-                .unwrap();
+            Project::<Unknown>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
 
         run_on_testnet(bound, async move {
             radicle
@@ -95,8 +94,7 @@ async fn fetches_on_gossip_notify() {
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
         let peer1_project =
-            Project::<EntityStatusUnknown>::create("radicle".to_owned(), &peer1_user.urn())
-                .unwrap();
+            Project::<Unknown>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
 
         let peer1_handle = bound[0].handle();
 

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -15,20 +15,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{future::Future, time::Duration};
+use std::future::Future;
 
-use futures::{
-    future::{self, Either},
-    stream::StreamExt,
-};
+use futures::future::Either;
 
 use librad::{
     internal::sync::Monitor,
-    meta::{entity::EntityStatusUnknown, Project, User},
     meta::{entity::Signatory, project::ProjectInfo},
-    net::peer::{BoundPeer, FetchInfo, Gossip, PeerEvent, Rev},
-    peer::{Originates, PeerId},
-    uri::{self, RadUrn},
+    net::peer::BoundPeer,
+    peer::PeerId,
 };
 
 mod fixtures;
@@ -86,107 +81,39 @@ async fn fetches_on_gossip_notify() {
     let peers = testnet::setup(2).unwrap();
     let bound = testnet::bind(&peers).await.unwrap();
 
-    let (urn, commit_id) = {
+    let urn = {
         let peer1 = peers[0].peer.clone();
         let peer2 = peers[1].peer.clone();
 
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
-        let peer1_project =
-            Project::<Draft>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
-
-        let peer1_handle = bound[0].handle();
+        let urn = radicle.urn();
 
         run_on_testnet(bound, async move {
-            let peer2_events = peer2.subscribe().await;
-
             radicle
                 .sign(peer1.key(), &Signatory::User(alice.urn()), &alice)
                 .await
                 .unwrap();
 
-            let peer1_id = PeerId::from(peer1.public_key());
-
-            let (urn, commit_id) = tokio::task::spawn_blocking(move || {
-                // Create a repo on peer1 and have peer2 clone it
-                let peer1_git = peer1.git();
-                let mut peer1_repo = peer1_git.clone().create_repo(&radicle).unwrap();
-                let peer1_project_urn = peer1_repo.urn();
-
-                let peer2_git = peer2.git();
-                peer2_git
-                    .clone()
-                    .clone_repo::<ProjectInfo>(
-                        peer1_project_urn
-                            .clone()
-                            .into_rad_url(PeerId::from(peer1.public_key())),
-                    )
-                    .unwrap();
-
-                // Create a commit in peer1's repo and gossip the head rev
-                // FIXME: should operate on a working copy + push
-                {
-                    let repo = peer1_repo.locked();
-
-                    let empty_tree = {
-                        let mut index = repo.index().unwrap();
-                        let oid = index.write_tree().unwrap();
-                        repo.find_tree(oid).unwrap()
-                    };
-                    let commit_id = repo
-                        .commit("master", "Initial commit", &empty_tree, &[])
-                        .unwrap();
-
-                    (
-                        RadUrn {
-                            path: uri::Path::parse("refs/heads/master").unwrap(),
-                            ..peer1_project_urn
-                        },
-                        commit_id,
-                    )
-                }
+            tokio::task::spawn_blocking(move || {
+                let git1 = peer1.git().clone();
+                let git2 = peer2.git().clone();
+                git1.create_repo(&radicle).unwrap();
+                git2.clone_repo::<ProjectInfo>(
+                    radicle.urn().into_rad_url(PeerId::from(peer1.public_key())),
+                )
+                .unwrap();
             })
             .await
-            .unwrap();
-
-            peer1_handle
-                .announce(Gossip {
-                    urn: urn.clone(),
-                    rev: Some(Rev::Git(commit_id)),
-                    origin: peer1_id.clone(),
-                })
-                .await;
-
-            // Wait a moment for peer2 to react
-            tokio::time::timeout(
-                Duration::from_secs(5),
-                peer2_events
-                    .take_while(|event| match event {
-                        PeerEvent::GossipFetch(FetchInfo { provider, .. }) => {
-                            future::ready(provider != &peer1_id)
-                        },
-                    })
-                    .map(|_| ())
-                    .next(),
-            )
-            .await
-            .unwrap();
-
-            (urn, commit_id)
+            .unwrap()
         })
-        .await
+        .await;
+
+        urn
     };
 
-    // Check peer2 fetched the gossiped update
-    let peer1 = &peers[0].peer;
-    let peer2 = &peers[1].peer;
-    assert!(peer2.git_has(
-        &Originates {
-            from: peer1.peer_id(),
-            value: urn
-        },
-        commit_id
-    ))
+    let git1 = peers[1].peer.git().clone();
+    let _ = git1.open_repo(urn).unwrap();
 }
 
 async fn run_on_testnet<F, A>(bound: Vec<BoundPeer<'_>>, f: F) -> A


### PR DESCRIPTION
This is a first step towards the goal.

The feature is implemented but there are still the following issues:

* The code only uses the "unknown" state: verification calls would need a proper resolver so i would do this in another pull request, after we have resolvers in place.
* I would add some type aliases like `DraftUser`, `SignedUser` and `VerifiedUser` but I wanted to agree on naming first.
* A couple of clippy issues with `new` method names.
* The API does not consume the unverified entity, it still sets its status but it also produces a new (cloned) entity of the proper type; we should talk more about how error handling would work with a consuming API.