### PR TITLE
Enable construction of `Paths` from a root set via the environment

### DIFF
--- a/librad/src/paths.rs
+++ b/librad/src/paths.rs
@@ -17,6 +17,7 @@
 
 use std::{
     collections::HashMap,
+    env,
     fs,
     io,
     path::{Path, PathBuf},
@@ -59,6 +60,13 @@ impl Paths {
             git_dir: root.join("git"),
         }
         .init()
+    }
+
+    pub fn from_env() -> Result<Self, io::Error> {
+        match env::var_os("RAD_HOME") {
+            None => Self::new(),
+            Some(root) => Self::from_root(root),
+        }
     }
 
     pub fn keys_dir(&self) -> &Path {


### PR DESCRIPTION
Naming of the environment variable, as well as the general XDG scheme, will
need to be revisited for robustness between different radicle applications.
