### PR TITLE
Split git-related things into modules + add more test utils

### DIFF
--- a/librad/src/git/ext/blob.rs
+++ b/librad/src/git/ext/blob.rs
@@ -1,0 +1,135 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{borrow::Cow, path::Path};
+
+use thiserror::Error;
+
+use crate::{
+    git::ext::{error::is_not_found_err, revwalk},
+    internal::result::ResultExt,
+};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    NotFound(#[from] NotFound),
+
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum NotFound {
+    #[error("Blob with path {0} not found")]
+    NoSuchBlob(String),
+
+    #[error("Branch {0} not found")]
+    NoSuchBranch(String),
+
+    #[error("The supplied git2::Reference does not have a target")]
+    NoRefTarget,
+}
+
+pub enum Branch<'a> {
+    Name(Cow<'a, str>),
+    Ref(git2::Reference<'a>),
+}
+
+impl<'a> From<&'a str> for Branch<'a> {
+    fn from(s: &'a str) -> Self {
+        Self::Name(Cow::Borrowed(s))
+    }
+}
+
+impl<'a> From<String> for Branch<'a> {
+    fn from(s: String) -> Self {
+        Self::Name(Cow::Owned(s))
+    }
+}
+
+impl<'a> From<git2::Reference<'a>> for Branch<'a> {
+    fn from(r: git2::Reference<'a>) -> Self {
+        Self::Ref(r)
+    }
+}
+
+pub enum Blob<'a> {
+    Tip { branch: Branch<'a>, path: &'a Path },
+    Init { branch: Branch<'a>, path: &'a Path },
+}
+
+impl<'a> Blob<'a> {
+    pub fn get(self, git: &'a git2::Repository) -> Result<git2::Blob<'a>, Error> {
+        match self {
+            Self::Tip { branch, path } => {
+                let reference = match branch {
+                    Branch::Name(name) => {
+                        git.find_reference(&name).or_matches(is_not_found_err, || {
+                            Err(Error::NotFound(NotFound::NoSuchBranch(
+                                name.to_owned().to_string(),
+                            )))
+                        })
+                    },
+
+                    Branch::Ref(reference) => Ok(reference),
+                }?;
+                let tree = reference.peel_to_tree()?;
+                blob(git, tree, path)
+            },
+
+            Self::Init { branch, path } => {
+                let start = match branch {
+                    Branch::Name(name) => Ok(revwalk::Start::Ref(name.to_string())),
+                    Branch::Ref(reference) => {
+                        match (reference.target(), reference.symbolic_target()) {
+                            (Some(oid), _) => Ok(revwalk::Start::Oid(oid)),
+                            (_, Some(sym)) => Ok(revwalk::Start::Ref(sym.to_string())),
+                            (_, _) => Err(Error::NotFound(NotFound::NoRefTarget)),
+                        }
+                    },
+                }?;
+
+                let revwalk = revwalk::FirstParent::new(git, start)?.reverse()?;
+                match revwalk.into_iter().next() {
+                    None => Err(Error::NotFound(NotFound::NoSuchBlob(
+                        path.display().to_string(),
+                    ))),
+                    Some(oid) => {
+                        let oid = oid?;
+                        let tree = git.find_commit(oid)?.tree()?;
+                        blob(git, tree, path)
+                    },
+                }
+            },
+        }
+    }
+}
+
+fn blob<'a>(
+    repo: &'a git2::Repository,
+    tree: git2::Tree<'a>,
+    path: &'a Path,
+) -> Result<git2::Blob<'a>, Error> {
+    let entry = tree.get_path(path).or_matches(is_not_found_err, || {
+        Err(Error::NotFound(NotFound::NoSuchBlob(
+            path.display().to_string(),
+        )))
+    })?;
+
+    entry.to_object(repo)?.peel_to_blob().map_err(Error::from)
+}

--- a/librad/src/git/ext/error.rs
+++ b/librad/src/git/ext/error.rs
@@ -15,16 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Extensions and wrappers for `git2` types
+pub fn is_not_found_err(e: &git2::Error) -> bool {
+    e.code() == git2::ErrorCode::NotFound
+}
 
-pub mod blob;
-pub mod error;
-pub mod oid;
-pub mod reference;
-pub mod revwalk;
-
-pub use blob::*;
-pub use error::*;
-pub use oid::*;
-pub use reference::*;
-pub use revwalk::*;
+pub fn is_exists_err(e: &git2::Error) -> bool {
+    e.code() == git2::ErrorCode::Exists
+}

--- a/librad/src/git/ext/oid.rs
+++ b/librad/src/git/ext/oid.rs
@@ -1,0 +1,73 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{fmt, ops::Deref};
+
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+/// Serializable [`git2::Oid`]
+#[derive(Debug)]
+pub struct Oid(pub git2::Oid);
+
+impl Serialize for Oid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Oid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct OidVisitor;
+
+        impl<'de> Visitor<'de> for OidVisitor {
+            type Value = Oid;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "a hexidecimal git2::Oid")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                s.parse().map(Oid).map_err(serde::de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(OidVisitor)
+    }
+}
+
+impl Deref for Oid {
+    type Target = git2::Oid;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<git2::Oid> for Oid {
+    fn as_ref(&self) -> &git2::Oid {
+        self
+    }
+}

--- a/librad/src/git/ext/reference.rs
+++ b/librad/src/git/ext/reference.rs
@@ -1,0 +1,110 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::internal::borrow::TryToOwned;
+
+/// Iterator chaining multiple [`git2::References`]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub struct References<'a> {
+    inner: Vec<git2::References<'a>>,
+}
+
+impl<'a> References<'a> {
+    pub fn new(refs: impl IntoIterator<Item = git2::References<'a>>) -> Self {
+        Self {
+            inner: refs.into_iter().collect(),
+        }
+    }
+
+    pub fn from_globs(
+        repo: &'a git2::Repository,
+        globs: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<Self, git2::Error> {
+        let globs = globs.into_iter();
+        let mut iters = globs
+            .size_hint()
+            .1
+            .map(Vec::with_capacity)
+            .unwrap_or_else(Vec::new);
+        for glob in globs {
+            let iter = repo.references_glob(glob.as_ref())?;
+            iters.push(iter);
+        }
+
+        Ok(Self::new(iters))
+    }
+
+    pub fn names<'b>(&'b mut self) -> ReferenceNames<'a, 'b> {
+        ReferenceNames {
+            inner: self.inner.iter_mut().map(|refs| refs.names()).collect(),
+        }
+    }
+
+    pub fn peeled(self) -> impl Iterator<Item = (String, git2::Oid)> + 'a {
+        self.filter_map(|reference| {
+            reference.ok().and_then(|head| {
+                head.name().and_then(|name| {
+                    head.target()
+                        .map(|target| (name.to_owned(), target.to_owned()))
+                })
+            })
+        })
+    }
+}
+
+impl<'a> Iterator for References<'a> {
+    type Item = Result<git2::Reference<'a>, git2::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.pop().and_then(|mut iter| match iter.next() {
+            None => self.next(),
+            Some(item) => {
+                self.inner.push(iter);
+                Some(item)
+            },
+        })
+    }
+}
+
+/// Iterator chaining multiple [`git2::ReferenceNames`]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub struct ReferenceNames<'repo, 'references> {
+    inner: Vec<git2::ReferenceNames<'repo, 'references>>,
+}
+
+impl<'a, 'b> Iterator for ReferenceNames<'a, 'b> {
+    type Item = Result<&'b str, git2::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.pop().and_then(|mut iter| match iter.next() {
+            None => self.next(),
+            Some(item) => {
+                self.inner.push(iter);
+                Some(item)
+            },
+        })
+    }
+}
+
+impl TryToOwned for git2::Repository {
+    type Owned = git2::Repository;
+    type Error = git2::Error;
+
+    fn try_to_owned(&self) -> Result<Self::Owned, Self::Error> {
+        git2::Repository::open(self.path())
+    }
+}

--- a/librad/src/git/ext/revwalk.rs
+++ b/librad/src/git/ext/revwalk.rs
@@ -1,0 +1,56 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pub enum Start {
+    Oid(git2::Oid),
+    Ref(String),
+}
+
+pub struct FirstParent<'a> {
+    inner: git2::Revwalk<'a>,
+}
+
+impl<'a> FirstParent<'a> {
+    pub fn new(repo: &'a git2::Repository, start: Start) -> Result<Self, git2::Error> {
+        let mut revwalk = repo.revwalk()?;
+        revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+        revwalk.simplify_first_parent()?;
+
+        match start {
+            Start::Oid(oid) => revwalk.push(oid),
+            Start::Ref(name) => revwalk.push_ref(&name),
+        }?;
+
+        Ok(Self { inner: revwalk })
+    }
+
+    pub fn reverse(mut self) -> Result<Self, git2::Error> {
+        let mut sort = git2::Sort::TOPOLOGICAL;
+        sort.insert(git2::Sort::REVERSE);
+        self.inner.set_sorting(sort)?;
+        Ok(self)
+    }
+}
+
+impl<'a> IntoIterator for FirstParent<'a> {
+    type Item = Result<git2::Oid, git2::Error>;
+    type IntoIter = git2::Revwalk<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner
+    }
+}

--- a/librad/src/git/storage/test.rs
+++ b/librad/src/git/storage/test.rs
@@ -1,0 +1,199 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use std::str::FromStr;
+
+use futures_await_test::async_test;
+
+use crate::{
+    hash::Hash,
+    meta::{entity::Draft, Project, User},
+    test::{ConstResolver, WithTmpDir},
+    uri::{self, RadUrn},
+};
+
+type TmpStorage = WithTmpDir<Storage>;
+
+fn storage() -> TmpStorage {
+    WithTmpDir::new(|path| {
+        let paths = Paths::from_root(path)?;
+        Storage::init(&paths, SecretKey::new())
+    })
+    .unwrap()
+}
+
+fn urn_from_idref(refname: &str) -> Option<RadUrn> {
+    refname
+        .strip_suffix("/refs/rad/id")
+        .and_then(|namespace_root| {
+            namespace_root
+                .split('/')
+                .next_back()
+                .and_then(|namespace| Hash::from_str(namespace).ok())
+                .map(|hash| RadUrn::new(hash, uri::Protocol::Git, uri::Path::empty()))
+        })
+}
+
+#[test]
+fn test_tracking_read_after_write() {
+    let store = storage();
+    let urn = RadUrn {
+        id: Hash::hash(b"lala"),
+        proto: uri::Protocol::Git,
+        path: uri::Path::empty(),
+    };
+    let peer = PeerId::from(SecretKey::new());
+
+    store.track(&urn, &peer).unwrap();
+    let tracked = store.tracked(&urn).unwrap().next();
+    assert_eq!(tracked, Some(peer))
+}
+
+#[test]
+fn test_idempotent_tracking() {
+    let store = storage();
+    let urn = RadUrn {
+        id: Hash::hash(b"lala"),
+        proto: uri::Protocol::Git,
+        path: uri::Path::empty(),
+    };
+    let peer = PeerId::from(SecretKey::new());
+
+    store.track(&urn, &peer).unwrap();
+
+    // Attempting to track again does not fail
+    store.track(&urn, &peer).unwrap();
+
+    let tracked = store.tracked(&urn).unwrap().next();
+    assert_eq!(tracked, Some(peer))
+}
+
+#[test]
+fn test_untrack() {
+    let store = storage();
+    let urn = RadUrn {
+        id: Hash::hash(b"lala"),
+        proto: uri::Protocol::Git,
+        path: uri::Path::empty(),
+    };
+    let peer = PeerId::from(SecretKey::new());
+
+    store.track(&urn, &peer).unwrap();
+    store.untrack(&urn, &peer).unwrap();
+
+    assert!(store.tracked(&urn).unwrap().next().is_none())
+}
+
+#[async_test]
+async fn test_all_metadata_heads() {
+    let store = storage();
+
+    // Create signed and verified user
+    let mut user = User::<Draft>::create("user".to_owned(), store.key.public()).unwrap();
+    user.sign_owned(&store.key).unwrap();
+    let user_resolver = ConstResolver::new(user.clone());
+    let verified_user = user
+        .clone()
+        .check_history_status(&user_resolver, &user_resolver)
+        .await
+        .unwrap();
+
+    // Create and sign two projects
+    let mut project_foo = Project::<Draft>::create("foo".to_owned(), user.urn()).unwrap();
+    let mut project_bar = Project::<Draft>::create("bar".to_owned(), user.urn()).unwrap();
+    project_foo
+        .sign_by_user(&store.key, &verified_user)
+        .unwrap();
+    project_bar
+        .sign_by_user(&store.key, &verified_user)
+        .unwrap();
+
+    // Store the three entities in their respective namespaces
+    println!("poop");
+    store.create_repo(&user).unwrap();
+    println!("piep");
+    store.create_repo(&project_foo).unwrap();
+    store.create_repo(&project_bar).unwrap();
+
+    let mut ids = HashSet::new();
+    let mut urns = HashMap::new();
+    ids.insert(user.hash());
+    ids.insert(project_foo.hash());
+    ids.insert(project_bar.hash());
+
+    // Iterate ove all namespaces
+    let all_metadata_heads =
+        References::from_globs(&store.backend, &["refs/namespaces/*/refs/rad/id"])
+            .unwrap()
+            .peeled()
+            .filter_map(|(refname, oid)| {
+                urn_from_idref(&refname).and_then(|urn| {
+                    store
+                        .backend
+                        .find_commit(oid)
+                        .map(|commit| (urn, commit))
+                        .ok()
+                })
+            });
+    for (urn, commit) in all_metadata_heads {
+        // Check that we found one of our IDs
+        let id = &urn.id;
+        assert!(ids.contains(id));
+
+        // Check that we can use the URN to find the same commit
+        let commit_from_urn = Reference::rad_id(urn.id.clone())
+            .find(&store.backend)
+            .unwrap()
+            .target()
+            .unwrap();
+        assert_eq!(commit_from_urn, commit.id());
+
+        // Bookkeeping for more tests
+        ids.remove(id);
+        urns.insert(id.to_owned(), urn);
+    }
+
+    // Check that we found all the entities that we saved
+    assert!(ids.is_empty());
+
+    // Pull out user blob and deserialize
+    assert_eq!(user, store.metadata(&user.urn()).unwrap());
+    let generic_user = store.some_metadata(&user.urn()).unwrap();
+    assert_eq!(generic_user.kind(), user.kind());
+    assert_eq!(generic_user.hash(), user.hash());
+
+    // Pull out foo blob and deserialize
+    assert_eq!(project_foo, store.metadata(&project_foo.urn()).unwrap());
+    let generic_foo = store.some_metadata(&project_foo.urn()).unwrap();
+    assert_eq!(generic_foo.kind(), project_foo.kind());
+    assert_eq!(generic_foo.hash(), project_foo.hash());
+
+    // Check user commit history length
+    let user_history = {
+        let rad_id = Reference::rad_id(user.urn().id);
+
+        let mut revwalk = store.backend.revwalk().unwrap();
+        revwalk.set_sorting(git2::Sort::TOPOLOGICAL).unwrap();
+        revwalk.simplify_first_parent().unwrap();
+        revwalk.push_ref(&rad_id.to_string()).unwrap();
+
+        revwalk.collect::<Vec<_>>()
+    };
+    assert_eq!(user_history.len(), 1);
+}

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -20,7 +20,12 @@ use std::{
     fmt::{self, Display},
 };
 
-use crate::{git::refs::Refs, hash::Hash, peer::PeerId, uri::RadUrn};
+use crate::{
+    git::{ext, refs::Refs},
+    hash::Hash,
+    peer::PeerId,
+    uri::RadUrn,
+};
 
 pub type Namespace = Hash;
 
@@ -59,6 +64,10 @@ impl Display for Reference {
 }
 
 impl Reference {
+    pub fn find<'a>(&self, repo: &'a git2::Repository) -> Result<git2::Reference<'a>, git2::Error> {
+        repo.find_reference(&self.to_string())
+    }
+
     pub fn rad_id(namespace: Namespace) -> Self {
         Self {
             namespace,
@@ -117,6 +126,12 @@ impl Reference {
             name: name.to_owned(),
             ..self.clone()
         }
+    }
+}
+
+impl<'a> Into<ext::blob::Branch<'a>> for &'a Reference {
+    fn into(self) -> ext::blob::Branch<'a> {
+        ext::blob::Branch::from(self.to_string())
     }
 }
 


### PR DESCRIPTION
In a desperate attempt to stay on top of the recent outbreak of productivity, and to minimise the amount of merge conflicts, I am:

* Splitting up "utitility" things into (a lot of) separate modules
* Imposing my own naming preferences
* Reducing some duplication
