### PR TITLE
Idempotent Track

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -358,17 +358,10 @@ impl Storage {
             "Storage::track"
         );
 
-        match self.backend.remote(&remote_name, &url) {
-            Ok(_) => Ok(()),
-            Err(err) => {
-                if err.code() == git2::ErrorCode::Exists {
-                    tracing::warn!(urn = %urn, peer = %peer, "already tracking remote");
-                    Ok(())
-                } else {
-                    Err(err.into())
-                }
-            },
-        }
+        self.backend
+            .remote(&remote_name, &url)
+            .map(|_| ())
+            .map_already_exists(|| Ok(()))
     }
 
     pub fn untrack(&self, urn: &RadUrn, peer: &PeerId) -> Result<(), Error> {

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -862,6 +862,29 @@ mod tests {
     }
 
     #[test]
+    fn test_idempotent_tracking() {
+        let tmp = tempdir().unwrap();
+        let paths = Paths::from_root(tmp).unwrap();
+        let key = SecretKey::new();
+        let store = Storage::init(&paths, key).unwrap();
+
+        let urn = RadUrn {
+            id: Hash::hash(b"lala"),
+            proto: uri::Protocol::Git,
+            path: uri::Path::empty(),
+        };
+        let peer = PeerId::from(SecretKey::new());
+
+        store.track(&urn, &peer).unwrap();
+
+        // Attempting to track again does not fail
+        store.track(&urn, &peer).unwrap();
+
+        let tracked = store.tracked(&urn).unwrap().next();
+        assert_eq!(tracked, Some(peer))
+    }
+
+    #[test]
     fn test_untrack() {
         let tmp = tempdir().unwrap();
         let paths = Paths::from_root(tmp).unwrap();


### PR DESCRIPTION
While integrating `librad` into `proxy`, I was running into an issue where tracking was attempted to be done twice on an entity. Presumably, it's because we insert the user first, then create a project with that user. But not 100% sure about this.

Either way, it seems useful for tracking to idempotent and not scream when we try to track the same peer twice.