### PR TITLE
Peer events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
  "url 2.1.1",
  "urltemplate",
@@ -2155,16 +2154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -34,7 +34,6 @@ tempfile = "3.1"
 thiserror = "1.0"
 secstr = "0.3"
 tracing = "0.1"
-tracing-futures = "0.2"
 urltemplate = "0.1"
 webpki = "0.21"
 

--- a/librad/src/net/gossip/storage.rs
+++ b/librad/src/net/gossip/storage.rs
@@ -17,7 +17,7 @@
 
 use crate::peer::PeerId;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum PutResult {
     Applied,
     Stale,


### PR DESCRIPTION
Introduce an upstream event channel for `net::Peer`.

Allows to subscribe to "background" activity triggered by gossip. Note that running the tests multithreaded is still flaky, so there might be some other issue.

On top of #149 