### PR TITLE
Fix RadUrn

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -806,12 +806,15 @@ impl Storage<WithSigner> {
                     },
                 }?;
 
+                let sym_log_msg = &format!("{} -> {}", src, target);
+                tracing::info!("creating symbolic link: {}", sym_log_msg);
+
                 self.backend
                     .reference_symbolic(
                         &src.to_string(),
                         &target.to_string(),
                         /* force */ true,
-                        &format!("{} -> {}", src, target),
+                        sym_log_msg,
                     )
                     .and(Ok(()))
                     .map_err(Error::from)

--- a/librad/src/git/storage/test.rs
+++ b/librad/src/git/storage/test.rs
@@ -206,15 +206,26 @@ async fn set_and_get_rad_self() -> Result<(), Error> {
         .check_history_status(&user_resolver, &user_resolver)
         .await
         .unwrap();
+    store.create_repo(&user)?;
+    store.set_default_rad_self(verified_user.clone())?;
 
     let mut project = Project::<Draft>::create("banana".to_owned(), user.urn())?;
     project.sign_by_user(&key, &verified_user)?;
 
-    // Store the three entities in their respective namespaces
-    store.create_repo(&user)?;
     let repo = store.create_repo(&project)?;
+    repo.set_rad_self(RadSelfSpec::Default)
+        .expect("repo error:");
 
-    assert_eq!(repo.get_rad_self().expect("repo error:"), user);
-    assert_eq!(store.get_rad_self(&project.urn())?, user);
+    assert_eq!(
+        repo.get_rad_self().expect("repo error:"),
+        store.default_rad_self()?
+    );
+    assert_eq!(
+        store.get_rad_self(&project.urn())?,
+        store.default_rad_self()?
+    );
+    Ok(())
+}
+
     Ok(())
 }

--- a/librad/src/git/storage/test.rs
+++ b/librad/src/git/storage/test.rs
@@ -227,5 +227,61 @@ async fn set_and_get_rad_self() -> Result<(), Error> {
     Ok(())
 }
 
+/// We want to test that structure of the storage is compliant with the
+/// [RFC](https://github.com/radicle-dev/radicle-link/blob/504fe66dd974eaddb329520264d1cfdeb492b28f/docs/rfc/identity_resolution.md).
+/// So for every namespace there should be a `rad/id` and `rad/refs`.
+#[async_test]
+async fn test_structure_of_refs() -> Result<(), Error> {
+    let key = SecretKey::new();
+    let store = storage(key.clone());
+    let mut refs = vec![];
+
+    // Create signed and verified user
+    let mut user = User::<Draft>::create("user".to_owned(), key.public())?;
+    user.sign_owned(&key)?;
+    let user_resolver = ConstResolver::new(user.clone());
+    let verified_user = user
+        .clone()
+        .check_history_status(&user_resolver, &user_resolver)
+        .await
+        .unwrap();
+    refs.push(Reference::rad_id(user.urn().id));
+    refs.push(Reference::rad_refs(user.urn().id, None));
+    store.create_repo(&user)?;
+    store.set_default_rad_self(verified_user)?;
+
+    // Set up project banana
+    {
+        let mut project = Project::<Draft>::create("banana".to_owned(), user.urn())?
+            .to_builder()
+            .add_key(key.public())
+            .build()?;
+        project.sign_owned(&key)?;
+        let namespace = project.urn().id;
+        refs.push(Reference::rad_id(namespace.clone()));
+        refs.push(Reference::rad_refs(namespace, None));
+        let _repo = store.create_repo(&project)?;
+    }
+
+    // Set up project pineapple
+    {
+        let mut project = Project::<Draft>::create("pineapple".to_owned(), user.urn())?
+            .to_builder()
+            .add_key(key.public())
+            .build()?;
+        project.sign_owned(&key)?;
+        let namespace = project.urn().id;
+        refs.push(Reference::rad_id(namespace.clone()));
+        refs.push(Reference::rad_refs(namespace, None));
+        let _repo = store.create_repo(&project)?;
+    }
+
+    // Ensure that we can find all the references
+    for reference in refs {
+        reference
+            .find(&store.backend)
+            .unwrap_or_else(|err| panic!("could not find ref '{}', error: {}", reference, err));
+    }
+
     Ok(())
 }

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -345,7 +345,7 @@ where
 
     /// `urn` getter
     pub fn urn(&self) -> RadUrn {
-        RadUrn::new(self.hash.to_owned(), Protocol::Git, Path::new())
+        RadUrn::new(self.root_hash.to_owned(), Protocol::Git, Path::new())
     }
 
     /// `parent_hash` getter


### PR DESCRIPTION
The `urn` method on `Entity` was using `hash` instead of `root_hash`. This means that are `RadUrn`'s weren't stable and the repository was not in the correct format. It would result in a lone `namespace/<id>` with just `rad/refs` while the entity's `rad/id` would live in another `namespace/<id>`.

This PR fixes this issue and adds a test case to ensure that we have each of those refs under the `namespace` for each repo we create.