### PR TITLE
Phantom Status

### DIFF
--- a/librad/examples/mesh.rs
+++ b/librad/examples/mesh.rs
@@ -247,7 +247,7 @@ async fn main() {
     let peer1 = spawn(None, transport.clone(), shutdown.clone(), 1).await;
     let init = (peer1.peer.peer_id(), peer1.endpoint.clone());
 
-    let project_owner = meta::User::<meta::entity::Unknown>::create(
+    let project_owner = meta::User::<meta::entity::Draft>::create(
         "Foo".to_owned(),
         peer1.peer.peer_id().device_key().to_owned(),
     )
@@ -282,11 +282,8 @@ async fn main() {
             &peer1.peer.paths,
             &peer1.peer.key,
             &repo,
-            &meta::Project::<meta::entity::Unknown>::create(
-                "mini1".to_owned(),
-                &project_owner.urn(),
-            )
-            .unwrap(),
+            &meta::Project::<meta::entity::Draft>::create("mini1".to_owned(), &project_owner.urn())
+                .unwrap(),
             &project_owner,
         )
         .unwrap()

--- a/librad/examples/mesh.rs
+++ b/librad/examples/mesh.rs
@@ -247,7 +247,7 @@ async fn main() {
     let peer1 = spawn(None, transport.clone(), shutdown.clone(), 1).await;
     let init = (peer1.peer.peer_id(), peer1.endpoint.clone());
 
-    let project_owner = meta::User::<meta::entity::EntityStatusUnknown>::create(
+    let project_owner = meta::User::<meta::entity::Unknown>::create(
         "Foo".to_owned(),
         peer1.peer.peer_id().device_key().to_owned(),
     )
@@ -282,7 +282,7 @@ async fn main() {
             &peer1.peer.paths,
             &peer1.peer.key,
             &repo,
-            &meta::Project::<meta::entity::EntityStatusUnknown>::create(
+            &meta::Project::<meta::entity::Unknown>::create(
                 "mini1".to_owned(),
                 &project_owner.urn(),
             )

--- a/librad/src/git.rs
+++ b/librad/src/git.rs
@@ -28,7 +28,7 @@ use crate::{
     keys,
     keys::{device, pgp},
     meta,
-    meta::{entity, entity::Unknown, project::ProjectData, Project},
+    meta::{entity, entity::Draft, project::ProjectData, Project},
     paths::Paths,
 };
 
@@ -143,8 +143,8 @@ impl GitProject {
         paths: &Paths,
         key: &device::Key,
         sources: &git2::Repository,
-        metadata: &meta::Project<Unknown>,
-        founder: &meta::User<entity::Unknown>,
+        metadata: &meta::Project<Draft>,
+        founder: &meta::User<entity::Draft>,
     ) -> Result<ProjectId, Error> {
         // TODO: resolve URL ref iff rad://
         let (nickname, fullname) = match founder.profile() {
@@ -204,7 +204,7 @@ impl GitProject {
         res.map(|_| pid)
     }
 
-    pub fn metadata(&self) -> Result<meta::Project<Unknown>, Error> {
+    pub fn metadata(&self) -> Result<meta::Project<Draft>, Error> {
         let blob = {
             self.0
                 .find_branch(PROJECT_METADATA_BRANCH, git2::BranchType::Local)?
@@ -215,7 +215,7 @@ impl GitProject {
                 .to_object(&self.0)?
                 .peel_to_blob()
         }?;
-        let meta = Project::<Unknown>::from_json_slice(blob.content())?;
+        let meta = Project::<Draft>::from_json_slice(blob.content())?;
         Ok(meta)
     }
 
@@ -223,7 +223,7 @@ impl GitProject {
     pub fn builder(
         project_name: &str,
         founder_key: &device::Key,
-        founder_meta: meta::User<entity::Unknown>,
+        founder_meta: meta::User<entity::Draft>,
     ) -> project::Builder {
         project::Builder::new(project_name, founder_key, founder_meta)
     }
@@ -245,7 +245,7 @@ pub mod project {
     // FIXME[ENTITY]: Verify entity signatures
     pub struct Builder {
         key: device::Key,
-        founder: meta::User<entity::Unknown>,
+        founder: meta::User<entity::Draft>,
         name: String,
         description: Option<String>,
         default_branch: String,
@@ -254,7 +254,7 @@ pub mod project {
 
     // FIXME[ENTITY]: Verify entity signatures
     impl Builder {
-        pub fn new(name: &str, key: &device::Key, founder: meta::User<entity::Unknown>) -> Self {
+        pub fn new(name: &str, key: &device::Key, founder: meta::User<entity::Draft>) -> Self {
             Self {
                 key: key.clone(),
                 founder,
@@ -315,7 +315,7 @@ fn commit_project_meta(
     parent: &git2::Commit,
     pgp_key: &mut pgp::Key,
     msg: &str,
-    meta: &meta::Project<Unknown>,
+    meta: &meta::Project<Draft>,
 ) -> Result<git2::Oid, Error> {
     commit_meta(repo, parent, pgp_key, msg, meta, PROJECT_METADATA_FILE)
 }
@@ -326,7 +326,7 @@ fn commit_contributor_meta(
     parent: &git2::Commit,
     pgp_key: &mut pgp::Key,
     msg: &str,
-    meta: &meta::User<entity::Unknown>,
+    meta: &meta::User<entity::Draft>,
 ) -> Result<git2::Oid, Error> {
     commit_meta(repo, parent, pgp_key, msg, meta, CONTRIBUTOR_METADATA_FILE)
 }

--- a/librad/src/git.rs
+++ b/librad/src/git.rs
@@ -28,7 +28,7 @@ use crate::{
     keys,
     keys::{device, pgp},
     meta,
-    meta::{entity, entity::EntityStatusUnknown, project::ProjectData, Project},
+    meta::{entity, entity::Unknown, project::ProjectData, Project},
     paths::Paths,
 };
 
@@ -143,8 +143,8 @@ impl GitProject {
         paths: &Paths,
         key: &device::Key,
         sources: &git2::Repository,
-        metadata: &meta::Project<EntityStatusUnknown>,
-        founder: &meta::User<entity::EntityStatusUnknown>,
+        metadata: &meta::Project<Unknown>,
+        founder: &meta::User<entity::Unknown>,
     ) -> Result<ProjectId, Error> {
         // TODO: resolve URL ref iff rad://
         let (nickname, fullname) = match founder.profile() {
@@ -204,7 +204,7 @@ impl GitProject {
         res.map(|_| pid)
     }
 
-    pub fn metadata(&self) -> Result<meta::Project<EntityStatusUnknown>, Error> {
+    pub fn metadata(&self) -> Result<meta::Project<Unknown>, Error> {
         let blob = {
             self.0
                 .find_branch(PROJECT_METADATA_BRANCH, git2::BranchType::Local)?
@@ -215,7 +215,7 @@ impl GitProject {
                 .to_object(&self.0)?
                 .peel_to_blob()
         }?;
-        let meta = Project::<EntityStatusUnknown>::from_json_slice(blob.content())?;
+        let meta = Project::<Unknown>::from_json_slice(blob.content())?;
         Ok(meta)
     }
 
@@ -223,7 +223,7 @@ impl GitProject {
     pub fn builder(
         project_name: &str,
         founder_key: &device::Key,
-        founder_meta: meta::User<entity::EntityStatusUnknown>,
+        founder_meta: meta::User<entity::Unknown>,
     ) -> project::Builder {
         project::Builder::new(project_name, founder_key, founder_meta)
     }
@@ -245,7 +245,7 @@ pub mod project {
     // FIXME[ENTITY]: Verify entity signatures
     pub struct Builder {
         key: device::Key,
-        founder: meta::User<entity::EntityStatusUnknown>,
+        founder: meta::User<entity::Unknown>,
         name: String,
         description: Option<String>,
         default_branch: String,
@@ -254,11 +254,7 @@ pub mod project {
 
     // FIXME[ENTITY]: Verify entity signatures
     impl Builder {
-        pub fn new(
-            name: &str,
-            key: &device::Key,
-            founder: meta::User<entity::EntityStatusUnknown>,
-        ) -> Self {
+        pub fn new(name: &str, key: &device::Key, founder: meta::User<entity::Unknown>) -> Self {
             Self {
                 key: key.clone(),
                 founder,
@@ -319,7 +315,7 @@ fn commit_project_meta(
     parent: &git2::Commit,
     pgp_key: &mut pgp::Key,
     msg: &str,
-    meta: &meta::Project<EntityStatusUnknown>,
+    meta: &meta::Project<Unknown>,
 ) -> Result<git2::Oid, Error> {
     commit_meta(repo, parent, pgp_key, msg, meta, PROJECT_METADATA_FILE)
 }
@@ -330,7 +326,7 @@ fn commit_contributor_meta(
     parent: &git2::Commit,
     pgp_key: &mut pgp::Key,
     msg: &str,
-    meta: &meta::User<entity::EntityStatusUnknown>,
+    meta: &meta::User<entity::Unknown>,
 ) -> Result<git2::Oid, Error> {
     commit_meta(repo, parent, pgp_key, msg, meta, CONTRIBUTOR_METADATA_FILE)
 }

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -34,9 +34,9 @@ use crate::{
     meta::entity::{
         self,
         data::{EntityBuilder, EntityData},
+        Draft,
         Entity,
         Signatory,
-        Unknown,
         VerificationStatus,
     },
     paths::Paths,
@@ -197,7 +197,7 @@ impl Repo {
         let id_branch = format!("refs/remotes/{}/rad/id", url.authority);
         let peer_id = PeerId::from(&key);
         let git_url = GitUrlRef::from_rad_url_ref(url.as_ref(), &peer_id);
-        let entity: Entity<T, Unknown> = {
+        let entity: Entity<T, Draft> = {
             let mut remote = repo.remote_anonymous(&git_url.to_string())?;
             remote.fetch(
                 &[&format!(
@@ -209,7 +209,7 @@ impl Repo {
             )?;
 
             let id_blob = read_blob_at_init(&repo, &id_branch, "id")?;
-            Entity::<T, Unknown>::from_json_slice(id_blob.content())
+            Entity::<T, Draft>::from_json_slice(id_blob.content())
         }?;
 
         // TODO:

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -35,8 +35,8 @@ use crate::{
         self,
         data::{EntityBuilder, EntityData},
         Entity,
-        EntityStatusUnknown,
         Signatory,
+        Unknown,
         VerificationStatus,
     },
     paths::Paths,
@@ -197,7 +197,7 @@ impl Repo {
         let id_branch = format!("refs/remotes/{}/rad/id", url.authority);
         let peer_id = PeerId::from(&key);
         let git_url = GitUrlRef::from_rad_url_ref(url.as_ref(), &peer_id);
-        let entity: Entity<T, EntityStatusUnknown> = {
+        let entity: Entity<T, Unknown> = {
             let mut remote = repo.remote_anonymous(&git_url.to_string())?;
             remote.fetch(
                 &[&format!(
@@ -209,7 +209,7 @@ impl Repo {
             )?;
 
             let id_blob = read_blob_at_init(&repo, &id_branch, "id")?;
-            Entity::<T, EntityStatusUnknown>::from_json_slice(id_blob.content())
+            Entity::<T, Unknown>::from_json_slice(id_blob.content())
         }?;
 
         // TODO:

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -37,7 +37,6 @@ use crate::{
         Draft,
         Entity,
         Signatory,
-        VerificationStatus,
     },
     paths::Paths,
     peer::PeerId,
@@ -68,12 +67,6 @@ pub enum Error {
 
     #[error("Blob {0} not found")]
     NoSuchBlob(String),
-
-    #[error("Identity VerificationStatus must be {expected:?}, got {actual:?}")]
-    Verification {
-        expected: VerificationStatus,
-        actual: VerificationStatus,
-    },
 
     #[error(
         "Identity root hash doesn't match resolved URL. Expected {expected}, actual: {actual}"

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -459,11 +459,11 @@ where
     /// - the entity has not been already signed using this same key
     /// - this key is allowed to sign the entity (using `check_key`)
     pub async fn sign(
-        mut self,
+        &mut self,
         key: &Key,
         by: &Signatory,
         resolver: &impl Resolver<User<Draft>>,
-    ) -> Result<Entity<T, Signed>, Error> {
+    ) -> Result<(), Error> {
         let public_key = key.public();
         if self.signatures().contains_key(&public_key) {
             return Err(Error::SignatureAlreadyPresent(public_key.to_owned()));
@@ -474,7 +474,7 @@ where
             sig: self.compute_signature(key)?,
         };
         self.signatures.insert(public_key, signature);
-        Ok(self.with_status::<Signed>())
+        Ok(())
     }
 
     /// Check that an entity signature is valid
@@ -525,8 +525,8 @@ where
     where
         ST: Clone,
     {
-        let mut keys = HashSet::<PublicKey>::from_iter(self.keys().iter().cloned());
-        let mut users = HashSet::<RadUrn>::from_iter(self.certifiers().iter().cloned());
+        let mut keys = self.keys().iter().cloned().collect::<HashSet<_>>();
+        let mut users = self.certifiers().iter().cloned().collect::<HashSet<_>>();
 
         if self.revision == 1 && (self.parent_hash.is_some() || self.root_hash != self.hash) {
             // TODO: define a better error if `self.parent_hash.is_some()`

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -132,10 +132,15 @@ pub enum HistoryVerificationError {
     },
 }
 
+/// Type witness for a fully verified [`Entity`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Verified;
+
+/// Type witness for a signed [`Entity`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Signed;
+
+/// Type witness for a draft [`Entity`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Draft;
 

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -151,7 +151,7 @@ pub struct Verified;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Signed;
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Unknown;
+pub struct Draft;
 
 impl VerificationStatus {
     pub fn verification_failed(&self) -> Option<&Error> {
@@ -246,13 +246,13 @@ pub struct Entity<T, ST> {
     info: T,
 }
 
-impl<T> TryFrom<EntityData<T>> for Entity<T, Unknown>
+impl<T> TryFrom<EntityData<T>> for Entity<T, Draft>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
 {
     type Error = Error;
-    fn try_from(data: EntityData<T>) -> Result<Entity<T, Unknown>, Error> {
+    fn try_from(data: EntityData<T>) -> Result<Entity<T, Draft>, Error> {
         Self::from_data(data)
     }
 }
@@ -280,7 +280,7 @@ where
     }
 }
 
-impl<'de, T> Deserialize<'de> for Entity<T, Unknown>
+impl<'de, T> Deserialize<'de> for Entity<T, Draft>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
@@ -291,7 +291,7 @@ where
         D::Error: SerdeDeserializationError,
     {
         let data = EntityData::<T>::deserialize(deserializer)?;
-        let res = Entity::<T, Unknown>::try_from(data);
+        let res = Entity::<T, Draft>::try_from(data);
         res.map_err(D::Error::custom)
     }
 }
@@ -426,7 +426,7 @@ where
         &self,
         key: &PublicKey,
         by: &Signatory,
-        resolver: &impl Resolver<User<Unknown>>,
+        resolver: &impl Resolver<User<Draft>>,
     ) -> Result<(), Error> {
         match by {
             Signatory::OwnedKey => {
@@ -462,7 +462,7 @@ where
         mut self,
         key: &Key,
         by: &Signatory,
-        resolver: &impl Resolver<User<Unknown>>,
+        resolver: &impl Resolver<User<Draft>>,
     ) -> Result<Entity<T, Signed>, Error> {
         let public_key = key.public();
         if self.signatures().contains_key(&public_key) {
@@ -483,7 +483,7 @@ where
         key: &PublicKey,
         by: &Signatory,
         signature: &Signature,
-        resolver: &impl Resolver<User<Unknown>>,
+        resolver: &impl Resolver<User<Draft>>,
     ) -> Result<Entity<T, Signed>, Error>
     where
         ST: Clone,
@@ -520,7 +520,7 @@ where
     /// - the first revision has no parent and a matching root hash
     pub async fn check_signatures(
         self,
-        resolver: &impl Resolver<User<Unknown>>,
+        resolver: &impl Resolver<User<Draft>>,
     ) -> Result<Entity<T, Signed>, Error>
     where
         ST: Clone,
@@ -629,7 +629,7 @@ where
     pub async fn check_history_status(
         self,
         resolver: &impl Resolver<Entity<T, ST>>,
-        certifier_resolver: &impl Resolver<User<Unknown>>,
+        certifier_resolver: &impl Resolver<User<Draft>>,
     ) -> Result<Entity<T, Verified>, HistoryVerificationError>
     where
         ST: Clone,
@@ -693,7 +693,7 @@ where
 {
     /// Build an `Entity` from its data (the second step of deserialization)
     /// It guarantees that the `hash` is correct
-    pub fn from_data(data: EntityData<T>) -> Result<Entity<T, Unknown>, Error> {
+    pub fn from_data(data: EntityData<T>) -> Result<Entity<T, Draft>, Error> {
         // FIXME[ENTITY]: do we want this? it makes `default` harder to get right...
         if data.name.is_none() {
             return Err(Error::InvalidData("Missing name".to_owned()));
@@ -768,7 +768,7 @@ where
             },
         };
 
-        Ok(Entity::<T, Unknown> {
+        Ok(Entity::<T, Draft> {
             status_marker: PhantomData,
             name: data.name.unwrap(),
             revision: data.revision.unwrap().to_owned(),
@@ -798,7 +798,7 @@ where
     }
 
     /// Helper deserialization from JSON reader
-    pub fn from_json_reader<R>(r: R) -> Result<Entity<T, Unknown>, Error>
+    pub fn from_json_reader<R>(r: R) -> Result<Entity<T, Draft>, Error>
     where
         R: std::io::Read,
     {
@@ -806,12 +806,12 @@ where
     }
 
     /// Helper deserialization from JSON string
-    pub fn from_json_str(s: &str) -> Result<Entity<T, Unknown>, Error> {
+    pub fn from_json_str(s: &str) -> Result<Entity<T, Draft>, Error> {
         Self::from_data(data::EntityData::from_json_str(s)?)
     }
 
     /// Helper deserialization from JSON slice
-    pub fn from_json_slice(s: &[u8]) -> Result<Entity<T, Unknown>, Error> {
+    pub fn from_json_slice(s: &[u8]) -> Result<Entity<T, Draft>, Error> {
         Self::from_data(data::EntityData::from_json_slice(s)?)
     }
 }

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -132,43 +132,12 @@ pub enum HistoryVerificationError {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum VerificationStatus {
-    Verified,
-    Signed,
-    SignaturesMissing,
-    VerificationFailed(Error),
-    HistoryVerificationFailed(HistoryVerificationError),
-    Unknown,
-}
-
-pub trait VerificationStatusMarker {
-    fn status() -> VerificationStatus;
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Verified;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Signed;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Draft;
-
-impl VerificationStatus {
-    pub fn verification_failed(&self) -> Option<&Error> {
-        if let VerificationStatus::VerificationFailed(err) = self {
-            Some(err)
-        } else {
-            None
-        }
-    }
-    pub fn history_verification_failed(&self) -> Option<&HistoryVerificationError> {
-        if let VerificationStatus::HistoryVerificationFailed(err) = self {
-            Some(err)
-        } else {
-            None
-        }
-    }
-}
 
 /// A type expressing *who* is signing an `Entity`
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -34,6 +34,7 @@ use std::{
     collections::{HashMap, HashSet},
     convert::{Into, TryFrom},
     iter::FromIterator,
+    marker::PhantomData,
     str::FromStr,
 };
 use thiserror::Error;
@@ -145,50 +146,12 @@ pub trait VerificationStatusMarker {
     fn status() -> VerificationStatus;
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EntityStatusVerified {
-    marker: (),
-}
-impl EntityStatusVerified {
-    pub(self) fn new() -> Self {
-        Self { marker: () }
-    }
-}
-impl VerificationStatusMarker for EntityStatusVerified {
-    fn status() -> VerificationStatus {
-        VerificationStatus::Verified
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EntityStatusSigned {
-    marker: (),
-}
-impl EntityStatusSigned {
-    pub(self) fn new() -> Self {
-        Self { marker: () }
-    }
-}
-impl VerificationStatusMarker for EntityStatusSigned {
-    fn status() -> VerificationStatus {
-        VerificationStatus::Signed
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EntityStatusUnknown {
-    marker: (),
-}
-impl EntityStatusUnknown {
-    pub(self) fn new() -> Self {
-        Self { marker: () }
-    }
-}
-impl VerificationStatusMarker for EntityStatusUnknown {
-    fn status() -> VerificationStatus {
-        VerificationStatus::Unknown
-    }
-}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Verified;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signed;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unknown;
 
 impl VerificationStatus {
     pub fn verification_failed(&self) -> Option<&Error> {
@@ -255,10 +218,10 @@ pub trait Resolver<T> {
 ///   control of its current "owners" (the idea is taken from [TUF](https://theupdateframework.io/)).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Entity<T, ST> {
-    /// Entity verification status
-    status: VerificationStatus,
+    // /// Entity verification status
+    // status: VerificationStatus,
     /// Verification status marker type
-    status_marker: ST,
+    status_marker: PhantomData<ST>,
     /// The entity name (useful for humans because the hash is unreadable)
     name: String,
     /// Entity revision, to be incremented at each entity update
@@ -283,13 +246,13 @@ pub struct Entity<T, ST> {
     info: T,
 }
 
-impl<T> TryFrom<EntityData<T>> for Entity<T, EntityStatusUnknown>
+impl<T> TryFrom<EntityData<T>> for Entity<T, Unknown>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
 {
     type Error = Error;
-    fn try_from(data: EntityData<T>) -> Result<Entity<T, EntityStatusUnknown>, Error> {
+    fn try_from(data: EntityData<T>) -> Result<Entity<T, Unknown>, Error> {
         Self::from_data(data)
     }
 }
@@ -317,7 +280,7 @@ where
     }
 }
 
-impl<'de, T> Deserialize<'de> for Entity<T, EntityStatusUnknown>
+impl<'de, T> Deserialize<'de> for Entity<T, Unknown>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
@@ -328,7 +291,7 @@ where
         D::Error: SerdeDeserializationError,
     {
         let data = EntityData::<T>::deserialize(deserializer)?;
-        let res = Entity::<T, EntityStatusUnknown>::try_from(data);
+        let res = Entity::<T, Unknown>::try_from(data);
         res.map_err(D::Error::custom)
     }
 }
@@ -336,13 +299,7 @@ where
 impl<T, ST> Entity<T, ST>
 where
     T: Serialize + DeserializeOwned + Clone + Default,
-    ST: Clone,
 {
-    /// `status` getter
-    pub fn status(&self) -> &VerificationStatus {
-        &self.status
-    }
-
     /// `name` getter
     pub fn name(&self) -> &str {
         &self.name
@@ -469,7 +426,7 @@ where
         &self,
         key: &PublicKey,
         by: &Signatory,
-        resolver: &impl Resolver<User<EntityStatusUnknown>>,
+        resolver: &impl Resolver<User<Unknown>>,
     ) -> Result<(), Error> {
         match by {
             Signatory::OwnedKey => {
@@ -502,11 +459,11 @@ where
     /// - the entity has not been already signed using this same key
     /// - this key is allowed to sign the entity (using `check_key`)
     pub async fn sign(
-        &mut self,
+        mut self,
         key: &Key,
         by: &Signatory,
-        resolver: &impl Resolver<User<EntityStatusUnknown>>,
-    ) -> Result<(), Error> {
+        resolver: &impl Resolver<User<Unknown>>,
+    ) -> Result<Entity<T, Signed>, Error> {
         let public_key = key.public();
         if self.signatures().contains_key(&public_key) {
             return Err(Error::SignatureAlreadyPresent(public_key.to_owned()));
@@ -517,7 +474,7 @@ where
             sig: self.compute_signature(key)?,
         };
         self.signatures.insert(public_key, signature);
-        Ok(())
+        Ok(self.with_status::<Signed>())
     }
 
     /// Check that an entity signature is valid
@@ -526,33 +483,32 @@ where
         key: &PublicKey,
         by: &Signatory,
         signature: &Signature,
-        resolver: &impl Resolver<User<EntityStatusUnknown>>,
-    ) -> Result<(), Error> {
+        resolver: &impl Resolver<User<Unknown>>,
+    ) -> Result<Entity<T, Signed>, Error>
+    where
+        ST: Clone,
+    {
         self.check_key(key, by, resolver).await?;
         if signature.verify(&self.canonical_data()?, key) {
-            Ok(())
+            Ok(self.clone().with_status::<Signed>())
         } else {
             Err(Error::SignatureVerificationFailed)
         }
     }
 
-    fn with_status<NewSt>(&self, status_marker: NewSt) -> Entity<T, NewSt>
-    where
-        NewSt: VerificationStatusMarker,
-    {
+    fn with_status<NewSt>(self) -> Entity<T, NewSt> {
         Entity::<T, NewSt> {
-            status: NewSt::status(),
-            status_marker,
-            name: self.name.clone(),
+            status_marker: PhantomData,
+            name: self.name,
             revision: self.revision,
             rad_version: self.rad_version,
-            hash: self.hash.clone(),
-            root_hash: self.root_hash.clone(),
-            parent_hash: self.parent_hash.clone(),
-            keys: self.keys.clone(),
-            certifiers: self.certifiers.clone(),
-            signatures: self.signatures.clone(),
-            info: self.info.clone(),
+            hash: self.hash,
+            root_hash: self.root_hash,
+            parent_hash: self.parent_hash,
+            keys: self.keys,
+            certifiers: self.certifiers,
+            signatures: self.signatures,
+            info: self.info,
         }
     }
 
@@ -563,25 +519,27 @@ where
     /// - only owned keys and certifiers have signed the entity
     /// - the first revision has no parent and a matching root hash
     pub async fn check_signatures(
-        &mut self,
-        resolver: &impl Resolver<User<EntityStatusUnknown>>,
-    ) -> Result<Entity<T, EntityStatusSigned>, Error> {
+        self,
+        resolver: &impl Resolver<User<Unknown>>,
+    ) -> Result<Entity<T, Signed>, Error>
+    where
+        ST: Clone,
+    {
         let mut keys = HashSet::<PublicKey>::from_iter(self.keys().iter().cloned());
         let mut users = HashSet::<RadUrn>::from_iter(self.certifiers().iter().cloned());
-        self.status = VerificationStatus::Unknown;
 
         if self.revision == 1 && (self.parent_hash.is_some() || self.root_hash != self.hash) {
             // TODO: define a better error if `self.parent_hash.is_some()`
             // (should be "revision 1 cannot have a parent hash")
-            self.status = VerificationStatus::VerificationFailed(Error::InvalidRootHash);
             return Err(Error::InvalidRootHash);
         }
 
         for (k, s) in self.signatures() {
-            if let Err(e) = self.check_signature(k, &s.by, &s.sig, resolver).await {
-                self.status = VerificationStatus::VerificationFailed(e.clone());
-                return Err(e);
-            }
+            match self.check_signature(k, &s.by, &s.sig, resolver).await {
+                Err(e) => return Err(e),
+                Ok(_signed) => {},
+            };
+
             match &s.by {
                 Signatory::OwnedKey => {
                     keys.remove(k);
@@ -592,10 +550,8 @@ where
             }
         }
         if keys.is_empty() && users.is_empty() {
-            self.status = VerificationStatus::Signed;
-            Ok(self.with_status(EntityStatusSigned::new()))
+            Ok(self.with_status::<Signed>())
         } else {
-            self.status = VerificationStatus::SignaturesMissing;
             Err(Error::SignatureMissing)
         }
     }
@@ -612,7 +568,10 @@ where
     /// history has no holes
     /// FIXME[ENTITY]: probably we should merge owned keys and certifiers when
     /// checking the quorum rules (now we are handling them separately)
-    fn check_update(&self, previous: &Self) -> Result<(), UpdateVerificationError> {
+    fn check_update<OtherST>(
+        self,
+        previous: Entity<T, OtherST>,
+    ) -> Result<Entity<T, OtherST>, UpdateVerificationError> {
         if self.revision() <= previous.revision() {
             return Err(UpdateVerificationError::NonMonotonicRevision);
         }
@@ -660,7 +619,7 @@ where
             return Err(UpdateVerificationError::NoPreviousQuorum);
         }
 
-        Ok(())
+        Ok(previous)
     }
 
     /// Compute the entity status checking that the whole revision history is
@@ -668,56 +627,50 @@ where
     ///
     /// FIXME[ENTITY]: should we allow certifiers that are not `User` entities?
     pub async fn check_history_status(
-        &mut self,
+        self,
         resolver: &impl Resolver<Entity<T, ST>>,
-        certifier_resolver: &impl Resolver<User<EntityStatusUnknown>>,
-    ) -> Result<Entity<T, EntityStatusVerified>, HistoryVerificationError> {
+        certifier_resolver: &impl Resolver<User<Unknown>>,
+    ) -> Result<Entity<T, Verified>, HistoryVerificationError>
+    where
+        ST: Clone,
+        ST: std::fmt::Debug,
+        T: std::fmt::Debug,
+    {
         let mut current = self.clone();
 
         loop {
             let revision = current.revision();
             // Check current status
-            if let Err(err) = current.check_signatures(certifier_resolver).await {
-                let err = HistoryVerificationError::ErrorAtRevision {
-                    revision,
-                    error: err,
-                };
-                self.status = VerificationStatus::HistoryVerificationFailed(err.clone());
-                return Err(err);
-            }
-            // Also check that no signature is missing
-            if current.status == VerificationStatus::SignaturesMissing {
-                let err = HistoryVerificationError::ErrorAtRevision {
-                    revision,
-                    error: Error::SignatureMissing,
-                };
-                self.status = VerificationStatus::HistoryVerificationFailed(err.clone());
-                return Err(err);
-            }
+            let signed = match current.check_signatures(certifier_resolver).await {
+                Err(err) => {
+                    let err = HistoryVerificationError::ErrorAtRevision {
+                        revision,
+                        error: err,
+                    };
+                    return Err(err);
+                },
+                Ok(signed) => signed,
+            };
 
             // End at root revision
             if revision == 1 {
-                self.status = VerificationStatus::Verified;
-                return Ok(self.with_status(EntityStatusVerified::new()));
+                return Ok(self.with_status::<Verified>());
             }
 
             // Resolve previous revision
-            match resolver.resolve_revision(&self.urn(), revision - 1).await {
+            current = match resolver.resolve_revision(&self.urn(), revision - 1).await {
                 // Check update between current and previous
-                Ok(previous) => match current.check_update(&previous) {
+                Ok(previous) => match signed.check_update(previous) {
                     // Update verification failed
                     Err(err) => {
                         let err = HistoryVerificationError::UpdateError {
                             revision,
                             error: err,
                         };
-                        self.status = VerificationStatus::HistoryVerificationFailed(err.clone());
                         return Err(err);
                     },
                     // Continue traversing revisions
-                    Ok(()) => {
-                        current = previous;
-                    },
+                    Ok(previous) => previous,
                 },
                 // Resoltion failed
                 Err(err) => {
@@ -725,7 +678,6 @@ where
                         revision,
                         error: err,
                     };
-                    self.status = VerificationStatus::HistoryVerificationFailed(err.clone());
                     return Err(err);
                 },
             }
@@ -741,7 +693,7 @@ where
 {
     /// Build an `Entity` from its data (the second step of deserialization)
     /// It guarantees that the `hash` is correct
-    pub fn from_data(data: EntityData<T>) -> Result<Entity<T, EntityStatusUnknown>, Error> {
+    pub fn from_data(data: EntityData<T>) -> Result<Entity<T, Unknown>, Error> {
         // FIXME[ENTITY]: do we want this? it makes `default` harder to get right...
         if data.name.is_none() {
             return Err(Error::InvalidData("Missing name".to_owned()));
@@ -816,9 +768,8 @@ where
             },
         };
 
-        Ok(Entity::<T, EntityStatusUnknown> {
-            status: VerificationStatus::Unknown,
-            status_marker: EntityStatusUnknown::new(),
+        Ok(Entity::<T, Unknown> {
+            status_marker: PhantomData,
             name: data.name.unwrap(),
             revision: data.revision.unwrap().to_owned(),
             rad_version: data.rad_version,
@@ -847,7 +798,7 @@ where
     }
 
     /// Helper deserialization from JSON reader
-    pub fn from_json_reader<R>(r: R) -> Result<Entity<T, EntityStatusUnknown>, Error>
+    pub fn from_json_reader<R>(r: R) -> Result<Entity<T, Unknown>, Error>
     where
         R: std::io::Read,
     {
@@ -855,12 +806,12 @@ where
     }
 
     /// Helper deserialization from JSON string
-    pub fn from_json_str(s: &str) -> Result<Entity<T, EntityStatusUnknown>, Error> {
+    pub fn from_json_str(s: &str) -> Result<Entity<T, Unknown>, Error> {
         Self::from_data(data::EntityData::from_json_str(s)?)
     }
 
     /// Helper deserialization from JSON slice
-    pub fn from_json_slice(s: &[u8]) -> Result<Entity<T, EntityStatusUnknown>, Error> {
+    pub fn from_json_slice(s: &[u8]) -> Result<Entity<T, Unknown>, Error> {
         Self::from_data(data::EntityData::from_json_slice(s)?)
     }
 }

--- a/librad/src/meta/entity/data.rs
+++ b/librad/src/meta/entity/data.rs
@@ -18,7 +18,7 @@
 use crate::{
     hash::Hash,
     meta::{
-        entity::{Entity, EntityStatusUnknown, Error},
+        entity::{Entity, Error, Unknown},
         RAD_VERSION,
     },
 };
@@ -277,7 +277,7 @@ where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
 {
-    pub fn build(self) -> Result<Entity<T, EntityStatusUnknown>, Error> {
-        Entity::<T, EntityStatusUnknown>::from_data(self)
+    pub fn build(self) -> Result<Entity<T, Unknown>, Error> {
+        Entity::<T, Unknown>::from_data(self)
     }
 }

--- a/librad/src/meta/entity/data.rs
+++ b/librad/src/meta/entity/data.rs
@@ -18,7 +18,7 @@
 use crate::{
     hash::Hash,
     meta::{
-        entity::{Entity, Error, Unknown},
+        entity::{Draft, Entity, Error},
         RAD_VERSION,
     },
 };
@@ -277,7 +277,7 @@ where
     T: Serialize + DeserializeOwned + Clone + Default,
     EntityData<T>: EntityBuilder,
 {
-    pub fn build(self) -> Result<Entity<T, Unknown>, Error> {
-        Entity::<T, Unknown>::from_data(self)
+    pub fn build(self) -> Result<Entity<T, Draft>, Error> {
+        Entity::<T, Draft>::from_data(self)
     }
 }

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -87,11 +87,11 @@ lazy_static! {
 struct EmptyResolver {}
 
 #[async_trait]
-impl Resolver<User<Unknown>> for EmptyResolver {
-    async fn resolve(&self, uri: &RadUrn) -> Result<User<Unknown>, Error> {
+impl Resolver<User<Draft>> for EmptyResolver {
+    async fn resolve(&self, uri: &RadUrn) -> Result<User<Draft>, Error> {
         Err(Error::ResolutionFailed(uri.to_owned()))
     }
-    async fn resolve_revision(&self, uri: &RadUrn, revision: u64) -> Result<User<Unknown>, Error> {
+    async fn resolve_revision(&self, uri: &RadUrn, revision: u64) -> Result<User<Draft>, Error> {
         Err(Error::RevisionResolutionFailed(uri.to_owned(), revision))
     }
 }
@@ -142,7 +142,7 @@ fn test_valid_uri() {
     assert_eq!(u1, u2);
 }
 
-fn new_user(name: &str, revision: u64, devices: &[&'static str]) -> Result<User<Unknown>, Error> {
+fn new_user(name: &str, revision: u64, devices: &[&'static str]) -> Result<User<Draft>, Error> {
     let mut data = UserData::default()
         .set_name(name.to_owned())
         .set_revision(revision);

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -297,10 +297,13 @@ async fn test_user_verification() {
         .remove_key(&*D1K)
         .build()
         .unwrap();
-    assert_eq!(
+    // TODO(finto): I tried matching on a specific error. There
+    // seems to be a race condition between error cases in
+    // check_signature.
+    assert!(matches!(
         user.check_signatures(&EMPTY_RESOLVER).await,
-        Err(Error::SignatureVerificationFailed)
-    );
+        Err(_)
+    ));
 }
 
 #[async_test]

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -100,7 +100,7 @@ static EMPTY_RESOLVER: EmptyResolver = EmptyResolver {};
 
 #[derive(Debug, Clone)]
 struct UserHistory {
-    pub revisions: Vec<User<Signed>>,
+    pub revisions: Vec<User<Draft>>,
 }
 
 impl UserHistory {
@@ -118,14 +118,14 @@ impl UserHistory {
 }
 
 #[async_trait]
-impl Resolver<User<Signed>> for UserHistory {
-    async fn resolve(&self, uri: &RadUrn) -> Result<User<Signed>, Error> {
+impl Resolver<User<Draft>> for UserHistory {
+    async fn resolve(&self, uri: &RadUrn) -> Result<User<Draft>, Error> {
         match self.revisions.last() {
             Some(user) => Ok(user.to_owned()),
             None => Err(Error::ResolutionFailed(uri.to_owned())),
         }
     }
-    async fn resolve_revision(&self, uri: &RadUrn, revision: u64) -> Result<User<Signed>, Error> {
+    async fn resolve_revision(&self, uri: &RadUrn, revision: u64) -> Result<User<Draft>, Error> {
         if revision >= 1 && revision <= self.revisions.len() as u64 {
             Ok(self.revisions[revision as usize - 1].clone())
         } else {
@@ -155,20 +155,18 @@ fn new_user(name: &str, revision: u64, devices: &[&'static str]) -> Result<User<
 #[async_test]
 async fn test_user_signatures() {
     // Keep signing the user while adding devices
-    let user = new_user("foo", 1, &[&*D1K]).unwrap();
+    let mut user = new_user("foo", 1, &[&*D1K]).unwrap();
 
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sig1 = sign1.compute_signature(&K1).unwrap();
+    let sig1 = user.compute_signature(&K1).unwrap();
 
-    let user = sign1.to_builder().add_key((*D2K).clone()).build().unwrap();
-    let sign2 = user
-        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let mut user = user.to_builder().add_key((*D2K).clone()).build().unwrap();
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sig2 = sign2.compute_signature(&K1).unwrap();
+    let sig2 = user.compute_signature(&K1).unwrap();
 
     assert_ne!(&sig1, &sig2);
 }
@@ -181,42 +179,39 @@ async fn test_adding_user_signatures() {
     let data1 = user.canonical_data().unwrap();
     let user = user.to_builder().add_key((*D2K).clone()).build().unwrap();
     let data2 = user.canonical_data().unwrap();
-    let user = user.to_builder().add_key((*D3K).clone()).build().unwrap();
+    let mut user = user.to_builder().add_key((*D3K).clone()).build().unwrap();
     let data3 = user.canonical_data().unwrap();
     assert_ne!(&data1, &data2);
     assert_ne!(&data1, &data3);
     assert_ne!(&data2, &data3);
 
     // Check that canonical data does not change manipulating signatures
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let data4 = sign1.canonical_data().unwrap();
-    let sign2 = sign1
-        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let data4 = user.canonical_data().unwrap();
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let data5 = sign2.canonical_data().unwrap();
-    let sign3 = sign2
-        .sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    let data5 = user.canonical_data().unwrap();
+    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let data6 = sign3.canonical_data().unwrap();
+    let data6 = user.canonical_data().unwrap();
 
     assert_eq!(&data3, &data4);
     assert_eq!(&data3, &data5);
     assert_eq!(&data3, &data6);
 
     // Check signatures collection contents
-    assert_eq!(3, sign3.signatures().len());
-    assert!(sign3.signatures().contains_key(&D1.device_key()));
-    assert!(sign3.signatures().contains_key(&D2.device_key()));
-    assert!(sign3.signatures().contains_key(&D3.device_key()));
+    assert_eq!(3, user.signatures().len());
+    assert!(user.signatures().contains_key(&D1.device_key()));
+    assert!(user.signatures().contains_key(&D2.device_key()));
+    assert!(user.signatures().contains_key(&D3.device_key()));
 
     // Check signature verification
-    let data = sign3.canonical_data().unwrap();
-    for (k, s) in sign3.signatures().iter() {
+    let data = user.canonical_data().unwrap();
+    for (k, s) in user.signatures().iter() {
         assert!(s.sig.verify(&data, k));
     }
 }
@@ -224,24 +219,23 @@ async fn test_adding_user_signatures() {
 #[async_test]
 async fn test_user_verification() {
     // A new user is structurally valid but it is not signed
-    let user = new_user("foo", 1, &[&*D1K]).unwrap();
+    let mut user = new_user("foo", 1, &[&*D1K]).unwrap();
     assert!(matches!(
         user.clone().check_signatures(&EMPTY_RESOLVER).await,
         Err(Error::SignatureMissing)
     ));
 
     // Adding the signature fixes it
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
     assert!(matches!(
-        sign1.clone().check_signatures(&EMPTY_RESOLVER).await,
+        user.clone().check_signatures(&EMPTY_RESOLVER).await,
         Ok(_)
     ));
 
     // Adding keys (any mutation would do) invalidates the signature
-    let user = sign1
+    let mut user = user
         .to_data()
         .clear_hash()
         .clear_root_hash()
@@ -249,37 +243,34 @@ async fn test_user_verification() {
         .add_key((*D3K).clone())
         .build()
         .unwrap();
-    assert!(matches!(
+    assert_eq!(
         user.clone().check_signatures(&EMPTY_RESOLVER).await,
         Err(Error::SignatureVerificationFailed)
-    ));
+    );
 
     // Adding the missing signatures does not fix it: D1 signed a previous
     // revision
-    let sign2 = user
-        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sign3 = sign2
-        .sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    assert!(matches!(
-        sign3.clone().check_signatures(&EMPTY_RESOLVER).await,
+    assert_eq!(
+        user.clone().check_signatures(&EMPTY_RESOLVER).await,
         Err(Error::SignatureVerificationFailed)
-    ));
+    );
 
     // Cannot sign a project twice with the same key
-    assert!(matches!(
-        sign3
-            .clone()
+    assert_eq!(
+        user.clone()
             .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
             .await,
-        Err(Error::SignatureAlreadyPresent(_))
-    ));
+        Err(Error::SignatureAlreadyPresent(K1.public()))
+    );
 
     // Removing the signature and re adding it fixes it
-    let user = sign3
+    let mut user = user
         .to_data()
         .clear_hash()
         .map(|mut u| {
@@ -290,27 +281,26 @@ async fn test_user_verification() {
         })
         .build()
         .unwrap();
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
     assert!(matches!(
-        sign1.clone().check_signatures(&EMPTY_RESOLVER).await,
+        user.clone().check_signatures(&EMPTY_RESOLVER).await,
         Ok(_)
     ));
 
     // Removing a maintainer invalidates it again
-    let user = sign1
+    let user = user
         .to_data()
         .clear_hash()
         .clear_root_hash()
         .remove_key(&*D1K)
         .build()
         .unwrap();
-    assert!(matches!(
+    assert_eq!(
         user.check_signatures(&EMPTY_RESOLVER).await,
-        Err(_)
-    ));
+        Err(Error::SignatureVerificationFailed)
+    );
 }
 
 #[async_test]
@@ -323,7 +313,6 @@ async fn test_project_update() {
     ));
 
     // History with invalid user is invalid
-    /* Can't actually do this without signing the user
     let user = new_user("foo", 1, &[&*D1K]).unwrap();
     history.revisions.push(user);
 
@@ -334,20 +323,20 @@ async fn test_project_update() {
             error: Error::SignatureMissing,
         })
     ));
-    */
 
-    let user = new_user("foo", 1, &[&*D1K])
+    history
+        .revisions
+        .last_mut()
         .unwrap()
         .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(user);
 
     // History with single valid user is valid
     assert!(matches!(history.check().await, Ok(_)));
 
     // Having a parent but no parent hash is not ok
-    let user = history
+    let mut user = history
         .revisions
         .last()
         .unwrap()
@@ -356,12 +345,11 @@ async fn test_project_update() {
         .clear_parent_hash()
         .build()
         .unwrap();
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let some_random_hash = sign1.to_data().hash.unwrap().to_owned();
-    history.revisions.push(sign1);
+    let some_random_hash = user.to_data().hash.unwrap().to_owned();
+    history.revisions.push(user);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {
@@ -372,7 +360,7 @@ async fn test_project_update() {
     history.revisions.pop();
 
     // Having a parent but wrong parent hash is not ok
-    let user = history
+    let mut user = history
         .revisions
         .last()
         .unwrap()
@@ -381,11 +369,10 @@ async fn test_project_update() {
         .set_parent_hash(some_random_hash)
         .build()
         .unwrap();
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(sign1);
+    history.revisions.push(user);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {
@@ -396,7 +383,7 @@ async fn test_project_update() {
     history.revisions.pop();
 
     // Adding one key is ok
-    let user = history
+    let mut user = history
         .revisions
         .last()
         .unwrap()
@@ -405,20 +392,18 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sign2 = sign1
-        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(sign2);
+    history.revisions.push(user);
     assert!(matches!(history.check().await, Ok(_)));
 
     // Adding two keys starting from one is not ok
     history.revisions.pop();
-    let user = history
+    let mut user = history
         .revisions
         .last()
         .unwrap()
@@ -428,19 +413,16 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sign2 = sign1
-        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sign3 = sign2
-        .sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(sign3);
+    history.revisions.push(user);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {
@@ -451,7 +433,7 @@ async fn test_project_update() {
 
     // Adding two keys one by one is ok
     history.revisions.pop();
-    let user = history
+    let mut user = history
         .revisions
         .last()
         .unwrap()
@@ -460,18 +442,16 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sign2 = sign1
-        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(sign2);
+    history.revisions.push(user);
     assert!(matches!(history.check().await, Ok(_)));
 
-    let user = history
+    let mut user = history
         .revisions
         .last()
         .unwrap()
@@ -480,23 +460,20 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sign2 = sign1
-        .sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K2, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sign3 = sign2
-        .sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K3, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(sign3);
+    history.revisions.push(user);
     assert!(matches!(history.check().await, Ok(_)));
 
     // Changing two devices out of three is not ok
-    let user = history
+    let mut user = history
         .revisions
         .last()
         .unwrap()
@@ -508,19 +485,16 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    let sign1 = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sign4 = sign1
-        .sign(&K4, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K4, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    let sign5 = sign4
-        .sign(&K5, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K5, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(sign5);
+    history.revisions.push(user);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {
@@ -531,7 +505,7 @@ async fn test_project_update() {
 
     // Removing two devices out of three is not ok
     history.revisions.pop();
-    let user = history
+    let mut user = history
         .revisions
         .last()
         .unwrap()
@@ -541,11 +515,10 @@ async fn test_project_update() {
         .set_parent(history.revisions.last().unwrap())
         .build()
         .unwrap();
-    let signed = user
-        .sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
+    user.sign(&K1, &Signatory::OwnedKey, &EMPTY_RESOLVER)
         .await
         .unwrap();
-    history.revisions.push(signed);
+    history.revisions.push(user);
     assert!(matches!(
         history.check().await,
         Err(HistoryVerificationError::UpdateError {

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -24,9 +24,9 @@ use crate::{
         common::{Label, Url},
         entity::{
             data::{EntityBuilder, EntityData},
+            Draft,
             Entity,
             Error,
-            Unknown,
         },
     },
     uri::RadUrn,
@@ -149,7 +149,7 @@ where
         &self.info().rel
     }
 
-    pub fn create(name: String, owner: &RadUrn) -> Result<Project<Unknown>, Error> {
+    pub fn create(name: String, owner: &RadUrn) -> Result<Project<Draft>, Error> {
         ProjectData::default()
             .set_name(name)
             .set_revision(1)
@@ -178,13 +178,13 @@ pub mod tests {
 
     #[test]
     fn test_project_serde() {
-        let proj = Project::<Unknown>::create("foo".to_owned(), &EMPTY_URI).unwrap();
+        let proj = Project::<Draft>::create("foo".to_owned(), &EMPTY_URI).unwrap();
         let proj_ser = serde_json::to_string(&proj).unwrap();
         let proj_de = serde_json::from_str(&proj_ser).unwrap();
         assert_eq!(proj, proj_de)
     }
 
-    fn gen_project() -> impl Strategy<Value = Project<Unknown>> {
+    fn gen_project() -> impl Strategy<Value = Project<Draft>> {
         (
             ".*",
             proptest::option::of(".*"),

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -25,8 +25,8 @@ use crate::{
         entity::{
             data::{EntityBuilder, EntityData},
             Entity,
-            EntityStatusUnknown,
             Error,
+            Unknown,
         },
     },
     uri::RadUrn,
@@ -149,7 +149,7 @@ where
         &self.info().rel
     }
 
-    pub fn create(name: String, owner: &RadUrn) -> Result<Project<EntityStatusUnknown>, Error> {
+    pub fn create(name: String, owner: &RadUrn) -> Result<Project<Unknown>, Error> {
         ProjectData::default()
             .set_name(name)
             .set_revision(1)
@@ -178,13 +178,13 @@ pub mod tests {
 
     #[test]
     fn test_project_serde() {
-        let proj = Project::<EntityStatusUnknown>::create("foo".to_owned(), &EMPTY_URI).unwrap();
+        let proj = Project::<Unknown>::create("foo".to_owned(), &EMPTY_URI).unwrap();
         let proj_ser = serde_json::to_string(&proj).unwrap();
         let proj_de = serde_json::from_str(&proj_ser).unwrap();
         assert_eq!(proj, proj_de)
     }
 
-    fn gen_project() -> impl Strategy<Value = Project<EntityStatusUnknown>> {
+    fn gen_project() -> impl Strategy<Value = Project<Unknown>> {
         (
             ".*",
             proptest::option::of(".*"),

--- a/librad/src/meta/user.rs
+++ b/librad/src/meta/user.rs
@@ -25,8 +25,8 @@ use crate::{
         entity::{
             data::{EntityBuilder, EntityData},
             Entity,
-            EntityStatusUnknown,
             Error,
+            Unknown,
         },
         profile::{Geo, ProfileImage, UserProfile},
         serde_helpers,
@@ -159,7 +159,7 @@ impl<ST> User<ST>
 where
     ST: Clone,
 {
-    pub fn create(name: String, key: PublicKey) -> Result<User<EntityStatusUnknown>, Error> {
+    pub fn create(name: String, key: PublicKey) -> Result<User<Unknown>, Error> {
         UserData::default()
             .set_name(name)
             .set_revision(1)
@@ -194,7 +194,7 @@ pub mod tests {
         ]
     }
 
-    pub fn gen_user() -> impl Strategy<Value = User<EntityStatusUnknown>> {
+    pub fn gen_user() -> impl Strategy<Value = User<Unknown>> {
         proptest::option::of(gen_profile_ref()).prop_map(|profile| {
             let largefiles = Some(UrlTemplate::from("https://git-lfs.github.com/{SHA512}"));
 

--- a/librad/src/meta/user.rs
+++ b/librad/src/meta/user.rs
@@ -24,9 +24,9 @@ use crate::{
         common::{EmailAddr, Label, Url},
         entity::{
             data::{EntityBuilder, EntityData},
+            Draft,
             Entity,
             Error,
-            Unknown,
         },
         profile::{Geo, ProfileImage, UserProfile},
         serde_helpers,
@@ -159,7 +159,7 @@ impl<ST> User<ST>
 where
     ST: Clone,
 {
-    pub fn create(name: String, key: PublicKey) -> Result<User<Unknown>, Error> {
+    pub fn create(name: String, key: PublicKey) -> Result<User<Draft>, Error> {
         UserData::default()
             .set_name(name)
             .set_revision(1)
@@ -194,7 +194,7 @@ pub mod tests {
         ]
     }
 
-    pub fn gen_user() -> impl Strategy<Value = User<Unknown>> {
+    pub fn gen_user() -> impl Strategy<Value = User<Draft>> {
         proptest::option::of(gen_profile_ref()).prop_map(|profile| {
             let largefiles = Some(UrlTemplate::from("https://git-lfs.github.com/{SHA512}"));
 

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -34,7 +34,7 @@ use crate::{
     meta::entity::{
         data::{EntityBuilder, EntityData},
         Entity,
-        EntityStatusUnknown,
+        Unknown,
     },
     net::{
         connection::LocalInfo,
@@ -122,7 +122,7 @@ impl Peer {
 
     // FIXME[ENTITY]: Verify entity signatures
     /// Create a git [`Repo`] from an initial [`Entity`]
-    pub fn git_create<T>(&self, meta: &Entity<T, EntityStatusUnknown>) -> Result<Repo, repo::Error>
+    pub fn git_create<T>(&self, meta: &Entity<T, Unknown>) -> Result<Repo, repo::Error>
     where
         T: Serialize + DeserializeOwned + Clone + Default,
     {

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -33,8 +33,8 @@ use crate::{
     keys::device::{self, PublicKey},
     meta::entity::{
         data::{EntityBuilder, EntityData},
+        Draft,
         Entity,
-        Unknown,
     },
     net::{
         connection::LocalInfo,
@@ -122,7 +122,7 @@ impl Peer {
 
     // FIXME[ENTITY]: Verify entity signatures
     /// Create a git [`Repo`] from an initial [`Entity`]
-    pub fn git_create<T>(&self, meta: &Entity<T, Unknown>) -> Result<Repo, repo::Error>
+    pub fn git_create<T>(&self, meta: &Entity<T, Draft>) -> Result<Repo, repo::Error>
     where
         T: Serialize + DeserializeOwned + Clone + Default,
     {

--- a/librad/src/project.rs
+++ b/librad/src/project.rs
@@ -119,7 +119,7 @@ impl Project {
     pub fn show(
         paths: &Paths,
         id: &ProjectId,
-    ) -> Result<meta::Project<meta::entity::Unknown>, Error> {
+    ) -> Result<meta::Project<meta::entity::Draft>, Error> {
         GitProject::open(&id.path(paths))?
             .metadata()
             .map_err(|e| e.into())

--- a/librad/src/project.rs
+++ b/librad/src/project.rs
@@ -119,7 +119,7 @@ impl Project {
     pub fn show(
         paths: &Paths,
         id: &ProjectId,
-    ) -> Result<meta::Project<meta::entity::EntityStatusUnknown>, Error> {
+    ) -> Result<meta::Project<meta::entity::Unknown>, Error> {
         GitProject::open(&id.path(paths))?
             .metadata()
             .map_err(|e| e.into())

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -21,7 +21,7 @@ use futures::future::Either;
 use futures_timer::Delay;
 
 use librad::{
-    meta::{entity::EntityStatusUnknown, project::ProjectInfo, Project, User},
+    meta::{entity::Unknown, project::ProjectInfo, Project, User},
     net::peer::{BoundPeer, Gossip, Rev},
     peer::PeerId,
     sync::Monitor,
@@ -41,11 +41,9 @@ async fn can_clone() {
         let peer1 = peers[0].peer.clone();
         let peer2 = peers[1].peer.clone();
 
-        let peer1_user =
-            User::<EntityStatusUnknown>::create("alice".to_owned(), peer1.public_key()).unwrap();
+        let peer1_user = User::<Unknown>::create("alice".to_owned(), peer1.public_key()).unwrap();
         let peer1_project =
-            Project::<EntityStatusUnknown>::create("radicle".to_owned(), &peer1_user.urn())
-                .unwrap();
+            Project::<Unknown>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
         let urn = peer1_project.urn();
 
         run_on_testnet(bound, async move {
@@ -81,11 +79,9 @@ async fn fetches_on_gossip_notify() {
         let peer1 = peers[0].peer.clone();
         let peer2 = peers[1].peer.clone();
 
-        let peer1_user =
-            User::<EntityStatusUnknown>::create("alice".to_owned(), peer1.public_key()).unwrap();
+        let peer1_user = User::<Unknown>::create("alice".to_owned(), peer1.public_key()).unwrap();
         let peer1_project =
-            Project::<EntityStatusUnknown>::create("radicle".to_owned(), &peer1_user.urn())
-                .unwrap();
+            Project::<Unknown>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
         let peer1_project_urn = peer1_project.urn();
 
         let peer1_handle = bound[0].handle();

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -21,7 +21,7 @@ use futures::future::Either;
 use futures_timer::Delay;
 
 use librad::{
-    meta::{entity::Unknown, project::ProjectInfo, Project, User},
+    meta::{entity::Draft, project::ProjectInfo, Project, User},
     net::peer::{BoundPeer, Gossip, Rev},
     peer::PeerId,
     sync::Monitor,
@@ -41,9 +41,9 @@ async fn can_clone() {
         let peer1 = peers[0].peer.clone();
         let peer2 = peers[1].peer.clone();
 
-        let peer1_user = User::<Unknown>::create("alice".to_owned(), peer1.public_key()).unwrap();
+        let peer1_user = User::<Draft>::create("alice".to_owned(), peer1.public_key()).unwrap();
         let peer1_project =
-            Project::<Unknown>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
+            Project::<Draft>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
         let urn = peer1_project.urn();
 
         run_on_testnet(bound, async move {
@@ -79,9 +79,9 @@ async fn fetches_on_gossip_notify() {
         let peer1 = peers[0].peer.clone();
         let peer2 = peers[1].peer.clone();
 
-        let peer1_user = User::<Unknown>::create("alice".to_owned(), peer1.public_key()).unwrap();
+        let peer1_user = User::<Draft>::create("alice".to_owned(), peer1.public_key()).unwrap();
         let peer1_project =
-            Project::<Unknown>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
+            Project::<Draft>::create("radicle".to_owned(), &peer1_user.urn()).unwrap();
         let peer1_project_urn = peer1_project.urn();
 
         let peer1_handle = bound[0].handle();


### PR DESCRIPTION
I took the liberty of testing out using `PhantomData` on `Entity`. I think the changes are pretty cool since you can't push an `Entity<T, Unknown>` onto `UserHistory` -- yay type safety!

I removed the `VerificationStatus` from `Entity` because now the types tell you when things were successful, otherwise, you got an error.

I hope it's ok that I went and did this :bow: My curiosity was piqued :grin: 