### PR TITLE
Check if a fetch triggered by gossip actually applied the value

### DIFF
--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -423,20 +423,13 @@ impl LocalStorage for PeerStorage {
         let _guard = span.enter();
 
         match want.urn.proto {
-            uri::Protocol::Git => {
-                let this = self.clone();
-                tokio::task::spawn_blocking(move || {
-                    this.git_has(
-                        &Originates {
-                            from: want.origin,
-                            value: want.urn,
-                        },
-                        want.rev.map(|Rev::Git(head)| head),
-                    )
-                })
-                .await
-                .unwrap_or(false)
-            },
+            uri::Protocol::Git => self.git_has(
+                &Originates {
+                    from: want.origin,
+                    value: want.urn,
+                },
+                want.rev.map(|Rev::Git(head)| head),
+            ),
         }
     }
 }


### PR DESCRIPTION
Otherwise, pretend we've already seen it -- which just means to stop propagating the gossip here. We know at this point that the provider either lied, or the ref was already gone before we could fetch it. In either case, and since there was no error, noone else should be able to get the data from the provider either. And since we don't have it, neither from us.