### PR TITLE
Unlock

### DIFF
--- a/ci/build-test
+++ b/ci/build-test
@@ -2,6 +2,4 @@
 set -eou pipefail
 
 echo '--- Build & Test'
-# Single-threaded to make the integration tests less flaky. Should be dropped
-# once we don't need to rely on a timeout there.
-cargo test --all -- --test-threads=1
+cargo test --all

--- a/librad/src/git/ext.rs
+++ b/librad/src/git/ext.rs
@@ -21,6 +21,8 @@ use std::{fmt, ops::Deref};
 
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::internal::borrow::TryToOwned;
+
 /// Serializable [`git2::Oid`]
 #[derive(Debug)]
 pub struct Oid(pub git2::Oid);
@@ -175,5 +177,14 @@ impl<'a, 'b> Iterator for ReferenceNames<'a, 'b> {
                 Some(item)
             },
         })
+    }
+}
+
+impl TryToOwned for git2::Repository {
+    type Owned = git2::Repository;
+    type Error = git2::Error;
+
+    fn try_to_owned(&self) -> Result<Self::Owned, Self::Error> {
+        git2::Repository::open(self.path())
     }
 }

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -15,33 +15,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::HashSet;
 
-use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 
 use crate::{
     git::{
-        ext::{Git2ErrorExt, Oid, References},
-        refs::{self, Refs},
-        storage::{self, Storage, WithBlob},
-        types::{Namespace, Reference, Refspec},
-        url::GitUrlRef,
+        refs::Refs,
+        storage::{self, Storage},
+        types::Namespace,
     },
-    hash::Hash,
-    internal::{
-        borrow::{TryCow, TryToOwned},
-        canonical::{Cjson, CjsonError},
-    },
-    meta::entity::{
-        self,
-        data::{EntityBuilder, EntityData},
-        Draft,
-        Entity,
-        Signatory,
-    },
+    internal::borrow::{TryCow, TryToOwned},
     peer::PeerId,
-    uri::{self, RadUrl, RadUrn},
+    uri::RadUrn,
 };
 use radicle_surf::vcs::git as surf;
 
@@ -49,243 +35,51 @@ pub use storage::Tracked;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Unknown repo {0}")]
-    NoSuchUrn(RadUrn),
-
-    #[error(
-        "Identity root hash doesn't match resolved URL. Expected {expected}, actual: {actual}"
-    )]
-    RootHashMismatch { expected: Hash, actual: Hash },
-
-    #[error("Metadata is not signed")]
-    UnsignedMetadata,
-
-    #[error(transparent)]
-    Urn(#[from] uri::rad_urn::ParseError),
-
-    #[error(transparent)]
-    Entity(#[from] entity::Error),
-
-    #[error(transparent)]
-    Refsig(#[from] refs::signed::Error),
-
-    #[error(transparent)]
-    Cjson(#[from] CjsonError),
-
     #[error(transparent)]
     Storage(#[from] storage::Error),
 
     #[error(transparent)]
     Git(#[from] git2::Error),
-
-    #[error(transparent)]
-    Surf(#[from] surf::error::Error),
 }
 
+/// A logical repository.
+///
+/// This is just a (thin) wrapper around [`Storage`] so the [`RadUrn`] context
+/// doesn't need to be passed around.
 pub struct Repo<'a> {
     pub urn: RadUrn,
-    storage: TryCow<'a, Storage>,
+    pub(super) storage: TryCow<'a, Storage>,
 }
 
 impl<'a> Repo<'a> {
-    pub fn create<T>(storage: &'a Storage, meta: &Entity<T, Draft>) -> Result<Self, Error>
-    where
-        T: Serialize + DeserializeOwned + Clone + Default,
-        EntityData<T>: EntityBuilder,
-    {
-        let span = tracing::info_span!("Repo::create");
-        let _guard = span.enter();
-
-        // FIXME: properly verify meta
-
-        if meta.signatures().is_empty() {
-            return Err(Error::UnsignedMetadata);
-        }
-
-        // FIXME: certifier identities must exist, or be supplied
-
-        let this = Self {
-            urn: RadUrn::new(
-                meta.root_hash().to_owned(),
-                uri::Protocol::Git,
-                uri::Path::empty(),
-            ),
-            storage: storage.into(),
-        };
-        this.commit_initial_meta(meta)?;
-        this.track_signers(&meta)?;
-        this.update_refs()?;
-
-        Ok(this)
+    pub fn namespace(&self) -> Namespace {
+        self.urn.id.clone()
     }
 
-    pub fn open(storage: &'a Storage, urn: RadUrn) -> Result<Self, Error> {
-        {
-            let id_ref = Reference::rad_id(urn.id.clone());
-            if !storage.has_ref(&id_ref)? {
-                return Err(Error::NoSuchUrn(urn));
-            }
-        }
-
-        Ok(Self {
-            urn: RadUrn {
-                path: uri::Path::empty(),
-                ..urn
-            },
-            storage: storage.into(),
-        })
-    }
-
-    pub fn clone<T>(storage: &'a Storage, url: RadUrl) -> Result<Self, Error>
-    where
-        T: Serialize + DeserializeOwned + Clone + Default,
-        EntityData<T>: EntityBuilder,
-    {
-        let span = tracing::info_span!("Repo::clone", repo.url = %url);
-        let _guard = span.enter();
-
-        let local_peer_id = PeerId::from(&storage.key);
-        let this = Self {
-            urn: RadUrn {
-                path: uri::Path::empty(),
-                ..url.urn.clone()
-            },
-            storage: storage.into(),
-        };
-
-        // Fetch the identity first
-        let git_url = GitUrlRef::from_rad_url_ref(url.as_ref(), &local_peer_id);
-        let meta = this.fetch_id(git_url)?;
-
-        // TODO: properly verify meta
-
-        if meta.signatures().is_empty() {
-            return Err(Error::UnsignedMetadata);
-        }
-
-        if meta.root_hash() != &url.urn.id {
-            return Err(Error::RootHashMismatch {
-                expected: url.urn.id.to_owned(),
-                actual: meta.root_hash().to_owned(),
-            });
-        }
-
-        this.track_signers(&meta)?;
-        this.update_refs()?;
-        this.fetch(&url.authority)?;
-
-        Ok(this)
-    }
-
-    pub fn browser(&'_ self) -> Result<surf::Browser<'_>, Error> {
-        Ok(surf::Browser::new(&self.storage.backend)?)
-    }
-
+    /// Fetch new refs and objects for this repo from [`PeerId`]
     pub fn fetch(&self, from: &PeerId) -> Result<(), Error> {
-        let span = tracing::info_span!("Repo::fetch", repo.fetch.from = %from);
-        let _guard = span.enter();
-
-        let namespace = &self.urn.id;
-
-        let mut remote = {
-            let local_peer = PeerId::from(&self.storage.key);
-            let url = GitUrlRef::from_rad_url_ref(self.urn.as_rad_url_ref(from), &local_peer);
-            self.storage.remote_anonymous(&url.to_string())
-        }?;
-        remote.connect(git2::Direction::Fetch)?;
-
-        let rad_refs = self.rad_refs()?;
-        let tracked_trans = rad_refs.remotes.flatten().collect::<HashSet<&PeerId>>();
-
-        // Fetch rad/refs of all known remotes
-        {
-            let refspecs =
-                Refspec::rad_refs(namespace.clone(), from, tracked_trans.iter().cloned())
-                    .map(|spec| spec.to_string())
-                    .collect::<Vec<String>>();
-            tracing::debug!(refspecs = ?refspecs, "Fetching rad/refs");
-            remote.fetch(&refspecs, Some(&mut self.fetch_options()), None)?;
-        }
-
-        // Read the signed refs of all known remotes, and compare their `heads`
-        // against the advertised refs. If signed and advertised branch head
-        // match, non-fast-forwards are permitted. Otherwise, the branch is
-        // skipped.
-        {
-            let remote_heads: HashMap<&str, git2::Oid> = remote
-                .list()?
-                .iter()
-                .map(|rhead| (rhead.name(), rhead.oid()))
-                .collect();
-
-            let refspecs = Refspec::fetch_heads(
-                namespace.clone(),
-                remote_heads,
-                tracked_trans.iter().cloned(),
-                from,
-                |peer| self.rad_refs_of(peer),
-                |peer| self.certifiers_of(peer),
-            )?
-            .map(|spec| spec.to_string())
-            .collect::<Vec<String>>();
-
-            tracing::debug!(refspecs = ?refspecs, "Fetching refs/heads");
-            remote.fetch(&refspecs, Some(&mut self.fetch_options()), None)?;
-        }
-
-        // At this point, the transitive tracking graph may have changed. Let's
-        // update the refs, but don't recurse here for now (we could, if
-        // we reload `self.refs()` and compare to the value we had
-        // before fetching).
-        self.update_refs()
+        self.storage
+            .fetch_repo(&self.urn, from)
+            .map_err(Error::from)
     }
 
+    /// Obtain a read-only view of this repo
+    pub fn browser(&'_ self) -> Result<surf::Browser<'_>, Error> {
+        self.storage.browser(&self.urn).map_err(Error::from)
+    }
+
+    /// Track [`PeerId`]s view of this repo
+    ///
+    /// Equivalent to `git remote add`.
     pub fn track(&self, peer: &PeerId) -> Result<(), Error> {
-        self.storage.track(&self.urn, peer)?;
-        Ok(())
+        self.storage.track(&self.urn, peer).map_err(Error::from)
     }
 
-    // FIXME: decide if we want to require verified entities
-    fn track_signers<T>(&self, meta: &Entity<T, Draft>) -> Result<(), Error>
-    where
-        T: Serialize + DeserializeOwned + Clone + Default,
-    {
-        let span = tracing::debug_span!("Repo::track_signers", meta.urn = %meta.urn());
-        let _guard = span.enter();
-
-        meta.signatures()
-            .iter()
-            .map(|(pk, sig)| {
-                let peer_id = PeerId::from(pk.clone());
-                match &sig.by {
-                    Signatory::User(urn) => (peer_id, Some(urn)),
-                    Signatory::OwnedKey => (peer_id, None),
-                }
-            })
-            .try_for_each(|(peer, urn)| {
-                tracing::debug!(
-                    tracked.peer = %peer,
-                    tracked.urn =
-                        %urn.map(|urn| urn.to_string()).unwrap_or_else(|| "None".to_owned()),
-                    "Tracking signer of {}",
-                    meta.urn()
-                );
-
-                // Track the signer's version of this repo (if any)
-                self.track(&peer)?;
-                // Track the signer's version of the identity she used for
-                // signing (if any)
-                if let Some(urn) = urn {
-                    self.storage.track(urn, &peer)?;
-                }
-
-                Ok(())
-            })
-    }
-
+    /// Stop tracking [`PeerId`]s view of this repo
+    ///
+    /// Equivalent to `git remote rm`.
     pub fn untrack(&self, peer: &PeerId) -> Result<(), Error> {
-        self.storage.untrack(&self.urn, peer)?;
-        Ok(())
+        self.storage.untrack(&self.urn, peer).map_err(Error::from)
     }
 
     /// Retrieve all _directly_ tracked peers
@@ -293,83 +87,32 @@ impl<'a> Repo<'a> {
     /// To retrieve the transitively tracked peers, use [`rad_refs`] and inspect
     /// the `remotes`.
     pub fn tracked(&self) -> Result<Tracked, Error> {
-        let tracked = self.storage.tracked(&self.urn)?;
-        Ok(tracked)
+        self.storage.tracked(&self.urn).map_err(Error::from)
     }
 
-    /// Read the current [`Refs`] from the repo state
+    /// Retrieve all directly _as well_ as transitively tracked peers
     pub fn rad_refs(&self) -> Result<Refs, Error> {
-        let span = tracing::debug_span!("Repo::rad_refs", urn = %self.urn);
-        let _guard = span.enter();
-
-        // Collect refs/heads (our branches) at their current state
-        let heads = self.references_glob(Some("refs/heads/*"))?;
-        let heads: BTreeMap<String, Oid> = heads.map(|(name, oid)| (name, Oid(oid))).collect();
-
-        tracing::debug!(heads = ?heads);
-
-        // Get 1st degree tracked peers from the remotes configured in .git/config
-        let tracked = self.tracked()?;
-        let mut remotes: HashMap<PeerId, HashMap<PeerId, HashSet<PeerId>>> =
-            tracked.map(|peer| (peer, HashMap::new())).collect();
-
-        tracing::debug!(remotes.bare = ?remotes);
-
-        // For each of the 1st degree tracked peers, lookup their rad/refs (if any),
-        // verify the signature, and add their [`Remotes`] to ours (minus the 3rd
-        // degree)
-        for (peer, tracked) in remotes.iter_mut() {
-            match self.rad_refs_of(peer.clone()) {
-                Ok(refs) => *tracked = refs.remotes.cutoff(),
-                Err(Error::Storage(storage::Error::NoSuchBranch(_)))
-                | Err(Error::Storage(storage::Error::NoSuchBlob(_))) => {},
-                Err(e) => return Err(e),
-            }
-        }
-
-        tracing::debug!(remotes.verified = ?remotes);
-
-        Ok(Refs {
-            heads,
-            remotes: remotes.into(),
-        })
+        self.storage.rad_refs(&self.urn).map_err(Error::from)
     }
 
-    /// The set of all certifiers of this repo's identity, transitively
+    /// Retrieve the certifier URNs of this repo's identity
     pub fn certifiers(&self) -> Result<HashSet<RadUrn>, Error> {
-        let mut refs = References::from_globs(
-            &self.storage,
-            &[
-                format!("refs/namespaces/{}/refs/rad/ids/*", &self.urn.id),
-                format!("refs/namespaces/{}/refs/remotes/**/rad/ids/*", &self.urn.id),
-            ],
-        )?;
-        let refnames = refs.names();
-        Ok(urns_from_refs(refnames).collect())
+        self.storage.certifiers(&self.urn).map_err(Error::from)
     }
 
-    pub fn namespace(&self) -> Namespace {
-        self.urn.id.clone()
+    /// Check if the given [`git2::Oid`] exists within the context of this repo
+    pub fn has_commit(&self, oid: git2::Oid) -> Result<bool, Error> {
+        self.storage.has_commit(&self.urn, oid).map_err(Error::from)
     }
+
+    // TODO: find a better way to expose low-level git operations
 
     pub fn index(&self) -> Result<git2::Index, Error> {
-        let idx = self.storage.index()?;
-        Ok(idx)
+        self.storage.index().map_err(Error::from)
     }
 
     pub fn find_tree(&self, oid: git2::Oid) -> Result<git2::Tree, Error> {
-        let tree = self.storage.find_tree(oid)?;
-        Ok(tree)
-    }
-
-    pub fn blob(&self, data: &[u8]) -> Result<git2::Oid, Error> {
-        let oid = self.storage.blob(data)?;
-        Ok(oid)
-    }
-
-    pub fn find_blob(&self, oid: git2::Oid) -> Result<git2::Blob, Error> {
-        let blob = self.storage.find_blob(oid)?;
-        Ok(blob)
+        self.storage.find_tree(oid).map_err(Error::from)
     }
 
     pub fn commit(
@@ -379,221 +122,9 @@ impl<'a> Repo<'a> {
         tree: &git2::Tree,
         parents: &[&git2::Commit],
     ) -> Result<git2::Oid, Error> {
-        let author = self.storage.signature()?;
-        let head = Reference::head(self.namespace(), None, branch);
-        let oid = self.storage.commit(
-            Some(&head.to_string()),
-            &author,
-            &author,
-            msg,
-            tree,
-            parents,
-        )?;
-
-        self.update_refs()?;
-
-        Ok(oid)
-    }
-
-    pub fn find_commit(&self, oid: git2::Oid) -> Result<git2::Commit, Error> {
-        let commit = self.storage.find_commit(oid)?;
-        Ok(commit)
-    }
-
-    pub fn references_glob(
-        &'a self,
-        globs: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<impl Iterator<Item = (String, git2::Oid)> + 'a, Error> {
-        let namespace_prefix = format!("refs/namespaces/{}/", &self.urn.id);
-
-        let refs = References::from_globs(
-            &self.storage,
-            globs
-                .into_iter()
-                .map(|glob| format!("{}{}", namespace_prefix, glob.as_ref())),
-        )?;
-
-        Ok(refs.peeled().filter_map(move |(name, target)| {
-            name.strip_prefix(&namespace_prefix)
-                .map(|name| (name.to_owned(), target))
-        }))
-    }
-
-    fn commit_initial_meta<T>(&self, meta: &Entity<T, Draft>) -> Result<git2::Oid, Error>
-    where
-        T: Serialize + DeserializeOwned + Clone + Default,
-        EntityData<T>: EntityBuilder,
-    {
-        let canonical_data = Cjson(meta).canonical_form()?;
-        let blob = self.storage.blob(&canonical_data)?;
-        let tree = {
-            let mut builder = self.storage.treebuilder(None)?;
-            builder.insert("id", blob, 0o100_644)?;
-            let oid = builder.write()?;
-            self.storage.find_tree(oid)
-        }?;
-        let author = self.storage.signature()?;
-
-        let branch_name = Reference::rad_id(self.namespace());
-
-        let oid = self.storage.commit(
-            Some(&branch_name.to_string()),
-            &author,
-            &author,
-            &format!("Initialised with identity {}", meta.root_hash()),
-            &tree,
-            &[],
-        )?;
-
-        tracing::debug!(
-            repo.urn = %self.urn,
-            repo.id.branch = %branch_name,
-            repo.id.oid = %oid,
-            "Initial metadata committed"
-        );
-
-        Ok(oid)
-    }
-
-    // FIXME: decide if we want to require verified entities
-    fn fetch_id<T>(&self, url: GitUrlRef) -> Result<Entity<T, Draft>, Error>
-    where
-        T: Serialize + DeserializeOwned + Clone + Default,
-        EntityData<T>: EntityBuilder,
-    {
-        tracing::debug!("Fetching id of {}", url);
-
-        let id_branch = Reference::rad_id(self.namespace());
-        let certifiers_glob = Reference::rad_ids_glob(self.namespace());
-
-        // Map rad/id to rad/id (not remotes/X/rad/id) -- we need an owned
-        // id, and the remote one is supposed to be valid regardless of the
-        // peer we're cloning from. A resolver may later decide whether it's
-        // up-to-date.
-        let refspecs = [
-            Refspec {
-                remote: id_branch.clone(),
-                local: id_branch.clone(),
-                force: false,
-            },
-            Refspec {
-                remote: certifiers_glob.clone(),
-                local: certifiers_glob,
-                force: false,
-            },
-        ]
-        .iter()
-        .map(|spec| spec.to_string())
-        .collect::<Vec<String>>();
-
-        {
-            tracing::trace!(repo.clone.refspecs = ?refspecs);
-            let mut remote = self.storage.remote_anonymous(&url.to_string())?;
-            remote.fetch(&refspecs, Some(&mut self.fetch_options()), None)?;
-        }
-
-        let entity: Entity<T, Draft> = {
-            let blob = WithBlob::Init {
-                reference: &id_branch,
-                file_name: "id",
-            }
-            .get(&self.storage)?;
-            Entity::<T, Draft>::from_json_slice(blob.content())
-        }?;
-
-        Ok(entity)
-    }
-
-    fn rad_refs_of(&self, peer: PeerId) -> Result<Refs, Error> {
-        let signed = {
-            let refs = Reference::rad_refs(self.namespace(), peer.clone());
-            let blob = WithBlob::Tip {
-                reference: &refs,
-                file_name: "refs",
-            }
-            .get(&self.storage)?;
-            refs::Signed::from_json(blob.content(), &peer)
-        }?;
-
-        Ok(Refs::from(signed))
-    }
-
-    fn update_refs(&self) -> Result<(), Error> {
-        let span = tracing::debug_span!("Repo::update_refs");
-        let _guard = span.enter();
-
-        let refsig_canonical = self
-            .rad_refs()?
-            .sign(&self.storage.key)
-            .and_then(|signed| Cjson(signed).canonical_form())?;
-
-        let rad_refs_ref = Reference::rad_refs(self.namespace(), None).to_string();
-
-        let parent: Option<git2::Commit> = self
-            .storage
-            .find_reference(&rad_refs_ref)
-            .and_then(|refs| refs.peel_to_commit().map(Some))
-            .map_not_found::<Error, _>(|| Ok(None))?;
-        let tree = {
-            let blob = self.storage.blob(&refsig_canonical)?;
-            let mut builder = self.storage.treebuilder(None)?;
-
-            builder.insert("refs", blob, 0o100_644)?;
-            let oid = builder.write()?;
-
-            self.storage.find_tree(oid)
-        }?;
-
-        // Don't create a new commit if it would be the same tree as the parent
-        if let Some(ref parent) = parent {
-            if parent.tree()?.id() == tree.id() {
-                return Ok(());
-            }
-        }
-
-        let author = self.storage.signature()?;
-        self.storage.commit(
-            Some(&rad_refs_ref),
-            &author,
-            &author,
-            "",
-            &tree,
-            &parent.iter().collect::<Vec<&git2::Commit>>(),
-        )?;
-
-        Ok(())
-    }
-
-    fn certifiers_of(&self, peer: &PeerId) -> Result<HashSet<RadUrn>, Error> {
-        let mut refs = References::from_globs(
-            &self.storage,
-            &[format!(
-                "refs/namespaces/{}/refs/remotes/{}/rad/ids/*",
-                &self.urn.id, peer
-            )],
-        )?;
-        let refnames = refs.names();
-        Ok(urns_from_refs(refnames).collect())
-    }
-
-    fn fetch_options(&self) -> git2::FetchOptions<'a> {
-        let mut cbs = git2::RemoteCallbacks::new();
-        cbs.sideband_progress(|prog| {
-            tracing::trace!("{}", unsafe { std::str::from_utf8_unchecked(prog) });
-            true
-        })
-        .update_tips(|name, old, new| {
-            tracing::debug!("{}: {} -> {}", name, old, new);
-            true
-        });
-
-        let mut fos = git2::FetchOptions::new();
-        fos.prune(git2::FetchPrune::Off)
-            .update_fetchhead(true)
-            .download_tags(git2::AutotagOption::None)
-            .remote_callbacks(cbs);
-
-        fos
+        self.storage
+            .commit(&self.urn, branch, msg, tree, parents)
+            .map_err(Error::from)
     }
 }
 
@@ -606,15 +137,4 @@ impl TryToOwned for Repo<'_> {
         let urn = self.urn.clone();
         Ok(Self { storage, urn })
     }
-}
-
-fn urns_from_refs<'a, E>(
-    refs: impl Iterator<Item = Result<&'a str, E>> + 'a,
-) -> impl Iterator<Item = RadUrn> + 'a {
-    refs.filter_map(|refname| {
-        refname
-            .ok()
-            .and_then(|name| name.split('/').next_back())
-            .and_then(|urn| urn.parse().ok())
-    })
 }

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -205,7 +205,7 @@ impl Storage {
 
         // Fetch the identity first
         let git_url = GitUrlRef::from_rad_url_ref(url.as_ref(), &local_peer_id);
-        let meta = self.fetch_id(&urn, git_url)?;
+        let meta = self.fetch_id(git_url)?;
 
         // TODO: properly verify meta
 
@@ -497,14 +497,14 @@ impl Storage {
 
     // FIXME: decide if we want to require verified entities
     // FIXME: yes, we do want that
-    fn fetch_id<T>(&self, urn: &RadUrn, url: GitUrlRef) -> Result<Entity<T, Draft>, Error>
+    fn fetch_id<T>(&self, url: GitUrlRef) -> Result<Entity<T, Draft>, Error>
     where
         T: Serialize + DeserializeOwned + Clone + Default,
         EntityData<T>: EntityBuilder,
     {
         tracing::debug!("Fetching id of {}", url);
 
-        let namespace = urn.id.clone();
+        let namespace = url.repo.clone();
         let id_branch = Reference::rad_id(namespace.clone());
         let certifiers_glob = Reference::rad_ids_glob(namespace);
 

--- a/librad/src/internal.rs
+++ b/librad/src/internal.rs
@@ -19,6 +19,7 @@
 //!
 //! Code here may change in incompatible ways without prior notice.
 
+pub mod borrow;
 pub mod canonical;
 pub mod channel;
 pub mod sync;

--- a/librad/src/internal/borrow.rs
+++ b/librad/src/internal/borrow.rs
@@ -1,0 +1,88 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{borrow::Borrow, ops::Deref};
+
+use TryCow::*;
+
+/// A fallible version of [`std::borrow::ToOwned`]
+pub trait TryToOwned {
+    type Owned: Borrow<Self>;
+    type Error: std::error::Error;
+
+    fn try_to_owned(&self) -> Result<Self::Owned, Self::Error>;
+}
+
+/// A fallible version of [`std::borrow::Cow`]
+///
+/// Instead of [`std::borrow::ToOwned`], turning a borrowed [`TryCow`] value
+/// into an owned one requires [`TryToOwned`], thus the conversion may fail.
+pub enum TryCow<'a, B>
+where
+    B: 'a + TryToOwned + ?Sized,
+{
+    Borrowed(&'a B),
+    Owned(<B as TryToOwned>::Owned),
+}
+
+impl<T: TryToOwned> TryCow<'_, T> {
+    pub fn try_into_owned(self) -> Result<<T as TryToOwned>::Owned, <T as TryToOwned>::Error> {
+        match self {
+            Borrowed(borrowed) => borrowed.try_to_owned(),
+            Owned(owned) => Ok(owned),
+        }
+    }
+
+    pub fn try_to_mut(
+        &mut self,
+    ) -> Result<&mut <T as TryToOwned>::Owned, <T as TryToOwned>::Error> {
+        match *self {
+            Borrowed(borrowed) => {
+                *self = borrowed.try_to_owned().map(Owned)?;
+                match *self {
+                    Borrowed(..) => unreachable!(),
+                    Owned(ref mut owned) => Ok(owned),
+                }
+            },
+
+            Owned(ref mut owned) => Ok(owned),
+        }
+    }
+}
+
+impl<T: TryToOwned + ?Sized> Deref for TryCow<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match *self {
+            Borrowed(borrowed) => borrowed,
+            Owned(ref owned) => owned.borrow(),
+        }
+    }
+}
+
+impl<T: TryToOwned + ?Sized> AsRef<T> for TryCow<'_, T> {
+    fn as_ref(&self) -> &T {
+        self
+    }
+}
+
+impl<'a, T: TryToOwned + ?Sized> From<&'a T> for TryCow<'a, T> {
+    fn from(t: &'a T) -> Self {
+        Borrowed(t)
+    }
+}

--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -599,16 +599,7 @@ where
                     })))
                     .await;
 
-                let res = {
-                    let remote_id = remote_id.clone();
-                    let val = val.clone();
-                    let storage = self.storage.clone();
-                    tokio::task::spawn_blocking(move || storage.put(&remote_id, val))
-                        .await
-                        .expect("storage.put panicked")
-                };
-
-                match res {
+                match self.storage.put(&remote_id, val.clone()).await {
                     // `val` was new, and is now fetched to local storage. Let
                     // connected peers know they can now fetch it from us.
                     PutResult::Applied => {
@@ -679,13 +670,7 @@ where
 
             Want { origin, val } => {
                 tracing::trace!(msg = "Want", origin.peer.id = %origin.peer_id, origin.value = ?val);
-                let have = {
-                    let val = val.clone();
-                    let storage = self.storage.clone();
-                    tokio::task::spawn_blocking(move || storage.ask(val))
-                        .await
-                        .expect("storage.ask panicked")
-                };
+                let have = self.storage.ask(val.clone()).await;
 
                 if have {
                     self.reply(

--- a/librad/src/net/gossip/storage.rs
+++ b/librad/src/net/gossip/storage.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use async_trait::async_trait;
+
 use crate::peer::PeerId;
 
 #[derive(Clone, Copy, Debug)]
@@ -25,6 +27,7 @@ pub enum PutResult {
     Error,
 }
 
+#[async_trait]
 pub trait LocalStorage: Clone + Send + Sync {
     type Update;
 
@@ -39,11 +42,11 @@ pub trait LocalStorage: Clone + Send + Sync {
     /// up-to-date, or it was not possible to fetch the actual state from
     /// the `provider`. In this case, the network is asked to retransmit
     /// [`Self::Update`], so we can eventually try again.
-    fn put(&self, provider: &PeerId, has: Self::Update) -> PutResult;
+    async fn put(&self, provider: &PeerId, has: Self::Update) -> PutResult;
 
     /// Ask the local storage if value `A` is available.
     ///
     /// This is used to notify the asking peer that they may fetch value `A`
     /// from us.
-    fn ask(&self, want: Self::Update) -> bool;
+    async fn ask(&self, want: Self::Update) -> bool;
 }

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -18,22 +18,24 @@
 use std::{
     future::Future,
     io,
-    net::{SocketAddr, ToSocketAddrs},
+    net::SocketAddr,
+    sync::{Arc, Mutex},
 };
 
-use futures::executor::block_on;
+use async_trait::async_trait;
+use futures::future::{BoxFuture, FutureExt};
 use thiserror::Error;
 
 use crate::{
     git::{self, repo, server::GitServer, storage::Storage as GitStorage},
-    internal::channel::Fanout,
+    internal::{borrow::TryToOwned, channel::Fanout},
     keys::{PublicKey, SecretKey},
     net::{
         connection::LocalInfo,
-        discovery,
+        discovery::Discovery,
         gossip::{self, LocalStorage, PutResult},
-        protocol::{self, Protocol},
-        quic::{self, BoundEndpoint, Endpoint},
+        protocol::Protocol,
+        quic::{self, Endpoint},
     },
     paths::Paths,
     peer::{Originates, OriginatesRef, PeerId},
@@ -58,10 +60,33 @@ pub enum GitFetchError {
 }
 
 #[derive(Debug, Error)]
-#[error("Failed to bind to {addr}")]
-pub struct BindError {
-    addr: SocketAddr,
-    source: quic::Error,
+#[non_exhaustive]
+pub enum BootstrapError {
+    #[error("Failed to bind to {addr}")]
+    Bind {
+        addr: SocketAddr,
+        source: quic::Error,
+    },
+
+    #[error(transparent)]
+    Storage(#[from] git::storage::Error),
+
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AcceptError {
+    #[error(transparent)]
+    Storage(#[from] git::storage::Error),
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ApiError {
+    #[error(transparent)]
+    Storage(#[from] git::storage::Error),
 }
 
 /// Upstream events.
@@ -81,37 +106,101 @@ pub struct FetchInfo {
     pub result: PutResult,
 }
 
-/// A stateful network peer.
-///
-/// Implements [`LocalStorage`]. A [`Peer`] can be bound to one or more
-/// [`SocketAddr`]esses.
 #[derive(Clone)]
+pub struct PeerConfig<Disco> {
+    pub key: SecretKey,
+    pub paths: Paths,
+    pub listen_addr: SocketAddr,
+    pub gossip_params: gossip::MembershipParams,
+    pub disco: Disco,
+}
+
+impl<D> PeerConfig<D>
+where
+    D: Discovery<Addr = SocketAddr>,
+    <D as Discovery>::Stream: 'static,
+{
+    pub async fn try_into_peer(self) -> Result<Peer, BootstrapError> {
+        Peer::bootstrap(self).await
+    }
+}
+
+/// Main entry point for `radicle-link` applications on top of a connected
+/// [`Peer`]
+pub struct PeerApi {
+    key: SecretKey,
+    protocol: Protocol<PeerStorage, Gossip>,
+    storage: GitStorage,
+    subscribers: Fanout<PeerEvent>,
+}
+
+impl PeerApi {
+    pub fn protocol(&self) -> &Protocol<PeerStorage, Gossip> {
+        &self.protocol
+    }
+
+    pub fn storage(&self) -> &GitStorage {
+        &self.storage
+    }
+
+    pub fn key(&self) -> &SecretKey {
+        &self.key
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        self.key.public()
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        PeerId::from(&self.key)
+    }
+
+    pub async fn subscribe(&self) -> impl futures::Stream<Item = PeerEvent> {
+        self.subscribers.subscribe().await
+    }
+}
+
+impl TryToOwned for PeerApi {
+    type Owned = Self;
+    type Error = ApiError;
+
+    fn try_to_owned(&self) -> Result<Self::Owned, Self::Error> {
+        let storage = self.storage.try_to_owned()?;
+        Ok(Self {
+            key: self.key.clone(),
+            protocol: self.protocol.clone(),
+            storage,
+            subscribers: self.subscribers.clone(),
+        })
+    }
+}
+
+/// A bootstrapped network peer
+///
+/// The peer is already bound to a network socket, and ready to execute the
+/// protocol stack. In order to actually send and receive from the network, the
+/// [`Peer`] needs to be exchanged for a [`Future`] using `accept`, which must
+/// be polled to make progress. `accept` also returns a [`PeerApi`], which
+/// provides methods for passing messages up- and downstream.
+///
+/// The intermediate, bound state is mainly useful to query the [`SocketAddr`]
+/// chosen by the operating system when the [`Peer`] was bootstrapped using
+/// `0.0.0.0:0`.
 pub struct Peer {
     key: SecretKey,
     paths: Paths,
-    git: GitStorage,
+
+    listen_addr: SocketAddr,
+
+    protocol: Protocol<PeerStorage, Gossip>,
+    run_loop: BoxFuture<'static, ()>,
 
     subscribers: Fanout<PeerEvent>,
 }
 
 impl Peer {
-    pub fn new(paths: Paths, git: GitStorage) -> Self {
-        Self {
-            key: git.key.clone(),
-            paths,
-            git,
-            subscribers: Fanout::new(),
-        }
-    }
-
-    pub fn init(paths: Paths, key: SecretKey) -> Result<Self, git::storage::Error> {
-        let git = GitStorage::init(&paths, key.clone())?;
-        Ok(Self {
-            key,
-            paths,
-            git,
-            subscribers: Fanout::new(),
-        })
+    pub fn listen_addr(&self) -> SocketAddr {
+        self.listen_addr
     }
 
     pub fn peer_id(&self) -> PeerId {
@@ -122,53 +211,80 @@ impl Peer {
         self.key.public()
     }
 
-    // FIXME: this should not be here, but we can't otherwise do entity signing
-    // in tests
-    pub fn key(&self) -> &SecretKey {
-        &self.key
+    pub fn accept(self) -> Result<(PeerApi, impl Future), AcceptError> {
+        let storage = GitStorage::open(&self.paths, self.key.clone())?;
+        let api = PeerApi {
+            key: self.key,
+            storage,
+            protocol: self.protocol,
+            subscribers: self.subscribers,
+        };
+        Ok((api, self.run_loop))
     }
 
-    /// Bind to the given [`SocketAddr`].
-    ///
-    /// Calling `bind` will cause the process to listen on the given address,
-    /// but that won't have any effect (except perhaps for filling up kernel
-    /// buffers) until the returned [`BoundPeer`] is run. The reason for
-    /// this intermediate bootstrapping step is that we may want to bind to
-    /// a random port, and later retrieve which port was actually chosen by the
-    /// kernel.
-    pub async fn bind<'a>(self, addr: SocketAddr) -> Result<BoundPeer<'a>, BindError> {
-        let peer_id = PeerId::from(&self.key);
-        let git = GitServer::new(&self.paths);
-        let endpoint = Endpoint::bind(&self.key, addr)
+    async fn bootstrap<D>(config: PeerConfig<D>) -> Result<Self, BootstrapError>
+    where
+        D: Discovery<Addr = SocketAddr>,
+        <D as Discovery>::Stream: 'static,
+    {
+        let peer_id = PeerId::from(&config.key);
+
+        let git = GitServer::new(&config.paths);
+
+        let endpoint = Endpoint::bind(&config.key, config.listen_addr)
             .await
-            .map_err(|e| BindError { addr, source: e })?;
+            .map_err(|e| BootstrapError::Bind {
+                addr: config.listen_addr,
+                source: e,
+            })?;
+        let listen_addr = endpoint.local_addr()?;
+
+        let subscribers = Fanout::new();
+        let peer_storage = {
+            let storage = GitStorage::open(&config.paths, config.key.clone())?;
+            PeerStorage {
+                inner: Arc::new(Mutex::new(storage)),
+                peer_id: peer_id.clone(),
+                subscribers: subscribers.clone(),
+            }
+        };
+
         let gossip = gossip::Protocol::new(
             &peer_id,
-            gossip::PeerAdvertisement::new(endpoint.local_addr().unwrap()),
-            gossip::MembershipParams::default(),
-            self,
+            gossip::PeerAdvertisement::new(listen_addr),
+            config.gossip_params,
+            peer_storage,
         );
+
         let protocol = Protocol::new(gossip, git);
         git::transport::register().register_stream_factory(&peer_id, Box::new(protocol.clone()));
 
-        Ok(BoundPeer {
-            peer_id,
-            endpoint,
+        let run_loop = protocol
+            .clone()
+            .run(endpoint, config.disco.discover())
+            .boxed();
+
+        Ok(Self {
+            key: config.key,
+            paths: config.paths,
+            listen_addr,
             protocol,
+            run_loop,
+            subscribers,
         })
     }
+}
 
-    /// Subscribe to [`PeerEvent`]s
-    pub async fn subscribe(&self) -> impl futures::Stream<Item = PeerEvent> {
-        self.subscribers.subscribe().await
-    }
+#[derive(Clone)]
+pub struct PeerStorage {
+    inner: Arc<Mutex<GitStorage>>,
+    peer_id: PeerId,
 
-    pub fn git(&self) -> &GitStorage {
-        &self.git
-    }
+    subscribers: Fanout<PeerEvent>,
+}
 
-    /// Update a git repo
-    pub fn git_fetch<'a>(
+impl PeerStorage {
+    fn git_fetch<'a>(
         &'a self,
         from: &PeerId,
         urn: impl Into<OriginatesRef<'a, RadUrn>>,
@@ -177,28 +293,30 @@ impl Peer {
         let urn = self.urn_context(urn);
 
         if let Some(head) = head.into() {
-            if self.git.has_commit(&urn, head)? {
+            if self.inner.lock().unwrap().has_commit(&urn, head)? {
                 return Err(GitFetchError::KnownObject(head));
             }
         }
 
-        self.git
-            .clone()
+        self.inner
+            .lock()
+            .unwrap()
             .open_repo(urn)?
             .fetch(from)
             .map_err(|e| e.into())
     }
 
     /// Determine if we have the given object locally
-    pub fn git_has<'a>(
+    fn git_has<'a>(
         &'a self,
         urn: impl Into<OriginatesRef<'a, RadUrn>>,
         head: impl Into<Option<git2::Oid>>,
     ) -> bool {
         let urn = self.urn_context(urn);
+        let git = self.inner.lock().unwrap();
         match head.into() {
-            None => self.git.has_urn(&urn).unwrap_or(false),
-            Some(head) => self.git.has_commit(&urn, head).unwrap_or(false),
+            None => git.has_urn(&urn).unwrap_or(false),
+            Some(head) => git.has_commit(&urn, head).unwrap_or(false),
         }
     }
 
@@ -208,7 +326,7 @@ impl Peer {
         let OriginatesRef { from, value } = urn.into();
         let urn = value.clone();
 
-        if from == &self.peer_id() {
+        if from == &self.peer_id {
             return urn;
         }
 
@@ -230,16 +348,13 @@ impl Peer {
             ..urn
         }
     }
-
-    fn emit_event_sync(&self, event: PeerEvent) {
-        block_on(self.subscribers.emit(event))
-    }
 }
 
-impl LocalStorage for Peer {
+#[async_trait]
+impl LocalStorage for PeerStorage {
     type Update = Gossip;
 
-    fn put(&self, provider: &PeerId, has: Self::Update) -> PutResult {
+    async fn put(&self, provider: &PeerId, has: Self::Update) -> PutResult {
         let span = tracing::info_span!("Peer::LocalStorage::put");
         let _guard = span.enter();
 
@@ -249,14 +364,25 @@ impl LocalStorage for Peer {
                     // TODO: may need to fetch eagerly if we tracked while offline (#141)
                     None => PutResult::Uninteresting,
                     Some(Rev::Git(head)) => {
-                        match self.git_fetch(
-                            provider,
-                            OriginatesRef {
-                                from: &has.origin,
-                                value: &has.urn,
-                            },
-                            head,
-                        ) {
+                        let res = {
+                            let this = self.clone();
+                            let provider = provider.clone();
+                            let has = has.clone();
+                            tokio::task::spawn_blocking(move || {
+                                this.git_fetch(
+                                    &provider,
+                                    OriginatesRef {
+                                        from: &has.origin,
+                                        value: &has.urn,
+                                    },
+                                    head,
+                                )
+                            })
+                            .await
+                            .unwrap()
+                        };
+
+                        match res {
                             Ok(()) => PutResult::Applied,
                             Err(e) => match e {
                                 GitFetchError::KnownObject(_) => PutResult::Stale,
@@ -272,89 +398,39 @@ impl LocalStorage for Peer {
                     },
                 };
 
-                self.emit_event_sync(PeerEvent::GossipFetch(FetchInfo {
-                    provider: provider.clone(),
-                    gossip: has,
-                    result: res,
-                }));
+                self.subscribers
+                    .emit(PeerEvent::GossipFetch(FetchInfo {
+                        provider: provider.clone(),
+                        gossip: has,
+                        result: res,
+                    }))
+                    .await;
 
                 res
             },
         }
     }
 
-    fn ask(&self, want: Self::Update) -> bool {
+    async fn ask(&self, want: Self::Update) -> bool {
         let span = tracing::info_span!("Peer::LocalStorage::ask");
         let _guard = span.enter();
 
         match want.urn.proto {
-            uri::Protocol::Git => self.git_has(
-                &Originates {
-                    from: want.origin,
-                    value: want.urn,
-                },
-                want.rev.map(|Rev::Git(head)| head),
-            ),
+            uri::Protocol::Git => {
+                let this = self.clone();
+                tokio::task::spawn_blocking(move || {
+                    this.git_has(
+                        &Originates {
+                            from: want.origin,
+                            value: want.urn,
+                        },
+                        want.rev.map(|Rev::Git(head)| head),
+                    )
+                })
+                .await
+                .unwrap_or(false)
+            },
         }
-    }
-}
-
-/// A [`Peer`] bound to a particular [`SocketAddr`] using [`Peer::bind`] and
-/// ready to be [`BoundPeer::run`]
-pub struct BoundPeer<'a> {
-    peer_id: PeerId,
-    endpoint: BoundEndpoint<'a>,
-    protocol: Protocol<Peer, Gossip>,
-}
-
-impl<'a> BoundPeer<'a> {
-    pub fn peer_id(&self) -> &PeerId {
-        &self.peer_id
-    }
-
-    /// Inspect the bound address before calling `run`.
-    ///
-    /// Useful, for example, to obtain the actual address after having bound the
-    /// peer to `0.0.0.0:0`.
-    pub fn bound_addr(&self) -> io::Result<SocketAddr> {
-        self.endpoint.local_addr()
-    }
-
-    /// Obtain a [`Handle`] to the underlying [`Protocol`], so downstream
-    /// communication is possible after calling `run`.
-    pub fn handle(&self) -> Handle {
-        Handle(self.protocol.clone())
-    }
-
-    /// Run the protocol stack, bootstrapping from `known_peers`.
-    ///
-    /// This consumes `self`, and does not terminate unless and until the
-    /// supplied `shutdown` future resolves.
-    pub async fn run<P, S, F>(mut self, known_peers: P, shutdown: F)
-    where
-        P: IntoIterator<Item = (PeerId, S)>,
-        S: ToSocketAddrs,
-        F: Future<Output = ()> + Send + Unpin,
-    {
-        let disco = discovery::Static::new(known_peers).into_stream();
-        self.protocol.run(self.endpoint, disco, shutdown).await
-    }
-}
-
-/// A handle to the [`Protocol`] of a running [`BoundPeer`]
-pub struct Handle(Protocol<Peer, Gossip>);
-
-impl Handle {
-    pub async fn announce(&self, have: Gossip) {
-        self.0.announce(have).await
-    }
-
-    pub async fn query(&self, want: Gossip) -> impl futures::Stream<Item = gossip::Has<Gossip>> {
-        self.0.query(want).await
-    }
-
-    pub async fn subscribe(&self) -> impl futures::Stream<Item = protocol::ProtocolEvent> {
-        self.0.subscribe().await
     }
 }
 


### PR DESCRIPTION
Alright, I promise to hold off on big-ass changes like this for a while, but I felt like this one has to go in in order to enable upstream integration :)

So, this whole locking business turned out to be rather peculiar, and so I went and studied `libgit2` for a bit to see how it deals with concurrent access to a repository. The outcome is that it does account for it (and if it didn't, we'd be screwed anyway). _But_ there might be slight inconsistencies when accessing the repo with two different handles -- for example, `libgit2` goes to great lengths to detect odb changes, but _I think_ less so with the refsdb (ie. you create a branch with one handle, and _may_ not immediately see it from the other). I think this is perfectly acceptable.

Hence, this change does the following:

* The networking stack gets it's own `git2::Repository` behind a mutex (it has to `Sync` because of futures)
* After boostrapping a network `Peer` object, you obtain a `PeerApi`, which is the main (and sole) entry point for `radicle-link` applications. You can get access to a `Storage`, which is a separate instance of a `git2::Repository`, but _not_ behind a lock. You can "clone" it, which involves obtaining a new handle.
* All git operations are now implemented in terms of `Storage`, with `Repo` just being a namespace-aware wrapper.