### PR TITLE
Pass secret key to storage only where needed

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -19,6 +19,7 @@ use std::{
     borrow::Borrow,
     collections::{BTreeMap, HashMap, HashSet},
     io,
+    marker::PhantomData,
     ops::{Deref, Range},
     path::Path,
 };
@@ -50,7 +51,7 @@ use crate::{
     keys::SecretKey,
     meta::entity::{self, data::EntityInfoExt, Draft, Entity, GenericDraftEntity, Signatory},
     paths::Paths,
-    peer::PeerId,
+    peer::{self, PeerId},
     uri::{self, RadUrl, RadUrn},
 };
 
@@ -69,6 +70,15 @@ pub enum Error {
 
     #[error("Metadata is not signed")]
     UnsignedMetadata,
+
+    #[error("Signer key does not match key used at initialisation")]
+    SignerKeyMismatch,
+
+    #[error("Can't refer to the local key for this operation")]
+    SelfReferential,
+
+    #[error(transparent)]
+    PeerId(#[from] peer::conversion::Error),
 
     #[error(transparent)]
     Urn(#[from] uri::rad_urn::ParseError),
@@ -95,13 +105,17 @@ pub enum Error {
     Io(#[from] io::Error),
 }
 
-pub struct Storage {
+pub type NoSigner = PhantomData<!>;
+pub type WithSigner = SecretKey;
+
+pub struct Storage<S> {
     pub(super) backend: git2::Repository,
-    pub(crate) key: SecretKey,
+    peer_id: PeerId,
+    signer: S,
 }
 
 // FIXME(kim): we really don't want to export this
-impl Deref for Storage {
+impl<S> Deref for Storage<S> {
     type Target = git2::Repository;
 
     fn deref(&self) -> &Self::Target {
@@ -109,196 +123,36 @@ impl Deref for Storage {
     }
 }
 
-impl AsRef<git2::Repository> for Storage {
+impl<S> AsRef<git2::Repository> for Storage<S> {
     fn as_ref(&self) -> &git2::Repository {
         self
     }
 }
 
-impl Storage {
-    /// Open the `Storage` found at the given [`Paths`]'s `git_dir`.
-    /// If the path does not exist we initialise the `Storage` with
-    /// [`Storage::init`].
-    pub fn open(paths: &Paths, key: SecretKey) -> Result<Self, Error> {
-        git2::Repository::open_bare(paths.git_dir())
-            .map(|backend| Self {
-                backend,
-                key: key.clone(),
-            })
-            .or_matches(is_not_found_err, || Ok(Self::init(paths, key)?))
-    }
-
+impl<S: Clone> Storage<S> {
     /// Obtain a new, owned handle to the backing store.
     pub fn reopen(&self) -> Result<Self, Error> {
         self.try_to_owned()
     }
 
-    /// Initialise the `Storage` at the given [`Paths`]'s `git_dir`.
-    pub fn init(paths: &Paths, key: SecretKey) -> Result<Self, Error> {
-        let repo = git2::Repository::init_opts(
-            paths.git_dir(),
-            git2::RepositoryInitOptions::new()
-                .bare(true)
-                .no_reinit(true)
-                .external_template(false),
-        )?;
-
-        let mut config = repo.config()?;
-        config.set_str("user.name", "radicle")?;
-        config.set_str("user.email", &format!("radicle@{}", PeerId::from(&key)))?;
-
-        Ok(Self { backend: repo, key })
+    pub fn peer_id(&self) -> &PeerId {
+        &self.peer_id
     }
 
-    pub fn create_repo<T>(&self, meta: &Entity<T, Draft>) -> Result<Repo, Error>
-    where
-        T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
-    {
-        let span = tracing::info_span!("Storage::create_repo");
-        let _guard = span.enter();
-
-        // FIXME: properly verify meta
-
-        if meta.signatures().is_empty() {
-            return Err(Error::UnsignedMetadata);
-        }
-
-        // FIXME: certifier identities must exist, or be supplied
-
-        let urn = RadUrn::new(
-            meta.root_hash().to_owned(),
-            uri::Protocol::Git,
-            uri::Path::empty(),
-        );
-
-        self.commit_initial_meta(&meta)?;
-        self.track_signers(&meta)?;
-        self.update_refs(&urn)?;
-
-        Ok(Repo {
-            urn,
-            storage: self.into(),
-        })
-    }
-
-    pub fn open_repo(&self, urn: RadUrn) -> Result<Repo, Error> {
-        {
-            let id_ref = Reference::rad_id(urn.id.clone());
-            if !self.has_ref(&id_ref)? {
-                return Err(Error::NoSuchUrn(urn));
-            }
-        }
-
-        Ok(Repo {
-            urn: RadUrn {
-                path: uri::Path::empty(),
-                ..urn
-            },
-            storage: self.into(),
-        })
-    }
-
-    /// Attempt to clone the designated repo from the network.
-    ///
-    /// Note that this method **must** be spawned on a `async` runtime, where
-    /// currently the only supported method is [`tokio::task::spawn_blocking`].
-    pub fn clone_repo<T>(&self, url: RadUrl) -> Result<Repo, Error>
-    where
-        T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
-    {
-        let span = tracing::info_span!("Storage::clone_repo", url = %url);
-        let _guard = span.enter();
-
-        let local_peer_id = PeerId::from(&self.key);
+    pub fn open_repo(&self, urn: RadUrn) -> Result<Repo<S>, Error> {
         let urn = RadUrn {
             path: uri::Path::empty(),
-            ..url.urn.clone()
+            ..urn
         };
 
-        // Fetch the identity first
-        let git_url = GitUrlRef::from_rad_url_ref(url.as_ref(), &local_peer_id);
-        let meta: Entity<T, Draft> = self.fetch_id(git_url)?;
-
-        // TODO: properly verify meta
-
-        if meta.signatures().is_empty() {
-            return Err(Error::UnsignedMetadata);
+        if !self.has_urn(&urn)? {
+            return Err(Error::NoSuchUrn(urn));
         }
-
-        if meta.root_hash() != &url.urn.id {
-            return Err(Error::RootHashMismatch {
-                expected: url.urn.id.to_owned(),
-                actual: meta.root_hash().to_owned(),
-            });
-        }
-
-        self.track_signers(&meta)?;
-        self.update_refs(&urn)?;
-        self.fetch_repo(&urn, &url.authority)?;
 
         Ok(Repo {
             urn,
             storage: self.into(),
         })
-    }
-
-    pub fn fetch_repo(&self, urn: &RadUrn, from: &PeerId) -> Result<(), Error> {
-        let span = tracing::info_span!("Storage::fetch", fetch.urn = %urn, fetch.from = %from);
-        let _guard = span.enter();
-
-        let namespace = &urn.id;
-
-        let mut remote = {
-            let local_peer = PeerId::from(&self.key);
-            let url = GitUrlRef::from_rad_url_ref(urn.as_rad_url_ref(from), &local_peer);
-            self.remote_anonymous(&url.to_string())
-        }?;
-        remote.connect(git2::Direction::Fetch)?;
-
-        let rad_refs = self.rad_refs(urn)?;
-        let tracked_trans = rad_refs.remotes.flatten().collect::<HashSet<&PeerId>>();
-
-        // Fetch rad/refs of all known remotes
-        {
-            let refspecs =
-                Refspec::rad_refs(namespace.clone(), from, tracked_trans.iter().cloned())
-                    .map(|spec| spec.to_string())
-                    .collect::<Vec<String>>();
-            tracing::debug!(refspecs = ?refspecs, "Fetching rad/refs");
-            remote.fetch(&refspecs, Some(&mut self.fetch_options()), None)?;
-        }
-
-        // Read the signed refs of all known remotes, and compare their `heads`
-        // against the advertised refs. If signed and advertised branch head
-        // match, non-fast-forwards are permitted. Otherwise, the branch is
-        // skipped.
-        {
-            let remote_heads: HashMap<&str, git2::Oid> = remote
-                .list()?
-                .iter()
-                .map(|rhead| (rhead.name(), rhead.oid()))
-                .collect();
-
-            let refspecs = Refspec::fetch_heads(
-                namespace.clone(),
-                remote_heads,
-                tracked_trans.iter().cloned(),
-                from,
-                |peer| self.rad_refs_of(urn, peer),
-                |peer| self.certifiers_of(urn, peer),
-            )?
-            .map(|spec| spec.to_string())
-            .collect::<Vec<String>>();
-
-            tracing::debug!(refspecs = ?refspecs, "Fetching refs/heads");
-            remote.fetch(&refspecs, Some(&mut self.fetch_options()), None)?;
-        }
-
-        // At this point, the transitive tracking graph may have changed. Let's
-        // update the refs, but don't recurse here for now (we could, if
-        // we reload `self.refs()` and compare to the value we had
-        // before fetching).
-        self.update_refs(urn)
     }
 
     /// Get a [`surf::Browser`] for the project at `urn`. The `Browser` will be
@@ -312,179 +166,6 @@ impl Storage {
             &namespace,
             revision,
         )?)
-    }
-
-    // Utils
-
-    pub fn has_commit(&self, urn: &RadUrn, oid: git2::Oid) -> Result<bool, Error> {
-        let span = tracing::warn_span!("Storage::has_commit", urn = %urn, oid = %oid);
-        let _guard = span.enter();
-
-        if oid.is_zero() {
-            return Ok(false);
-        }
-
-        let commit = self.backend.find_commit(oid);
-        match commit {
-            Err(e) if is_not_found_err(&e) => {
-                tracing::warn!("commit not found");
-                Ok(false)
-            },
-            Ok(commit) => {
-                let namespace = &urn.id;
-                let branch = urn.path.deref_or_default();
-                let branch = branch.strip_prefix("refs/").unwrap_or(branch);
-
-                let refs = References::from_globs(
-                    &self.backend,
-                    &[format!("refs/namespaces/{}/refs/{}", namespace, branch)],
-                )?;
-
-                for (_, oid) in refs.peeled() {
-                    if oid == commit.id() || self.backend.graph_descendant_of(oid, commit.id())? {
-                        return Ok(true);
-                    }
-                }
-
-                Ok(false)
-            },
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    pub fn has_ref(&self, reference: &Reference) -> Result<bool, Error> {
-        self.backend
-            .find_reference(&reference.to_string())
-            .map(|_| true)
-            .or_matches(is_not_found_err, || Ok(false))
-    }
-
-    pub fn has_urn(&self, urn: &RadUrn) -> Result<bool, Error> {
-        let namespace = &urn.id;
-        let branch = urn.path.deref_or_default();
-        let branch = branch.strip_prefix("refs/").unwrap_or(branch);
-        self.backend
-            .find_reference(&format!("refs/namespaces/{}/refs/{}", namespace, branch))
-            .map(|_| true)
-            .or_matches(is_not_found_err, || Ok(false))
-    }
-
-    pub fn track(&self, urn: &RadUrn, peer: &PeerId) -> Result<(), Error> {
-        let remote_name = tracking_remote_name(urn, peer);
-        let url = GitUrlRef::from_rad_urn(&urn, &PeerId::from(&self.key), peer).to_string();
-
-        tracing::debug!(
-            urn = %urn,
-            peer = %peer,
-            "Storage::track"
-        );
-
-        self.backend
-            .remote(&remote_name, &url)
-            .map(|_| ())
-            .or_matches(is_exists_err, || Ok(()))
-    }
-
-    pub fn untrack(&self, urn: &RadUrn, peer: &PeerId) -> Result<(), Error> {
-        let remote_name = tracking_remote_name(urn, peer);
-        // TODO: This removes all remote tracking branches matching the
-        // fetchspec (I suppose). Not sure this is what we want.
-        self.backend
-            .remote_delete(&remote_name)
-            .map_err(|e| e.into())
-    }
-
-    pub fn tracked(&self, urn: &RadUrn) -> Result<Tracked, Error> {
-        Tracked::collect(&self.backend, urn).map_err(|e| e.into())
-    }
-
-    /// Read the current [`Refs`] from the repo state
-    pub fn rad_refs(&self, urn: &RadUrn) -> Result<Refs, Error> {
-        let span = tracing::debug_span!("Storage::rad_refs", urn = %urn);
-        let _guard = span.enter();
-
-        // Collect refs/heads (our branches) at their current state
-        let heads = self.references_glob(urn, Some("refs/heads/*"))?;
-        let heads: BTreeMap<String, Oid> = heads.map(|(name, oid)| (name, Oid(oid))).collect();
-
-        tracing::debug!(heads = ?heads);
-
-        // Get 1st degree tracked peers from the remotes configured in .git/config
-        let tracked = self.tracked(urn)?;
-        let mut remotes: HashMap<PeerId, HashMap<PeerId, HashSet<PeerId>>> =
-            tracked.map(|peer| (peer, HashMap::new())).collect();
-
-        tracing::debug!(remotes.bare = ?remotes);
-
-        // For each of the 1st degree tracked peers, lookup their rad/refs (if any),
-        // verify the signature, and add their [`Remotes`] to ours (minus the 3rd
-        // degree)
-        for (peer, tracked) in remotes.iter_mut() {
-            match self.rad_refs_of(urn, peer.clone()) {
-                Ok(refs) => *tracked = refs.remotes.cutoff(),
-                Err(Error::Blob(blob::Error::NotFound(_))) => {},
-                Err(e) => return Err(e),
-            }
-        }
-
-        tracing::debug!(remotes.verified = ?remotes);
-
-        Ok(Refs {
-            heads,
-            remotes: remotes.into(),
-        })
-    }
-
-    pub fn rad_refs_of(&self, urn: &RadUrn, peer: PeerId) -> Result<Refs, Error> {
-        let signed = {
-            let refs = Reference::rad_refs(urn.id.clone(), peer.clone());
-            let blob = Blob::Tip {
-                branch: refs.borrow().into(),
-                path: Path::new("refs"),
-            }
-            .get(&self)?;
-            refs::Signed::from_json(blob.content(), &peer)
-        }?;
-
-        Ok(Refs::from(signed))
-    }
-
-    /// The set of all certifiers of the given identity, transitively
-    pub fn certifiers(&self, urn: &RadUrn) -> Result<HashSet<RadUrn>, Error> {
-        let mut refs = References::from_globs(
-            &self,
-            &[
-                format!("refs/namespaces/{}/refs/rad/ids/*", &urn.id),
-                format!("refs/namespaces/{}/refs/remotes/**/rad/ids/*", &urn.id),
-            ],
-        )?;
-        let refnames = refs.names();
-        Ok(urns_from_refs(refnames).collect())
-    }
-
-    // FIXME: REMOVE
-    pub fn commit(
-        &self,
-        urn: &RadUrn,
-        branch: &str,
-        msg: &str,
-        tree: &git2::Tree,
-        parents: &[&git2::Commit],
-    ) -> Result<git2::Oid, Error> {
-        let author = self.signature()?;
-        let head = Reference::head(urn.id.clone(), None, branch);
-        let oid = self.backend.commit(
-            Some(&head.to_string()),
-            &author,
-            &author,
-            msg,
-            tree,
-            parents,
-        )?;
-
-        self.update_refs(urn)?;
-
-        Ok(oid)
     }
 
     /// Get the [`Entity`] metadata found at the provided [`RadUrn`].
@@ -568,6 +249,412 @@ impl Storage {
         )?;
         let refnames = refs.names();
         Ok(urns_from_refs(refnames).collect())
+    }
+
+    pub fn has_commit(&self, urn: &RadUrn, oid: git2::Oid) -> Result<bool, Error> {
+        let span = tracing::warn_span!("Storage::has_commit", urn = %urn, oid = %oid);
+        let _guard = span.enter();
+
+        if oid.is_zero() {
+            return Ok(false);
+        }
+
+        let commit = self.backend.find_commit(oid);
+        match commit {
+            Err(e) if is_not_found_err(&e) => {
+                tracing::warn!("commit not found");
+                Ok(false)
+            },
+            Ok(commit) => {
+                let namespace = &urn.id;
+                let branch = urn.path.deref_or_default();
+                let branch = branch.strip_prefix("refs/").unwrap_or(branch);
+
+                let refs = References::from_globs(
+                    &self.backend,
+                    &[format!("refs/namespaces/{}/refs/{}", namespace, branch)],
+                )?;
+
+                for (_, oid) in refs.peeled() {
+                    if oid == commit.id() || self.backend.graph_descendant_of(oid, commit.id())? {
+                        return Ok(true);
+                    }
+                }
+
+                Ok(false)
+            },
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub fn has_ref(&self, reference: &Reference) -> Result<bool, Error> {
+        self.backend
+            .find_reference(&reference.to_string())
+            .map(|_| true)
+            .or_matches(is_not_found_err, || Ok(false))
+    }
+
+    pub fn has_urn(&self, urn: &RadUrn) -> Result<bool, Error> {
+        let namespace = &urn.id;
+        let branch = urn.path.deref_or_default();
+        let branch = branch.strip_prefix("refs/").unwrap_or(branch);
+        self.backend
+            .find_reference(&format!("refs/namespaces/{}/refs/{}", namespace, branch))
+            .map(|_| true)
+            .or_matches(is_not_found_err, || Ok(false))
+    }
+
+    pub fn untrack(&self, urn: &RadUrn, peer: &PeerId) -> Result<(), Error> {
+        let remote_name = tracking_remote_name(urn, peer);
+        // TODO: This removes all remote tracking branches matching the
+        // fetchspec (I suppose). Not sure this is what we want.
+        self.backend
+            .remote_delete(&remote_name)
+            .map_err(|e| e.into())
+    }
+
+    pub fn tracked(&self, urn: &RadUrn) -> Result<Tracked, Error> {
+        Tracked::collect(&self.backend, urn).map_err(|e| e.into())
+    }
+
+    /// Read the current [`Refs`] from the repo state
+    pub fn rad_refs(&self, urn: &RadUrn) -> Result<Refs, Error> {
+        let span = tracing::debug_span!("Storage::rad_refs", urn = %urn);
+        let _guard = span.enter();
+
+        // Collect refs/heads (our branches) at their current state
+        let heads = self.references_glob(urn, Some("refs/heads/*"))?;
+        let heads: BTreeMap<String, Oid> = heads.map(|(name, oid)| (name, Oid(oid))).collect();
+
+        tracing::debug!(heads = ?heads);
+
+        // Get 1st degree tracked peers from the remotes configured in .git/config
+        let tracked = self.tracked(urn)?;
+        let mut remotes: HashMap<PeerId, HashMap<PeerId, HashSet<PeerId>>> =
+            tracked.map(|peer| (peer, HashMap::new())).collect();
+
+        tracing::debug!(remotes.bare = ?remotes);
+
+        // For each of the 1st degree tracked peers, lookup their rad/refs (if any),
+        // verify the signature, and add their [`Remotes`] to ours (minus the 3rd
+        // degree)
+        for (peer, tracked) in remotes.iter_mut() {
+            match self.rad_refs_of(urn, peer.clone()) {
+                Ok(refs) => *tracked = refs.remotes.cutoff(),
+                Err(Error::Blob(blob::Error::NotFound(_))) => {},
+                Err(e) => return Err(e),
+            }
+        }
+
+        tracing::debug!(remotes.verified = ?remotes);
+
+        Ok(Refs {
+            heads,
+            remotes: remotes.into(),
+        })
+    }
+
+    pub fn rad_refs_of(&self, urn: &RadUrn, peer: PeerId) -> Result<Refs, Error> {
+        let signed = {
+            let refs = Reference::rad_refs(urn.id.clone(), peer.clone());
+            let blob = Blob::Tip {
+                branch: refs.borrow().into(),
+                path: Path::new("refs"),
+            }
+            .get(&self)?;
+            refs::Signed::from_json(blob.content(), &peer)
+        }?;
+
+        Ok(Refs::from(signed))
+    }
+
+    /// The set of all certifiers of the given identity, transitively
+    pub fn certifiers(&self, urn: &RadUrn) -> Result<HashSet<RadUrn>, Error> {
+        let mut refs = References::from_globs(
+            &self,
+            &[
+                format!("refs/namespaces/{}/refs/rad/ids/*", &urn.id),
+                format!("refs/namespaces/{}/refs/remotes/**/rad/ids/*", &urn.id),
+            ],
+        )?;
+        let refnames = refs.names();
+        Ok(urns_from_refs(refnames).collect())
+    }
+
+    fn references_glob<'a>(
+        &'a self,
+        urn: &RadUrn,
+        globs: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<impl Iterator<Item = (String, git2::Oid)> + 'a, Error> {
+        let namespace_prefix = format!("refs/namespaces/{}/", &urn.id);
+
+        let refs = References::from_globs(
+            &self,
+            globs
+                .into_iter()
+                .map(|glob| format!("{}{}", namespace_prefix, glob.as_ref())),
+        )?;
+
+        Ok(refs.peeled().filter_map(move |(name, target)| {
+            name.strip_prefix(&namespace_prefix)
+                .map(|name| (name.to_owned(), target))
+        }))
+    }
+}
+
+impl Storage<NoSigner> {
+    /// Open the `Storage` found at the given [`Path`]'s `git_dir.
+    ///
+    /// The `Storage` must have been initialised with [`Storage::init`] prior to
+    /// calling this method.
+    pub fn open(paths: &Paths) -> Result<Self, Error> {
+        let backend = git2::Repository::open_bare(paths.git_dir())?;
+        let config = backend.config()?;
+        let peer_id = config.get_string("rad.peerid")?.parse()?;
+        Ok(Self {
+            backend,
+            peer_id,
+            signer: PhantomData,
+        })
+    }
+
+    pub fn with_signer(self, signer: SecretKey) -> Result<Storage<WithSigner>, Error> {
+        if self.peer_id != PeerId::from(&signer) {
+            return Err(Error::SignerKeyMismatch);
+        }
+
+        Ok(Storage {
+            backend: self.backend,
+            peer_id: self.peer_id,
+            signer,
+        })
+    }
+}
+
+impl Storage<WithSigner> {
+    /// Open the `Storage` found at the given [`Paths`]'s `git_dir`, or
+    /// initialise it if it isn't yet.
+    pub fn open_or_init(paths: &Paths, signer: SecretKey) -> Result<Self, Error> {
+        match Storage::open(paths) {
+            Ok(this) => {
+                if this.peer_id != PeerId::from(&signer) {
+                    Err(Error::SignerKeyMismatch)
+                } else {
+                    this.with_signer(signer)
+                }
+            },
+            Err(Error::Git(e)) if is_not_found_err(&e) => Self::init(paths, signer),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Initialise the `Storage` at the given [`Paths`]'s `git_dir`.
+    pub fn init(paths: &Paths, signer: SecretKey) -> Result<Self, Error> {
+        let backend = git2::Repository::init_opts(
+            paths.git_dir(),
+            git2::RepositoryInitOptions::new()
+                .bare(true)
+                .no_reinit(true)
+                .external_template(false),
+        )?;
+
+        let peer_id = PeerId::from(&signer);
+
+        let mut config = backend.config()?;
+        config.set_str("user.name", "radicle")?;
+        config.set_str("user.email", &format!("radicle@{}", peer_id))?;
+        config.set_str("rad.peerid", &peer_id.to_string())?;
+
+        Ok(Self {
+            backend,
+            peer_id,
+            signer,
+        })
+    }
+
+    pub fn downcast(self) -> Storage<NoSigner> {
+        Storage {
+            backend: self.backend,
+            peer_id: self.peer_id,
+            signer: PhantomData,
+        }
+    }
+
+    pub fn create_repo<T>(&self, meta: &Entity<T, Draft>) -> Result<Repo<WithSigner>, Error>
+    where
+        T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
+    {
+        let span = tracing::info_span!("Storage::create_repo");
+        let _guard = span.enter();
+
+        // FIXME: properly verify meta
+
+        if meta.signatures().is_empty() {
+            return Err(Error::UnsignedMetadata);
+        }
+
+        // FIXME: certifier identities must exist, or be supplied
+
+        let urn = RadUrn::new(
+            meta.root_hash().to_owned(),
+            uri::Protocol::Git,
+            uri::Path::empty(),
+        );
+
+        self.commit_initial_meta(&meta)?;
+        self.track_signers(&meta)?;
+        self.update_refs(&urn)?;
+
+        Ok(Repo {
+            urn,
+            storage: self.into(),
+        })
+    }
+
+    /// Attempt to clone the designated repo from the network.
+    ///
+    /// Note that this method **must** be spawned on a `async` runtime, where
+    /// currently the only supported method is [`tokio::task::spawn_blocking`].
+    pub fn clone_repo<T>(&self, url: RadUrl) -> Result<Repo<WithSigner>, Error>
+    where
+        T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
+    {
+        let span = tracing::info_span!("Storage::clone_repo", url = %url);
+        let _guard = span.enter();
+
+        let urn = RadUrn {
+            path: uri::Path::empty(),
+            ..url.urn.clone()
+        };
+
+        // Fetch the identity first
+        let git_url = GitUrlRef::from_rad_url_ref(url.as_ref(), &self.peer_id);
+        let meta: Entity<T, Draft> = self.fetch_id(git_url)?;
+
+        // TODO: properly verify meta
+
+        if meta.signatures().is_empty() {
+            return Err(Error::UnsignedMetadata);
+        }
+
+        if meta.root_hash() != &url.urn.id {
+            return Err(Error::RootHashMismatch {
+                expected: url.urn.id.to_owned(),
+                actual: meta.root_hash().to_owned(),
+            });
+        }
+
+        self.track_signers(&meta)?;
+        self.update_refs(&urn)?;
+        self.fetch_repo(&urn, &url.authority)?;
+
+        Ok(Repo {
+            urn,
+            storage: self.into(),
+        })
+    }
+
+    pub fn fetch_repo(&self, urn: &RadUrn, from: &PeerId) -> Result<(), Error> {
+        let span = tracing::info_span!("Storage::fetch", fetch.urn = %urn, fetch.from = %from);
+        let _guard = span.enter();
+
+        let namespace = &urn.id;
+
+        let mut remote = {
+            let url = GitUrlRef::from_rad_url_ref(urn.as_rad_url_ref(from), &self.peer_id);
+            self.remote_anonymous(&url.to_string())
+        }?;
+        remote.connect(git2::Direction::Fetch)?;
+
+        let rad_refs = self.rad_refs(urn)?;
+        let tracked_trans = rad_refs.remotes.flatten().collect::<HashSet<&PeerId>>();
+
+        // Fetch rad/refs of all known remotes
+        {
+            let refspecs =
+                Refspec::rad_refs(namespace.clone(), from, tracked_trans.iter().cloned())
+                    .map(|spec| spec.to_string())
+                    .collect::<Vec<String>>();
+            tracing::debug!(refspecs = ?refspecs, "Fetching rad/refs");
+            remote.fetch(&refspecs, Some(&mut self.fetch_options()), None)?;
+        }
+
+        // Read the signed refs of all known remotes, and compare their `heads`
+        // against the advertised refs. If signed and advertised branch head
+        // match, non-fast-forwards are permitted. Otherwise, the branch is
+        // skipped.
+        {
+            let remote_heads: HashMap<&str, git2::Oid> = remote
+                .list()?
+                .iter()
+                .map(|rhead| (rhead.name(), rhead.oid()))
+                .collect();
+
+            let refspecs = Refspec::fetch_heads(
+                namespace.clone(),
+                remote_heads,
+                tracked_trans.iter().cloned(),
+                from,
+                |peer| self.rad_refs_of(urn, peer),
+                |peer| self.certifiers_of(urn, peer),
+            )?
+            .map(|spec| spec.to_string())
+            .collect::<Vec<String>>();
+
+            tracing::debug!(refspecs = ?refspecs, "Fetching refs/heads");
+            remote.fetch(&refspecs, Some(&mut self.fetch_options()), None)?;
+        }
+
+        // At this point, the transitive tracking graph may have changed. Let's
+        // update the refs, but don't recurse here for now (we could, if
+        // we reload `self.refs()` and compare to the value we had
+        // before fetching).
+        self.update_refs(urn)
+    }
+
+    pub fn track(&self, urn: &RadUrn, peer: &PeerId) -> Result<(), Error> {
+        if peer == &self.peer_id {
+            return Err(Error::SelfReferential);
+        }
+
+        let remote_name = tracking_remote_name(urn, peer);
+        let url = GitUrlRef::from_rad_urn(&urn, &self.peer_id, peer).to_string();
+
+        tracing::debug!(
+            urn = %urn,
+            peer = %peer,
+            "Storage::track"
+        );
+
+        self.backend
+            .remote(&remote_name, &url)
+            .map(|_| ())
+            .or_matches(is_exists_err, || Ok(()))
+    }
+
+    // FIXME: REMOVE
+    pub fn commit(
+        &self,
+        urn: &RadUrn,
+        branch: &str,
+        msg: &str,
+        tree: &git2::Tree,
+        parents: &[&git2::Commit],
+    ) -> Result<git2::Oid, Error> {
+        let author = self.signature()?;
+        let head = Reference::head(urn.id.clone(), None, branch);
+        let oid = self.backend.commit(
+            Some(&head.to_string()),
+            &author,
+            &author,
+            msg,
+            tree,
+            parents,
+        )?;
+
+        self.update_refs(urn)?;
+
+        Ok(oid)
     }
 
     // Helpers
@@ -676,6 +763,7 @@ impl Storage {
                     Signatory::OwnedKey => (peer_id, None),
                 }
             })
+            .filter(|(peer, _)| peer != self.peer_id())
             .try_for_each(|(peer, urn)| {
                 tracing::debug!(
                     tracked.peer = %peer,
@@ -703,7 +791,7 @@ impl Storage {
 
         let refsig_canonical = self
             .rad_refs(urn)?
-            .sign(&self.key)
+            .sign(&self.signer)
             .and_then(|signed| Cjson(signed).canonical_form())?;
 
         let rad_refs_ref = Reference::rad_refs(urn.id.clone(), None).to_string();
@@ -742,26 +830,6 @@ impl Storage {
         Ok(())
     }
 
-    fn references_glob<'a>(
-        &'a self,
-        urn: &RadUrn,
-        globs: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> Result<impl Iterator<Item = (String, git2::Oid)> + 'a, Error> {
-        let namespace_prefix = format!("refs/namespaces/{}/", &urn.id);
-
-        let refs = References::from_globs(
-            &self,
-            globs
-                .into_iter()
-                .map(|glob| format!("{}{}", namespace_prefix, glob.as_ref())),
-        )?;
-
-        Ok(refs.peeled().filter_map(move |(name, target)| {
-            name.strip_prefix(&namespace_prefix)
-                .map(|name| (name.to_owned(), target))
-        }))
-    }
-
     // TODO: allow users to supply callbacks
     fn fetch_options(&'_ self) -> git2::FetchOptions<'_> {
         let mut cbs = git2::RemoteCallbacks::new();
@@ -784,14 +852,19 @@ impl Storage {
     }
 }
 
-impl TryToOwned for Storage {
+impl<S: Clone> TryToOwned for Storage<S> {
     type Owned = Self;
     type Error = Error;
 
     fn try_to_owned(&self) -> Result<Self::Owned, Self::Error> {
         let backend = self.backend.try_to_owned()?;
-        let key = self.key.clone();
-        Ok(Self { backend, key })
+        let peer_id = self.peer_id.clone();
+        let signer = self.signer.clone();
+        Ok(Self {
+            backend,
+            peer_id,
+            signer,
+        })
     }
 }
 

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -15,8 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![feature(str_strip)]
 #![feature(bool_to_option)]
+#![feature(never_type)]
+#![feature(str_strip)]
 
 #[macro_use]
 extern crate async_trait;


### PR DESCRIPTION
Fixes #196

---

First step towards using radicle-dev/radicle-keystore#1, instead of passing around the secret key. On top of #197 