### PR TITLE
Massi/better signatures

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -984,19 +984,12 @@ mod tests {
         let paths = Paths::from_root(tmp).unwrap();
         let user_key = SecretKey::new();
         let store = Storage::init(&paths, user_key.clone()).unwrap();
-        let cache = EntityMemoryCache::default();
+        let mut cache = EntityMemoryCache::default();
 
         // Create signed and verified user
         let mut user = User::<Draft>::create("user".to_owned(), user_key.public()).unwrap();
         user.sign_owned(&user_key).unwrap();
-        let verified_user = user
-            .clone()
-            .verify_signatures()
-            .unwrap()
-            .verify_certifiers(&cache)
-            .unwrap()
-            .verify_update(&None)
-            .unwrap();
+        let verified_user = user.clone().verify(&mut cache).unwrap();
 
         // Create and sign two projects
         let mut project_foo = Project::<Draft>::create("foo".to_owned(), user.urn()).unwrap();

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -991,11 +991,11 @@ mod tests {
         user.sign_owned(&user_key).unwrap();
         let verified_user = user
             .clone()
-            .check_signatures()
+            .verify_signatures()
             .unwrap()
-            .check_signatures_ownership(&cache)
+            .verify_certifiers(&cache)
             .unwrap()
-            .check_update(&None)
+            .verify_update(&None)
             .unwrap();
 
         // Create and sign two projects

--- a/librad/src/hash.rs
+++ b/librad/src/hash.rs
@@ -54,6 +54,10 @@ impl Hash {
     pub fn as_ref(&self) -> HashRef {
         HashRef(&self.0)
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
 }
 
 impl Hasher for Hash {

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -667,24 +667,6 @@ where
             info: self.info,
         }
     }
-
-    //FIXME[MASSI] this is only for `#[cfg(test)]`!!!
-    //#[cfg(test)]
-    pub fn as_verified(&self) -> Entity<T, Verified> {
-        Entity::<T, Verified> {
-            status_marker: PhantomData,
-            name: self.name.clone(),
-            revision: self.revision,
-            timestamp: self.timestamp,
-            rad_version: self.rad_version,
-            hash: self.hash.clone(),
-            root_hash: self.root_hash.clone(),
-            parent_hash: self.parent_hash.clone(),
-            keys: self.keys.clone(),
-            certifiers: self.certifiers.clone(),
-            info: self.info.clone(),
-        }
-    }
 }
 
 impl<T> Entity<T, Draft>

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -165,11 +165,10 @@ pub struct EntityTimestamp(i64);
 impl EntityTimestamp {
     /// Current time as Entity timestamp
     pub fn current_time() -> Self {
-        EntityTimestamp(
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map_or(0, |elapsed| elapsed.as_millis() as i64),
-        )
+        EntityTimestamp(SystemTime::now().duration_since(UNIX_EPOCH).map_or_else(
+            |err| -(err.duration().as_millis() as i64),
+            |elapsed| elapsed.as_millis() as i64,
+        ))
     }
 
     /// Milliseconds from Unix epoch
@@ -902,9 +901,9 @@ where
     T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
 {
     /// Fully verify this entity
-    pub fn check<CACHE>(&self, cache: &mut CACHE) -> Result<(), Error>
+    pub fn check<Cache>(&self, cache: &mut Cache) -> Result<(), Error>
     where
-        CACHE: EntityCache + KeyOwnershipStore,
+        Cache: EntityCache + KeyOwnershipStore,
     {
         self.check_signatures()?;
         self.check_certifiers(cache)?;
@@ -944,9 +943,9 @@ where
     T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
 {
     /// Fully verify this entity
-    pub fn verify<CACHE>(self, cache: &mut CACHE) -> Result<Entity<T, Verified>, Error>
+    pub fn verify<Cache>(self, cache: &mut Cache) -> Result<Entity<T, Verified>, Error>
     where
-        CACHE: EntityCache + KeyOwnershipStore,
+        Cache: EntityCache + KeyOwnershipStore,
     {
         self.check_certifiers(cache).map(|_| self.with_status())
     }

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -144,6 +144,9 @@ pub enum HistoryVerificationError {
         revision: EntityRevision,
         error: UpdateVerificationError,
     },
+
+    #[error("Entity cache error ({0})")]
+    CacheError(#[from] cache::Error),
 }
 
 /// Type representing an entity revision
@@ -559,7 +562,7 @@ where
 
     /// `urn` getter
     pub fn urn(&self) -> RadUrn {
-        RadUrn::new(self.hash.to_owned(), Protocol::Git, Path::new())
+        RadUrn::new(self.root_hash.to_owned(), Protocol::Git, Path::new())
     }
 
     /// `parent_hash` getter

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -36,6 +36,7 @@ use crate::{
     uri::{Path, Protocol, RadUrn},
 };
 
+pub mod cache;
 pub mod data;
 
 use data::{EntityData, EntityInfo, EntityInfoExt, EntityKind};
@@ -104,6 +105,9 @@ pub enum Error {
 
     #[error("Resolution at revision failed ({0}, revision {1})")]
     RevisionResolutionFailed(RadUrn, u64),
+
+    #[error("Entity cache error ({0})")]
+    CacheError(#[from] cache::Error),
 }
 
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
@@ -216,6 +220,19 @@ pub struct Signed;
 /// Type witness for a draft [`Entity`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Draft;
+
+/// Verification status of an entity revision
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EntityRevisionStatus {
+    /// Unverified, signatures are still missing or otherwise invalid
+    Draft,
+    /// Fully verified
+    Verified,
+    /// Fully verified but tainted because of a retroactive key revocation
+    /// or a legitimate fork of the same revision
+    /// TODO: add relevant info to this status
+    Tainted,
+}
 
 /// A type expressing *who* is signing an `Entity`
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/librad/src/meta/entity/cache.rs
+++ b/librad/src/meta/entity/cache.rs
@@ -160,12 +160,14 @@ impl EntityMemoryCache {
     where
         T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
     {
-        let id = match self.entity_ids.get(&entity.urn()) {
+        let urn = entity.urn();
+        let id = match self.entity_ids.get(&urn) {
             Some(id) => *id,
             None => {
                 let new_id = self.entities.len();
                 let info = EntityInfo::new();
                 self.entities.push(info);
+                self.entity_ids.insert(urn, new_id);
                 self.register_hash(entity.hash(), new_id, entity.revision());
                 new_id
             },
@@ -355,13 +357,13 @@ impl EntityMemoryCache {
                 None => {
                     let new_key_id = self.keys.len();
                     self.keys.push(k.to_owned());
+                    self.key_ids.insert(k.to_owned(), new_key_id);
                     new_key_id
                 },
             };
             owned_keys.insert(key_id);
         }
         let (id, info) = self.get_or_create_entity_info(entity);
-
         let required_previous_revisions = revision as usize - 1;
         if info.revisions.len() < required_previous_revisions {
             return Err(Error::MissingParentEntity(urn, revision));

--- a/librad/src/meta/entity/cache.rs
+++ b/librad/src/meta/entity/cache.rs
@@ -1,0 +1,414 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    hash::Hash,
+    keys::PublicKey,
+    meta::entity::{
+        Draft,
+        Entity,
+        EntityCertifierSignature,
+        EntityInfoExt,
+        EntityRevision,
+        EntityRevisionStatus,
+        EntitySelfSignature,
+        EntityTimestamp,
+        GenericEntity,
+        Verified,
+    },
+    uri::RadUrn,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum Error {
+    #[error("Missing entity (urn {0})")]
+    MissingEntity(RadUrn),
+
+    #[error("Missing entity revision (entity {0}, revision {1})")]
+    MissingEntityRevision(RadUrn, EntityRevision),
+
+    #[error("Missing parent entity (entity {0}, revision {1})")]
+    MissingParentEntity(RadUrn, EntityRevision),
+
+    #[error("Missing certifier (entity {0}, revision {1}, certifier {2})")]
+    MissingCertifier(RadUrn, EntityRevision, RadUrn),
+
+    #[error("Missing certifier (entity {0}, revision {1}, certifier {2})")]
+    MissingSignature(RadUrn, EntityRevision, RadUrn),
+
+    #[error("Entity tainted (entity {0}, revision {1})")]
+    EntityTainted(RadUrn, EntityRevision),
+
+    #[error("Signatures revoked")]
+    SignaturesRevoked(),
+
+    #[error("Missing internal entity id ({0})")]
+    MissingInternalEntityId(EntityInternalId),
+
+    #[error("Missing internal revision ({0})")]
+    MissingInternalRevision(EntityRevision),
+
+    #[error("Missing key ({0})")]
+    MissingKey(PublicKey),
+}
+
+type EntityInternalId = usize;
+type KeyInternalId = usize;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EntityHashInfo {
+    pub id: EntityInternalId,
+    pub revision: EntityRevision,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EntitySignatureInfo {
+    pub revision: EntityRevision,
+    pub time: EntityTimestamp,
+    pub key_id: KeyInternalId,
+    pub revoked: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct EntitySignatureTargetInfo {
+    pub id: EntityInternalId,
+    pub revision: EntityRevision,
+}
+
+#[derive(Clone, Debug)]
+struct EntityInfo {
+    pub last_verified_revision: Option<GenericEntity<Verified>>,
+    pub draft_revision: Option<GenericEntity<Draft>>,
+    pub revisions: Vec<EntityRevisionInfo>,
+}
+
+impl EntityInfo {
+    pub fn new() -> Self {
+        Self {
+            last_verified_revision: None,
+            draft_revision: None,
+            revisions: Vec::new(),
+        }
+    }
+
+    pub fn revision(&self, rev: EntityRevision) -> Result<&EntityRevisionInfo, Error> {
+        Ok(self
+            .revisions
+            .get(rev as usize - 1)
+            .ok_or(Error::MissingInternalRevision(rev))?)
+    }
+
+    pub fn revision_mut(&mut self, rev: EntityRevision) -> Result<&mut EntityRevisionInfo, Error> {
+        Ok(self
+            .revisions
+            .get_mut(rev as usize - 1)
+            .ok_or(Error::MissingInternalRevision(rev))?)
+    }
+
+    pub fn revisions_from(
+        &self,
+        start: EntityRevision,
+    ) -> impl IntoIterator<Item = EntityRevision> {
+        let end = self.revisions.len() as EntityRevision + 1;
+        start..end
+    }
+
+    pub fn tainted(&self) -> bool {
+        self.revisions
+            .last()
+            .map_or(false, |rev| rev.status == EntityRevisionStatus::Tainted)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EntityRevisionInfo {
+    pub hash: Hash,
+    pub status: EntityRevisionStatus,
+    pub timestamp: EntityTimestamp,
+    pub owned_keys: BTreeSet<KeyInternalId>,
+    pub signed_by: BTreeMap<EntityInternalId, EntitySignatureInfo>,
+    pub signature_targets: BTreeSet<EntitySignatureTargetInfo>,
+}
+
+pub struct EntityMemoryCache {
+    hashes: HashMap<Hash, EntityHashInfo>,
+    key_ids: HashMap<PublicKey, KeyInternalId>,
+    keys: Vec<PublicKey>,
+    entity_ids: HashMap<RadUrn, EntityInternalId>,
+    entities: Vec<EntityInfo>,
+}
+
+impl EntityMemoryCache {
+    pub fn new() -> Self {
+        Self {
+            hashes: HashMap::new(),
+            key_ids: HashMap::new(),
+            keys: Vec::new(),
+            entities: Vec::new(),
+            entity_ids: HashMap::new(),
+        }
+    }
+
+    fn get_or_create_entity_info<T>(
+        &mut self,
+        entity: &Entity<T, Verified>,
+    ) -> (EntityInternalId, &mut EntityInfo)
+    where
+        T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
+    {
+        let id = match self.entity_ids.get(&entity.urn()) {
+            Some(id) => *id,
+            None => {
+                let new_id = self.entities.len();
+                let info = EntityInfo::new();
+                self.entities.push(info);
+                self.register_hash(entity.hash(), new_id, entity.revision());
+                new_id
+            },
+        };
+        (id, &mut self.entities[id])
+    }
+
+    fn entity_info(&self, id: EntityInternalId) -> Result<&EntityInfo, Error> {
+        Ok(self
+            .entities
+            .get(id)
+            .ok_or(Error::MissingInternalEntityId(id))?)
+    }
+
+    fn entity_info_mut(&mut self, id: EntityInternalId) -> Result<&mut EntityInfo, Error> {
+        Ok(self
+            .entities
+            .get_mut(id)
+            .ok_or(Error::MissingInternalEntityId(id))?)
+    }
+
+    fn register_hash(&mut self, hash: &Hash, id: EntityInternalId, revision: EntityRevision) {
+        if !self.hashes.contains_key(hash) {
+            self.hashes
+                .insert(hash.to_owned(), EntityHashInfo { id, revision });
+        }
+    }
+
+    fn check_revocations(
+        &mut self,
+        id: EntityInternalId,
+        revision: EntityRevision,
+    ) -> Result<(), Error> {
+        if revision <= 1 {
+            return Ok(());
+        }
+
+        let info = self.entity_info(id)?;
+        let current = info.revision(revision)?;
+        let parent = info.revision(revision - 1)?;
+        let revoked_signatures: Vec<_> = parent
+            .signature_targets
+            .iter()
+            .filter_map(|target_signature| {
+                let signed_revision =
+                    self.entity_info(target_signature.id)
+                        .ok()
+                        .and_then(|target_entity| {
+                            target_entity.revision(target_signature.revision).ok()
+                        });
+                let signed_revision = match signed_revision {
+                    Some(rev) => rev,
+                    None => return None,
+                };
+
+                let signature_info = signed_revision.signed_by.get(&id);
+                let signature_info = match signature_info {
+                    Some(sig) => sig,
+                    None => return None,
+                };
+
+                if signature_info.time >= current.timestamp
+                    && !current.owned_keys.contains(&signature_info.key_id)
+                {
+                    Some(target_signature.to_owned())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if revoked_signatures.len() > 0 {
+            let mut tainted = Vec::new();
+            for sig in revoked_signatures {
+                tainted.push((sig.id, sig.revision));
+                let signed_entity = self.entity_info_mut(sig.id)?;
+                let signed_revision = signed_entity.revision_mut(sig.revision)?;
+                let revoked_signature = signed_revision
+                    .signed_by
+                    .get_mut(&id)
+                    .ok_or(Error::MissingInternalEntityId(id))?;
+                revoked_signature.revoked = true;
+            }
+            for (id, revision) in tainted {
+                self.set_tainted(id, revision);
+            }
+            Err(Error::SignaturesRevoked())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn apply_signatures<T>(
+        &mut self,
+        id: EntityInternalId,
+        entity: &Entity<T, Verified>,
+    ) -> Result<(), Error>
+    where
+        T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
+    {
+        let mut signed_by = Vec::new();
+        for (certifier_urn, s) in entity.certifiers().iter() {
+            let certifier_id =
+                *self
+                    .entity_ids
+                    .get(&certifier_urn)
+                    .ok_or(Error::MissingCertifier(
+                        entity.urn(),
+                        entity.revision(),
+                        certifier_urn.to_owned(),
+                    ))?;
+            let sig = s.as_ref().ok_or(Error::MissingSignature(
+                entity.urn(),
+                entity.revision(),
+                certifier_urn.to_owned(),
+            ))?;
+
+            self.entity_info_mut(certifier_id)?
+                .revision_mut(sig.revision)
+                .map_err(|_| Error::MissingEntityRevision(certifier_urn.to_owned(), sig.revision))?
+                .signature_targets
+                .insert(EntitySignatureTargetInfo {
+                    id,
+                    revision: entity.revision(),
+                });
+
+            signed_by.push((
+                certifier_id,
+                EntitySignatureInfo {
+                    revision: sig.revision,
+                    time: sig.timestamp,
+                    key_id: self
+                        .key_ids
+                        .get(&sig.key)
+                        .ok_or(Error::MissingKey(sig.key.to_owned()))?
+                        .to_owned(),
+                    revoked: false,
+                },
+            ));
+        }
+
+        let sigs = &mut self
+            .entity_info_mut(id)
+            .map_err(|_| Error::MissingEntity(entity.urn().to_owned()))?
+            .revision_mut(entity.revision())
+            .map_err(|_| Error::MissingEntityRevision(entity.urn().to_owned(), entity.revision()))?
+            .signed_by;
+        for (key, sig) in signed_by.iter() {
+            sigs.insert(*key, sig.to_owned());
+        }
+
+        Ok(())
+    }
+
+    fn set_tainted(&mut self, id: EntityInternalId, revision: EntityRevision) -> Result<(), Error> {
+        // FIXME: add tainting info
+        let mut tainted_revisions = Vec::new();
+        let mut tainted_targets = Vec::new();
+
+        for rev in self.entity_info(id)?.revisions_from(revision) {
+            tainted_revisions.push((id, rev));
+        }
+
+        while tainted_revisions.len() > 0 {
+            let (id, r) = tainted_revisions.pop().unwrap();
+
+            let rev = self.entity_info_mut(id)?.revision_mut(r)?;
+            if rev.status != EntityRevisionStatus::Tainted {
+                rev.status = EntityRevisionStatus::Tainted;
+                for sig in rev.signature_targets.iter() {
+                    tainted_targets.push(sig.to_owned());
+                }
+            }
+
+            while tainted_targets.len() > 0 {
+                let target = tainted_targets.pop().unwrap();
+                for rev in self.entity_info(target.id)?.revisions_from(target.revision) {
+                    tainted_revisions.push((id, rev));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn register_entity_revision<T>(&mut self, entity: &Entity<T, Verified>) -> Result<(), Error>
+    where
+        T: Serialize + DeserializeOwned + Clone + EntityInfoExt,
+    {
+        let urn = entity.urn();
+        let revision = entity.revision();
+        let mut owned_keys = BTreeSet::new();
+        for (k, _) in entity.keys() {
+            let key_id = match self.key_ids.get(k) {
+                Some(key_id) => *key_id,
+                None => {
+                    let new_key_id = self.keys.len();
+                    self.keys.push(k.to_owned());
+                    new_key_id
+                },
+            };
+            owned_keys.insert(key_id);
+        }
+        let (key, info) = self.get_or_create_entity_info(entity);
+
+        let required_previous_revisions = revision as usize - 1;
+        if info.revisions.len() < required_previous_revisions {
+            return Err(Error::MissingParentEntity(urn, revision));
+        };
+
+        let tainted = if info.revisions.len() == required_previous_revisions {
+            info.revisions.push(EntityRevisionInfo {
+                hash: entity.hash().to_owned(),
+                status: EntityRevisionStatus::Verified,
+                timestamp: unimplemented!(),
+                owned_keys,
+                signed_by: BTreeMap::new(),
+                signature_targets: BTreeSet::new(),
+            });
+            false
+        } else {
+            &info.revisions[required_previous_revisions].hash != entity.hash()
+        };
+
+        self.apply_signatures(key, entity)?;
+
+        if tainted {
+            self.set_tainted(key, revision)?;
+            Err(Error::EntityTainted(urn, entity.revision()))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/librad/src/meta/entity/data.rs
+++ b/librad/src/meta/entity/data.rs
@@ -20,13 +20,13 @@ use crate::{
     keys::PublicKey,
     meta::{
         entity::{
+            CertifierSignature,
             Draft,
             Entity,
-            EntityCertifierSignature,
             EntityRevision,
-            EntitySelfSignature,
             EntityTimestamp,
             Error,
+            SelfSignature,
         },
         project::ProjectInfo,
         user::UserInfo,
@@ -40,26 +40,26 @@ use std::collections::{BTreeMap, HashMap};
 
 /// Helper to serialize entity self signatures in a canonical way
 fn serialize_certifiers<S>(
-    value: &HashMap<RadUrn, Option<EntityCertifierSignature>>,
+    value: &HashMap<RadUrn, Option<CertifierSignature>>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let ordered: BTreeMap<RadUrn, Option<EntityCertifierSignature>> =
+    let ordered: BTreeMap<RadUrn, Option<CertifierSignature>> =
         value.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
     ordered.serialize(serializer)
 }
 
 /// Helper to serialize entity certifier signatures in a canonical way
 fn serialize_keys<S>(
-    value: &HashMap<PublicKey, Option<EntitySelfSignature>>,
+    value: &HashMap<PublicKey, Option<SelfSignature>>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let ordered: BTreeMap<PublicKey, Option<EntitySelfSignature>> =
+    let ordered: BTreeMap<PublicKey, Option<SelfSignature>> =
         value.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
     ordered.serialize(serializer)
 }
@@ -141,13 +141,13 @@ pub struct EntityData<T> {
         serialize_with = "serialize_keys",
         default
     )]
-    pub keys: HashMap<PublicKey, Option<EntitySelfSignature>>,
+    pub keys: HashMap<PublicKey, Option<SelfSignature>>,
     #[serde(
         skip_serializing_if = "HashMap::is_empty",
         serialize_with = "serialize_certifiers",
         default
     )]
-    pub certifiers: HashMap<RadUrn, Option<EntityCertifierSignature>>,
+    pub certifiers: HashMap<RadUrn, Option<CertifierSignature>>,
 
     pub info: T,
 }

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -146,7 +146,7 @@ impl UserHistory {
     }
 }
 
-impl EntityKeyOwnershipStore for UserHistory {
+impl KeyOwnershipStore for UserHistory {
     fn check_ownership(
         &self,
         _key: &PublicKey,

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -124,7 +124,7 @@ impl UserHistory {
                     error: err,
                 }
             })?;
-            let current = current.verify_certifiers(self).map_err(|err| {
+            let current = current.verify_certifiers(&cache).map_err(|err| {
                 HistoryVerificationError::ErrorAtRevision {
                     revision: current_revision,
                     error: err,
@@ -143,18 +143,6 @@ impl UserHistory {
             Some(user) => Ok(user),
             None => Err(HistoryVerificationError::EmptyHistory),
         }
-    }
-}
-
-impl KeyOwnershipStore for UserHistory {
-    fn check_ownership(
-        &self,
-        _key: &PublicKey,
-        _uri: &RadUrn,
-        _revision: EntityRevision,
-        _time: EntityTimestamp,
-    ) -> bool {
-        true
     }
 }
 

--- a/librad/src/meta/entity_test.rs
+++ b/librad/src/meta/entity_test.rs
@@ -186,7 +186,7 @@ fn new_user(
     revision: u64,
     devices: &[&'static PublicKey],
 ) -> Result<User<Draft>, Error> {
-    let mut data = UserData::default()
+    let mut data = UserData::new(EntityTimestamp::current_time())
         .set_name(name.to_owned())
         .set_revision(revision);
     for k in devices.iter() {

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -23,9 +23,10 @@ use crate::{
     meta::{
         common::{Label, Url},
         entity::{
-            data::{EntityData, EntityInfoExt, EntityKind},
+            data::{EntityData, EntityInfo, EntityInfoExt, EntityKind},
             Draft,
             Entity,
+            EntityTimestamp,
             Error,
         },
     },
@@ -74,6 +75,10 @@ impl EntityInfoExt for ProjectInfo {
             return Err(Error::InvalidData("Missing certifier".to_owned()));
         }
         Ok(())
+    }
+
+    fn as_info(&self) -> EntityInfo {
+        EntityInfo::Project(self.clone())
     }
 }
 
@@ -164,7 +169,7 @@ where
     }
 
     pub fn create(name: String, owner: RadUrn) -> Result<Project<Draft>, Error> {
-        ProjectData::default()
+        ProjectData::new(EntityTimestamp::current_time())
             .set_name(name)
             .set_revision(1)
             .add_certifier(owner)
@@ -196,7 +201,7 @@ pub mod tests {
             proptest::collection::vec(gen_relation(), 0..16),
         )
             .prop_map(|(name, description, branch, maintainers, rels)| {
-                ProjectData::default()
+                ProjectData::new(EntityTimestamp::current_time())
                     .set_revision(1)
                     .set_name(name)
                     .set_optional_description(description)

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -147,8 +147,8 @@ impl<ST> Project<ST>
 where
     ST: Clone,
 {
-    pub fn maintainers(&self) -> &std::collections::HashSet<RadUrn> {
-        self.certifiers()
+    pub fn maintainers(&self) -> impl Iterator<Item = &RadUrn> {
+        self.certifiers().iter().map(|(k, _)| k)
     }
 
     pub fn description(&self) -> &Option<String> {

--- a/librad/src/meta/user.rs
+++ b/librad/src/meta/user.rs
@@ -23,9 +23,10 @@ use crate::{
     meta::{
         common::{EmailAddr, Label, Url},
         entity::{
-            data::{EntityData, EntityInfoExt, EntityKind},
+            data::{EntityData, EntityInfo, EntityInfoExt, EntityKind},
             Draft,
             Entity,
+            EntityTimestamp,
             Error,
         },
         profile::{Geo, ProfileImage, UserProfile},
@@ -71,6 +72,10 @@ impl EntityInfoExt for UserInfo {
             return Err(Error::InvalidData("Missing keys".to_owned()));
         }
         Ok(())
+    }
+
+    fn as_info(&self) -> EntityInfo {
+        EntityInfo::User(self.clone())
     }
 }
 
@@ -175,7 +180,7 @@ where
     ST: Clone,
 {
     pub fn create(name: String, key: PublicKey) -> Result<User<Draft>, Error> {
-        UserData::default()
+        UserData::new(EntityTimestamp::current_time())
             .set_name(name)
             .set_revision(1)
             .add_key(key)
@@ -224,7 +229,7 @@ pub mod tests {
     pub fn gen_user() -> impl Strategy<Value = User<Draft>> {
         (proptest::option::of(gen_profile_ref()), gen_largefiles()).prop_map(
             |(profile, largefiles)| {
-                UserData::default()
+                UserData::new(EntityTimestamp::current_time())
                     .set_name("foo".to_owned())
                     .set_revision(1)
                     .add_key(K1.public())

--- a/librad/tests/fixtures.rs
+++ b/librad/tests/fixtures.rs
@@ -45,6 +45,12 @@ impl Deref for Alice {
     }
 }
 
+impl DerefMut for Alice {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 #[async_trait]
 impl Resolver<User<Draft>> for Alice {
     async fn resolve(&self, _uri: &RadUrn) -> Result<User<Draft>, Error> {

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -46,7 +46,6 @@ async fn can_clone() {
         let mut alice = Alice::new(peer1.public_key());
         alice.sign_owned(peer1.key()).unwrap();
         let verified_alice = alice.clone().verify(&mut cache).unwrap();
-        cache.register_verified_entity(&verified_alice).unwrap();
         let mut radicle = Radicle::new(&alice);
         radicle.sign_by_user(peer1.key(), &verified_alice).unwrap();
 
@@ -80,7 +79,6 @@ async fn fetches_on_gossip_notify() {
         let mut alice = Alice::new(peer1.public_key());
         alice.sign_owned(peer1.key()).unwrap();
         let verified_alice = alice.clone().verify(&mut cache).unwrap();
-        cache.register_verified_entity(&verified_alice).unwrap();
         let mut radicle = Radicle::new(&alice);
         radicle.sign_by_user(peer1.key(), &verified_alice).unwrap();
 

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use futures::{future, stream::StreamExt};
 
 use librad::{
-    meta::{entity::Signatory, project::ProjectInfo},
+    meta::project::ProjectInfo,
     net::peer::{FetchInfo, Gossip, PeerEvent, Rev},
     uri::{self, RadUrn},
 };
@@ -45,8 +45,7 @@ async fn can_clone() {
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
         radicle
-            .sign(peer1.key(), &Signatory::User(alice.urn()), &alice)
-            .await
+            .sign_by_user(peer1.key(), &alice.clone().as_verified())
             .unwrap();
 
         tokio::task::spawn_blocking(move || {
@@ -78,8 +77,7 @@ async fn fetches_on_gossip_notify() {
         let alice = Alice::new(peer1.public_key());
         let mut radicle = Radicle::new(&alice);
         radicle
-            .sign(peer1.key(), &Signatory::User(alice.urn()), &alice)
-            .await
+            .sign_by_user(peer1.key(), &alice.clone().as_verified())
             .unwrap();
 
         let peer1_storage = peer1.storage();

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -45,14 +45,7 @@ async fn can_clone() {
 
         let mut alice = Alice::new(peer1.public_key());
         alice.sign_owned(peer1.key()).unwrap();
-        let verified_alice = alice
-            .clone()
-            .check_signatures()
-            .unwrap()
-            .check_signatures_ownership(&cache)
-            .unwrap()
-            .check_update(&None)
-            .unwrap();
+        let verified_alice = alice.clone().verify(&mut cache).unwrap();
         cache.register_verified_entity(&verified_alice).unwrap();
         let mut radicle = Radicle::new(&alice);
         radicle.sign_by_user(peer1.key(), &verified_alice).unwrap();
@@ -86,14 +79,7 @@ async fn fetches_on_gossip_notify() {
 
         let mut alice = Alice::new(peer1.public_key());
         alice.sign_owned(peer1.key()).unwrap();
-        let verified_alice = alice
-            .clone()
-            .check_signatures()
-            .unwrap()
-            .check_signatures_ownership(&cache)
-            .unwrap()
-            .check_update(&None)
-            .unwrap();
+        let verified_alice = alice.clone().verify(&mut cache).unwrap();
         cache.register_verified_entity(&verified_alice).unwrap();
         let mut radicle = Radicle::new(&alice);
         radicle.sign_by_user(peer1.key(), &verified_alice).unwrap();


### PR DESCRIPTION
This code does the following:

* refactor how signatures are stored inside entities to make verification simpler
* implement an entity cache that holds the full signatures graph in memory in a compact form
* using this graph, implement:
  - key ownership verification
  - key revocation
  - forked entity revisions
  - entity tainting (with taint propagation) in case of signature revocation or revision forking

I am adapting entity verification to use this cache.