### PR TITLE
Get entities out of the monorepo

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -1096,7 +1096,7 @@ mod tests {
         let user_commits: Vec<git2::Commit> = user_history.collect();
         assert_eq!(user_commits.len(), 1);
     }
-    
+
     #[test]
     fn test_open_or_init() {
         let tmp = tempdir().unwrap();

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -108,9 +108,8 @@ pub struct LinearHistoryCommits<'a>(Option<git2::Commit<'a>>);
 impl<'a> Iterator for LinearHistoryCommits<'a> {
     type Item = git2::Commit<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.0.as_ref().and_then(|commit| commit.parents().next());
         let result = self.0.clone();
-        self.0 = next;
+        self.0 = self.0.as_ref().and_then(|commit| commit.parents().next());
         result
     }
 }

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -108,13 +108,7 @@ pub struct LinearHistoryCommits<'a>(Option<git2::Commit<'a>>);
 impl<'a> Iterator for LinearHistoryCommits<'a> {
     type Item = git2::Commit<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self
-            .0
-            .as_ref()
-            .and_then(|commit| match commit.parents().len() {
-                1 => commit.parents().next(),
-                _ => None,
-            });
+        let next = self.0.as_ref().and_then(|commit| commit.parents().next());
         let result = self.0.clone();
         self.0 = next;
         result

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -1031,7 +1031,7 @@ mod tests {
         project_foo.sign_by_user(&user_key, &verified_user).unwrap();
         project_bar.sign_by_user(&user_key, &verified_user).unwrap();
 
-        // Sture the three entities in their respective namespaces
+        // Store the three entities in their respective namespaces
         store.create_repo(&user).unwrap();
         store.create_repo(&project_foo).unwrap();
         store.create_repo(&project_bar).unwrap();

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -53,11 +53,11 @@ fn peer_from_key(key: &SecretKey) -> PeerId {
 }
 
 lazy_static! {
-    static ref K1: SecretKey = new_key_from_seed(1);
-    static ref K2: SecretKey = new_key_from_seed(2);
-    static ref K3: SecretKey = new_key_from_seed(3);
-    static ref K4: SecretKey = new_key_from_seed(4);
-    static ref K5: SecretKey = new_key_from_seed(5);
+    pub static ref K1: SecretKey = new_key_from_seed(1);
+    pub static ref K2: SecretKey = new_key_from_seed(2);
+    pub static ref K3: SecretKey = new_key_from_seed(3);
+    pub static ref K4: SecretKey = new_key_from_seed(4);
+    pub static ref K5: SecretKey = new_key_from_seed(5);
 }
 
 lazy_static! {


### PR DESCRIPTION
The idea is to approach the problem in layers.

The lowest layer is about finding the refs (commits) that point to entity metadata branches.
This is the 1st commit here.

Then I'd build machinery that given a commit extracts a "stream" of blobs out of it (which should be the raw data of the entity revisions).
This is an upcoming commit.

At that point we can deserialize the entities out of those blobs to get a real resolver, and at that point we can add the verification process into the mix...