### PR TITLE
Add get for rad/self

### DIFF
--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -76,6 +76,21 @@ impl<'a, S: Clone> Repo<'a, S> {
         self.storage.rad_refs(&self.urn).map_err(Error::from)
     }
 
+    /// Get `rad/self` identity for this repo.
+    pub fn get_rad_self(&self) -> Result<User<Draft>, Error> {
+        self.get_rad_self_of(None)
+    }
+
+    /// Get the `rad/self` identity for the remote `peer` under the `urn`.
+    pub fn get_rad_self_of<P>(&self, peer: P) -> Result<User<Draft>, Error>
+    where
+        P: Into<Option<PeerId>>,
+    {
+        self.storage
+            .get_rad_self_of(&self.urn, peer)
+            .map_err(Error::from)
+    }
+
     /// Retrieve the certifier URNs of this repo's identity
     pub fn certifiers(&self) -> Result<HashSet<RadUrn>, Error> {
         self.storage.certifiers(&self.urn).map_err(Error::from)
@@ -137,21 +152,6 @@ impl<'a> Repo<'a, WithSigner> {
     {
         self.storage
             .set_rad_self(&self.urn, spec)
-            .map_err(Error::from)
-    }
-
-    /// Get `rad/self` identity for this repo.
-    pub fn get_rad_self(&self) -> Result<User<Draft>, Error> {
-        self.get_rad_self_of(None)
-    }
-
-    /// Get the `rad/self` identity for the remote `peer` under the `urn`.
-    pub fn get_rad_self_of<P>(&self, peer: P) -> Result<User<Draft>, Error>
-    where
-        P: Into<Option<PeerId>>,
-    {
-        self.storage
-            .get_rad_self_of(&self.urn, peer)
             .map_err(Error::from)
     }
 }

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -26,6 +26,7 @@ use crate::{
         types::Namespace,
     },
     internal::borrow::{TryCow, TryToOwned},
+    meta::{entity::Draft, user::User},
     peer::PeerId,
     uri::{RadUrl, RadUrn},
 };
@@ -136,6 +137,21 @@ impl<'a> Repo<'a, WithSigner> {
     {
         self.storage
             .set_rad_self(&self.urn, spec)
+            .map_err(Error::from)
+    }
+
+    /// Get `rad/self` identity for this repo.
+    pub fn get_rad_self(&self) -> Result<User<Draft>, Error> {
+        self.get_rad_self_of(None)
+    }
+
+    /// Get the `rad/self` identity for the remote `peer` under the `urn`.
+    pub fn get_rad_self_of<P>(&self, peer: P) -> Result<User<Draft>, Error>
+    where
+        P: Into<Option<PeerId>>,
+    {
+        self.storage
+            .get_rad_self_of(&self.urn, peer)
             .map_err(Error::from)
     }
 }

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -60,7 +60,7 @@ use crate::{
             Signatory,
             Verified,
         },
-        user::{User, UserInfo},
+        user::User,
     },
     paths::Paths,
     peer::{self, PeerId},
@@ -213,14 +213,11 @@ impl<S: Clone> Storage<S> {
         T: Clone + Serialize + DeserializeOwned + EntityInfoExt,
         P: Into<Option<PeerId>>,
     {
-        let rad_id = Reference::rad_id(urn.id.clone()).set_remote(peer.into());
-        let blob = Blob::Tip {
-            branch: rad_id.borrow().into(),
-            path: Path::new("id"),
-        }
-        .get(&self.backend)?;
-
-        Entity::<T, Draft>::from_json_slice(blob.content()).map_err(Error::from)
+        self.metadata_from_reference(
+            Reference::rad_id(urn.id.clone())
+                .set_remote(peer.into())
+                .borrow(),
+        )
     }
 
     /// Like [`Storage::metadata`], but for situations where the type is not
@@ -235,14 +232,11 @@ impl<S: Clone> Storage<S> {
     where
         P: Into<Option<PeerId>>,
     {
-        let rad_id = Reference::rad_id(urn.id.clone()).set_remote(peer.into());
-        let blob = Blob::Tip {
-            branch: rad_id.borrow().into(),
-            path: Path::new("id"),
-        }
-        .get(&self.backend)?;
-
-        GenericDraftEntity::from_json_slice(blob.content()).map_err(Error::from)
+        self.metadata_from_reference(
+            Reference::rad_id(urn.id.clone())
+                .set_remote(peer.into())
+                .borrow(),
+        )
     }
 
     /// Get all the [`Entity`] data in this `Storage`.
@@ -254,15 +248,7 @@ impl<S: Clone> Storage<S> {
     ) -> Result<impl Iterator<Item = Result<GenericDraftEntity, Error>> + 'a, Error> {
         let iter = References::from_globs(&self.backend, &["refs/namespaces/*/rad/id"])?;
 
-        Ok(iter.map(move |reference| {
-            let reference = reference?;
-            let blob = Blob::Tip {
-                branch: reference.into(),
-                path: Path::new("id"),
-            }
-            .get(&self.backend)?;
-            GenericDraftEntity::from_json_slice(blob.content()).map_err(Error::from)
-        }))
+        Ok(iter.map(move |reference| self.metadata_from_reference(reference?)))
     }
 
     /// Retrieve the `rad/self` identity configured via
@@ -270,6 +256,19 @@ impl<S: Clone> Storage<S> {
     pub fn default_rad_self(&self) -> Result<User<Draft>, Error> {
         let urn = Config::try_from(&self.backend)?.user()?;
         self.metadata(&urn)
+    }
+
+    /// Get the `rad/self` identity for `urn`.
+    pub fn get_rad_self(&self, urn: &RadUrn) -> Result<User<Draft>, Error> {
+        self.get_rad_self_of(urn, None)
+    }
+
+    /// Get the `rad/self` identity for the remote `peer` under the `urn`.
+    pub fn get_rad_self_of<P>(&self, urn: &RadUrn, peer: P) -> Result<User<Draft>, Error>
+    where
+        P: Into<Option<PeerId>>,
+    {
+        self.metadata_from_reference(Reference::rad_self(urn.id.clone(), peer).borrow())
     }
 
     pub fn certifiers_of(&self, urn: &RadUrn, peer: &PeerId) -> Result<HashSet<RadUrn>, Error> {
@@ -432,6 +431,20 @@ impl<S: Clone> Storage<S> {
             name.strip_prefix(&namespace_prefix)
                 .map(|name| (name.to_owned(), target))
         }))
+    }
+
+    fn metadata_from_reference<'a, R, T>(&self, reference: R) -> Result<Entity<T, Draft>, Error>
+    where
+        R: Into<blob::Branch<'a>>,
+        T: Clone + Serialize + DeserializeOwned + EntityInfoExt,
+    {
+        let blob = Blob::Tip {
+            branch: reference.into(),
+            path: Path::new("id"),
+        }
+        .get(&self.backend)?;
+
+        Entity::<T, Draft>::from_json_slice(blob.content()).map_err(Error::from)
     }
 }
 
@@ -804,27 +817,6 @@ impl Storage<WithSigner> {
                     .map_err(Error::from)
             },
         }
-    }
-
-    /// Get the `rad/self` identity for `urn`.
-    pub fn get_rad_self(&self, urn: &RadUrn) -> Result<User<Draft>, Error> {
-        self.get_rad_self_of(urn, None)
-    }
-
-    /// Get the `rad/self` identity for the remote `peer` under the `urn`.
-    pub fn get_rad_self_of<P>(&self, urn: &RadUrn, peer: P) -> Result<User<Draft>, Error>
-    where
-        P: Into<Option<PeerId>>,
-    {
-        let rad_self = Reference::rad_self(urn.id.clone(), None).set_remote(peer.into());
-
-        let blob = Blob::Tip {
-            branch: rad_self.borrow().into(),
-            path: Path::new("id"),
-        }
-        .get(&self.backend)?;
-
-        Entity::<UserInfo, Draft>::from_json_slice(blob.content()).map_err(Error::from)
     }
 
     pub fn track(&self, urn: &RadUrn, peer: &PeerId) -> Result<(), Error> {


### PR DESCRIPTION
Allow us to retrieve the rad/self for some RadUrn (and PeerId) in our Storage.
For Repo it delegates to the Storage passing its own RadUrn.