### PR TITLE
serde is for JSON, minicbor is for CBOR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "libgit2-sys",
  "log",
  "matches",
+ "minicbor",
  "multibase",
  "multihash",
  "nonempty 0.2.0",
@@ -874,9 +875,7 @@ dependencies = [
  "rustls",
  "secstr",
  "serde",
- "serde_cbor",
  "serde_json",
- "serde_repr",
  "sha2",
  "sodiumoxide",
  "tempfile",
@@ -955,6 +954,26 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "minicbor"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba51ba9e365147a1bfb1442afbb5d887530eee5ed7dca410c2ba365ad617083"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3436a67b46fbf4b5cc25a37341b3daf0371496dac1161422b96225dde8f603ee"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mio"
@@ -1823,17 +1842,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,7 @@ unlicensed = "deny"
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 allow = [
     "Apache-2.0",
+    "BlueOak-1.0.0",
     "BSD-2-Clause",
     "CC0-1.0",
     "GPL-2.0",

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -25,14 +25,12 @@ rand = "0.7"
 rand_pcg = "0.2"
 rcgen = "0.7"
 regex = "1.3"
-serde_cbor = "0.10"
+secstr = "0.3"
 serde_json = "1.0"
-serde_repr = "0.1"
 sha2 = "0.8"
 sodiumoxide = "0.2"
 tempfile = "3.1"
 thiserror = "1.0"
-secstr = "0.3"
 tracing = "0.1"
 urltemplate = "0.1"
 webpki = "0.21"
@@ -54,6 +52,10 @@ features = []
 version = "0.11"
 default-features = false
 features = []
+
+[dependencies.minicbor]
+version = "0.4"
+features = ["std", "derive"]
 
 [dependencies.quinn]
 version = "0.6"

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -34,3 +34,6 @@ pub mod net;
 pub mod paths;
 pub mod peer;
 pub mod uri;
+
+#[cfg(test)]
+mod test;

--- a/librad/src/net/codec.rs
+++ b/librad/src/net/codec.rs
@@ -1,0 +1,91 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{io, marker::PhantomData};
+
+use bytes::{Buf, BufMut, BytesMut};
+use futures_codec::{Decoder, Encoder};
+use minicbor::{Decode, Encode};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CborCodecError {
+    #[error(transparent)]
+    Encode(#[from] minicbor::encode::Error<io::Error>),
+
+    #[error(transparent)]
+    Decode(#[from] minicbor::decode::Error),
+
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct CborCodec<Enc, Dec> {
+    enc: PhantomData<Enc>,
+    dec: PhantomData<Dec>,
+}
+
+impl<Enc, Dec> CborCodec<Enc, Dec> {
+    pub fn new() -> Self {
+        Self {
+            enc: PhantomData,
+            dec: PhantomData,
+        }
+    }
+}
+
+impl<Enc, Dec> Encoder for CborCodec<Enc, Dec>
+where
+    Enc: Encode,
+{
+    type Item = Enc;
+    type Error = CborCodecError;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let bytes = minicbor::to_vec(&item)?;
+
+        dst.reserve(bytes.len());
+        dst.put_slice(&bytes);
+
+        Ok(())
+    }
+}
+
+impl<Enc, Dec> Decoder for CborCodec<Enc, Dec>
+where
+    for<'b> Dec: Decode<'b>,
+{
+    type Item = Dec;
+    type Error = CborCodecError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let mut decoder = minicbor::Decoder::new(src);
+
+        let res = match decoder.decode() {
+            Ok(v) => Ok(Some(v)),
+            // try later if we reach EOF prematurely
+            Err(minicbor::decode::Error::EndOfInput) => Ok(None),
+            Err(e) => Err(e.into()),
+        };
+
+        let offset = decoder.position();
+        src.advance(offset);
+
+        res
+    }
+}

--- a/librad/src/net/gossip/error.rs
+++ b/librad/src/net/gossip/error.rs
@@ -17,14 +17,12 @@
 
 use std::io;
 
-use futures_codec::CborCodecError;
 use thiserror::Error;
+
+use crate::net::codec::CborCodecError;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Invalid payload")]
-    InvalidPayload(#[source] serde_cbor::Error),
-
     #[error("Connection to self")]
     SelfConnection,
 
@@ -32,14 +30,8 @@ pub enum Error {
     StorageErrorRateLimitExceeded,
 
     #[error(transparent)]
-    Io(#[from] io::Error),
-}
+    Cbor(#[from] CborCodecError),
 
-impl From<CborCodecError> for Error {
-    fn from(err: CborCodecError) -> Self {
-        match err {
-            CborCodecError::Cbor(e) => Self::InvalidPayload(e),
-            CborCodecError::Io(e) => Self::Io(e),
-        }
-    }
+    #[error(transparent)]
+    Io(#[from] io::Error),
 }

--- a/librad/src/net/gossip/rpc.rs
+++ b/librad/src/net/gossip/rpc.rs
@@ -17,18 +17,21 @@
 
 use std::hash::Hash;
 
-use serde::{Deserialize, Serialize};
+use minicbor::{Decode, Encode};
 
 use crate::net::gossip::types::{PeerAdvertisement, PeerInfo};
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub enum Rpc<Addr, Payload>
 where
     Addr: Clone + PartialEq + Eq + Hash,
 {
-    Membership(Membership<Addr>),
-    Gossip(Gossip<Addr, Payload>),
+    #[n(0)]
+    Membership(#[n(0)] Membership<Addr>),
+
+    #[n(1)]
+    Gossip(#[n(0)] Gossip<Addr, Payload>),
 }
 
 impl<A, P> From<Membership<A>> for Rpc<A, P>
@@ -49,38 +52,65 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub enum Membership<Addr>
 where
     Addr: Clone + PartialEq + Eq + Hash,
 {
-    Join(PeerAdvertisement<Addr>),
+    #[n(0)]
+    Join(#[n(0)] PeerAdvertisement<Addr>),
+
+    #[n(1)]
+    #[cbor(array)]
     ForwardJoin {
+        #[n(0)]
         joined: PeerInfo<Addr>,
+        #[n(1)]
         ttl: usize,
     },
-    Neighbour(PeerAdvertisement<Addr>),
+
+    #[n(2)]
+    Neighbour(#[n(0)] PeerAdvertisement<Addr>),
+
+    #[n(3)]
+    #[cbor(array)]
     Shuffle {
+        #[n(0)]
         origin: PeerInfo<Addr>,
+        #[n(1)]
         peers: Vec<PeerInfo<Addr>>,
+        #[n(2)]
         ttl: usize,
     },
+
+    #[n(4)]
+    #[cbor(array)]
     ShuffleReply {
+        #[n(0)]
         peers: Vec<PeerInfo<Addr>>,
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub enum Gossip<Addr, Payload>
 where
     Addr: Clone + PartialEq + Eq + Hash,
 {
+    #[n(0)]
+    #[cbor(array)]
     Have {
+        #[n(0)]
         origin: PeerInfo<Addr>,
+        #[n(1)]
         val: Payload,
     },
+
+    #[n(1)]
+    #[cbor(array)]
     Want {
+        #[n(0)]
         origin: PeerInfo<Addr>,
+        #[n(1)]
         val: Payload,
     },
 }

--- a/librad/src/net/gossip/types.rs
+++ b/librad/src/net/gossip/types.rs
@@ -17,33 +17,40 @@
 
 use std::{collections::HashSet, hash::Hash};
 
-use serde::{Deserialize, Serialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
+use minicbor::{Decode, Encode};
 
 use crate::peer::PeerId;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Encode, Decode)]
 #[repr(u8)]
 pub enum Capability {
+    #[n(0)]
     Reserved = 0,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[cbor(array)]
 pub struct PeerInfo<Addr>
 where
     Addr: Clone + PartialEq + Eq + Hash,
 {
+    #[n(0)]
     pub peer_id: PeerId,
+    #[n(1)]
     pub advertised_info: PeerAdvertisement<Addr>,
+    #[n(2)]
     pub seen_addrs: HashSet<Addr>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[cbor(array)]
 pub struct PeerAdvertisement<Addr>
 where
     Addr: Clone + PartialEq + Eq + Hash,
 {
+    #[n(0)]
     pub listen_addr: Addr,
+    #[n(1)]
     pub capabilities: HashSet<Capability>,
 }
 

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -440,34 +440,3 @@ impl LocalStorage for PeerStorage {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use crate::{hash::Hash, keys::SecretKey, peer::PeerId, uri::Path};
-
-    #[test]
-    fn test_rev_serde() {
-        let rev = Rev::Git(git2::Oid::hash_object(git2::ObjectType::Commit, b"chrzbrr").unwrap());
-        assert_eq!(
-            rev,
-            serde_cbor::from_slice(&serde_cbor::to_vec(&rev).unwrap()).unwrap()
-        )
-    }
-
-    #[test]
-    fn test_gossip_serde() {
-        let rev = Rev::Git(git2::Oid::hash_object(git2::ObjectType::Commit, b"chrzbrr").unwrap());
-        let gossip = Gossip::new(
-            Hash::hash(b"cerveza coronita"),
-            Path::new(),
-            rev,
-            PeerId::from(SecretKey::new()),
-        );
-        assert_eq!(
-            gossip,
-            serde_cbor::from_slice(&serde_cbor::to_vec(&gossip).unwrap()).unwrap()
-        )
-    }
-}

--- a/librad/src/peer.rs
+++ b/librad/src/peer.rs
@@ -17,13 +17,15 @@
 
 use std::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
 
+use minicbor::{Decode, Encode};
 use multibase::Base::Base32Z;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::keys::{self, PublicKey, SecretKey};
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
-pub struct PeerId(PublicKey);
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Encode, Decode)]
+#[cbor(array)]
+pub struct PeerId(#[n(0)] PublicKey);
 
 impl PeerId {
     pub fn device_key(&self) -> &PublicKey {
@@ -213,6 +215,8 @@ impl<'a, T> From<&'a Originates<T>> for OriginatesRef<'a, T> {
 pub mod tests {
     use super::*;
 
+    use crate::test::*;
+
     #[test]
     fn test_default_encoding_roundtrip() {
         let peer_id1 = PeerId::from(SecretKey::new().public());
@@ -231,10 +235,12 @@ pub mod tests {
 
     #[test]
     fn test_str_roundtrip() {
-        let peer_id1 = PeerId::from(SecretKey::new().public());
-        let peer_id2 = PeerId::from_str(&peer_id1.to_string()).unwrap();
+        str_roundtrip(PeerId::from(SecretKey::new().public()));
+    }
 
-        assert_eq!(peer_id1, peer_id2)
+    #[test]
+    fn test_cbor_roundtrip() {
+        cbor_roundtrip(PeerId::from(SecretKey::new().public()))
     }
 
     #[test]

--- a/librad/src/test.rs
+++ b/librad/src/test.rs
@@ -15,13 +15,35 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod connection;
-pub mod discovery;
-pub mod gossip;
-pub mod peer;
-pub mod protocol;
-pub mod quic;
-pub mod tls;
-pub mod upgrade;
+//! Common testing utilities
 
-mod codec;
+#[cfg(test)]
+use std::{
+    fmt::{Debug, Display},
+    str::FromStr,
+};
+
+pub(crate) fn json_roundtrip<A>(a: A)
+where
+    for<'de> A: Debug + PartialEq + serde::Serialize + serde::Deserialize<'de>,
+{
+    assert_eq!(
+        a,
+        serde_json::from_str(&serde_json::to_string(&a).unwrap()).unwrap()
+    )
+}
+
+pub(crate) fn cbor_roundtrip<A>(a: A)
+where
+    for<'de> A: Debug + PartialEq + minicbor::Encode + minicbor::Decode<'de>,
+{
+    assert_eq!(a, minicbor::decode(&minicbor::to_vec(&a).unwrap()).unwrap())
+}
+
+pub(crate) fn str_roundtrip<A>(a: A)
+where
+    A: Debug + PartialEq + Display + FromStr,
+    <A as FromStr>::Err: Debug,
+{
+    assert_eq!(a, a.to_string().parse().unwrap())
+}


### PR DESCRIPTION
Fixes #102 

Why only `serde` is not sufficient is described exhaustively in #102. I did consider alternatives, but still think CBOR is preferable:

* `protobufs` tend to be way less expressive than the target language, leading to wrapper boilerplate. For us specifically, the lack of generics and "real" union types are at least annoying. Some of this could be worked around in Rust using derive macros, but we'd loose the main advantage over CBOR today, which is an IDL.

* `flatbuffers` are really quite heavyweight to use, and we don't need the extra memory efficiency. Also no generics.

* `cap'n'proto` is even more efficient than `flatbuffers`, has all the expressivity one would want -- but is pretty much overkill for our use cases (also a bit niche). 