### PR TITLE
Remove Surf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,6 @@ dependencies = [
  "proptest",
  "quinn",
  "radicle-keystore",
- "radicle-surf",
  "rand 0.7.3",
  "rand_pcg 0.2.1",
  "rcgen",
@@ -1101,12 +1100,6 @@ name = "nonempty"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7747482c817116898e7aeda0d68c90998d47ee0db28b7030d44584ef7695d355"
-
-[[package]]
-name = "nonempty"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7ac1e5ea23db6d61ad103e91864675049644bf47c35912336352fa4e9c109"
 
 [[package]]
 name = "nonzero_ext"
@@ -1412,19 +1405,6 @@ dependencies = [
  "serde",
  "serde_cbor",
  "sodiumoxide",
- "thiserror",
-]
-
-[[package]]
-name = "radicle-surf"
-version = "0.2.1"
-source = "git+https://github.com/radicle-dev/radicle-surf?rev=5728b74e77d12769ac917d04c4901994f30092ae#5728b74e77d12769ac917d04c4901994f30092ae"
-dependencies = [
- "git2",
- "lazy_static",
- "nonempty 0.5.0",
- "regex",
- "serde",
  "thiserror",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -202,6 +202,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
     "https://github.com/radicle-dev/radicle-keystore",
-    "https://github.com/radicle-dev/radicle-surf",
     "https://github.com/kim/rustls"
 ]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -66,11 +66,6 @@ features = ["tls-rustls"]
 git = "https://github.com/radicle-dev/radicle-keystore"
 rev = "a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
 
-[dependencies.radicle-surf]
-git = "https://github.com/radicle-dev/radicle-surf"
-rev = "5728b74e77d12769ac917d04c4901994f30092ae"
-features = ["serialize"]
-
 [dependencies.rustls]
 version = "0.17"
 features = ["logging", "dangerous_configuration"]

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -17,7 +17,6 @@
 
 use std::collections::HashSet;
 
-use radicle_surf::vcs::git as surf;
 use thiserror::Error;
 
 use crate::{
@@ -54,13 +53,6 @@ pub struct Repo<'a, S: Clone> {
 impl<'a, S: Clone> Repo<'a, S> {
     pub fn namespace(&self) -> Namespace {
         self.urn.id.clone()
-    }
-
-    /// Obtain a read-only view of this repo
-    pub fn browser(&'_ self, revision: &str) -> Result<surf::Browser<'_>, Error> {
-        self.storage
-            .browser(&self.urn, revision)
-            .map_err(Error::from)
     }
 
     /// Stop tracking [`PeerId`]s view of this repo

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -26,7 +26,6 @@ use std::{
     path::Path,
 };
 
-use radicle_surf::vcs::git as surf;
 use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 
@@ -127,9 +126,6 @@ pub enum Error {
     Cjson(#[from] CjsonError),
 
     #[error(transparent)]
-    Surf(#[from] surf::error::Error),
-
-    #[error(transparent)]
     Blob(#[from] blob::Error),
 
     #[error(transparent)]
@@ -196,19 +192,6 @@ impl<S: Clone> Storage<S> {
             urn,
             storage: self.into(),
         })
-    }
-
-    /// Get a [`surf::Browser`] for the project at `urn`. The `Browser` will be
-    /// initialised with history found at the given `revision`.
-    pub fn browser(&'_ self, urn: &RadUrn, revision: &str) -> Result<surf::Browser<'_>, Error> {
-        let namespace = surf::Namespace::from(urn.id.to_string().as_str());
-        // TODO(finto): Should the revision be the default branch of the project?
-        // If so we need resolvers to fetch the project from the urn.
-        Ok(surf::Browser::new_with_namespace(
-            &self.backend,
-            &namespace,
-            revision,
-        )?)
     }
 
     /// Get the [`Entity`] metadata found at the provided [`RadUrn`].

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -27,8 +27,6 @@ extern crate lazy_static;
 extern crate radicle_keystore as keystore;
 extern crate sodiumoxide;
 
-pub use radicle_surf as surf;
-
 pub mod git;
 pub mod hash;
 pub mod internal;


### PR DESCRIPTION
This may be _controversial_, but I was thinking we could just remove surf altogether. `Storage` has an `AsRef<git::Repository>` impl so we can create a `Browser` by getting the ref, and then build the `Namespace` from the `RadUrn`'s `id`.

i.e.
```rust
let namespace = Namespace::from(urn.id.to_string());
let browser = Broswer::new_with_namespace(storage.as_ref(), &namespace, default_branch)?;
```

This means that we'll never get any mismatch between the `Browser` `librad` will given back and the `Browser` by the version provided by crates in upstream code.

If this doesn't suit, I can opt for the version bound route instead.