### PR TITLE
Gossip only `IpAddr`s, not `SocketAddr`s

### DIFF
--- a/librad/src/net/connection.rs
+++ b/librad/src/net/connection.rs
@@ -15,7 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::io;
+use std::{
+    io,
+    net::{IpAddr, SocketAddr},
+};
 
 use crate::peer::PeerId;
 use futures::io::{AsyncRead, AsyncWrite};
@@ -32,6 +35,16 @@ pub trait RemoteInfo {
 
     fn remote_peer_id(&self) -> &PeerId;
     fn remote_addr(&self) -> Self::Addr;
+}
+
+pub trait AsAddr<A> {
+    fn as_addr(&self) -> A;
+}
+
+impl AsAddr<IpAddr> for SocketAddr {
+    fn as_addr(&self) -> IpAddr {
+        self.ip()
+    }
 }
 
 pub trait Stream: RemoteInfo + AsyncRead + AsyncWrite + Unpin + Send + Sync + Sized {

--- a/librad/src/net/gossip/types.rs
+++ b/librad/src/net/gossip/types.rs
@@ -50,7 +50,11 @@ where
 {
     #[n(0)]
     pub listen_addr: Addr,
+
     #[n(1)]
+    pub listen_port: u16,
+
+    #[n(2)]
     pub capabilities: HashSet<Capability>,
 }
 
@@ -58,9 +62,10 @@ impl<Addr> PeerAdvertisement<Addr>
 where
     Addr: Clone + PartialEq + Eq + Hash,
 {
-    pub fn new(listen_addr: Addr) -> Self {
+    pub fn new(listen_addr: Addr, listen_port: u16) -> Self {
         Self {
             listen_addr,
+            listen_port,
             capabilities: HashSet::default(),
         }
     }

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -259,7 +259,7 @@ impl Peer {
 
         let gossip = gossip::Protocol::new(
             &peer_id,
-            gossip::PeerAdvertisement::new(listen_addr),
+            gossip::PeerAdvertisement::new(listen_addr.ip(), listen_addr.port()),
             config.gossip_params,
             peer_storage,
         );


### PR DESCRIPTION
Tracking ports will only become relevant after #66 (hole punching), and are plain wrong currently.