### PR TITLE
Git remote helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,10 +1413,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "radicle-git-helpers"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "git2",
+ "libgit2-sys",
+ "librad",
+ "librad-test",
+ "radicle-keystore",
+ "tempfile",
+]
+
+[[package]]
 name = "radicle-keystore"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-keystore?rev=a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa#a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
+source = "git+https://github.com/radicle-dev/radicle-keystore?rev=27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6#27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
 dependencies = [
+ "async-trait",
+ "futures",
  "lazy_static",
  "rpassword",
  "secstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "librad", "librad-test", "radicle-tracker" ]
+members = [ "librad", "librad-test", "git-helpers", "radicle-tracker" ]
 
 [patch.crates-io]
 # Ed25519 support for rustls

--- a/git-helpers/Cargo.toml
+++ b/git-helpers/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "radicle-git-helpers"
+description = "Git helpers for radicle-link"
+version = "0.1.0"
+authors = ["The Radicle Team <dev@radicle.xyz>"]
+edition = "2018"
+license = "GPL-3.0-or-later"
+
+[dependencies]
+anyhow = "1"
+
+[dependencies.librad]
+path = "../librad"
+
+[dependencies.radicle-keystore]
+git = "https://github.com/radicle-dev/radicle-keystore"
+rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
+
+[dependencies.git2]
+version = "0"
+default-features = false
+features = []
+
+[dependencies.libgit2-sys]
+version = "0"
+default-features = false
+features = []
+
+[[bin]]
+name = "git-remote-rad"
+path = "src/bin/remote/main.rs"
+
+[dev-dependencies]
+futures = ">= 0.3"
+tempfile = "3"
+
+[dev-dependencies.librad-test]
+path = "../librad-test"

--- a/git-helpers/src/bin/remote/main.rs
+++ b/git-helpers/src/bin/remote/main.rs
@@ -1,0 +1,97 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![feature(str_strip)]
+
+use std::{
+    env,
+    io,
+    path::{Path, PathBuf},
+};
+
+use librad::{
+    git::local::{
+        transport::{LocalTransport, Localio, Mode::Stateful, Settings},
+        url::LocalUrl,
+    },
+    keys::{PublicKey, SecretKey},
+    paths::Paths,
+};
+use radicle_git_helpers::credential;
+use radicle_keystore::{crypto::Pwhash, FileStorage, Keystore};
+
+// FIXME: this should be defined elsewhere to be consistent between applications
+const SECRET_KEY_FILE: &str = "librad.key";
+
+fn main() -> anyhow::Result<()> {
+    let url = {
+        let args = env::args().skip(1).take(2).collect::<Vec<_>>();
+        args[0]
+            .parse()
+            .or_else(|_| args[1].parse())
+            .or_else(|_| Err(anyhow::anyhow!("invalid args: {:?}", args)))
+    }?;
+
+    let git_dir = env::var("GIT_DIR").map(PathBuf::from)?;
+
+    let mut transport = {
+        let paths = Paths::from_env()?;
+        let key = get_signer(&git_dir, paths.keys_dir(), &url)?;
+        LocalTransport::new(Settings { paths, signer: key })
+    }?;
+
+    loop {
+        let mut buf = String::with_capacity(32);
+        io::stdin().read_line(&mut buf)?;
+        let line = buf.trim();
+
+        if line == "capabilities" {
+            println!("connect\n\n");
+            continue;
+        }
+
+        if let Some(service) = line.strip_prefix("connect ") {
+            let service = match service {
+                "git-upload-pack" => Ok(git2::transport::Service::UploadPack),
+                "git-receive-pack" => Ok(git2::transport::Service::ReceivePack),
+                unknown => Err(anyhow::anyhow!("unknown service: {}", unknown)),
+            }?;
+
+            println!();
+
+            transport
+                .connect(url, service, Stateful, Localio::inherit())?
+                .wait()?;
+
+            break;
+        }
+
+        return Err(anyhow::anyhow!("unexpected command: {}", line));
+    }
+
+    Ok(())
+}
+
+fn get_signer(git_dir: &Path, keys_dir: &Path, url: &LocalUrl) -> anyhow::Result<SecretKey> {
+    let pass = credential::Git::new(git_dir).get(url)?;
+    let file = keys_dir.join(SECRET_KEY_FILE);
+    let keystore = FileStorage::<_, PublicKey, _, _>::new(&file, Pwhash::new(pass));
+    keystore
+        .get_key()
+        .map(|keypair| keypair.secret_key)
+        .map_err(|e| e.into())
+}

--- a/git-helpers/src/credential.rs
+++ b/git-helpers/src/credential.rs
@@ -1,0 +1,105 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    env,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use keystore::pinentry::SecUtf8;
+use librad::git::local::url::LocalUrl;
+
+pub type Passphrase = SecUtf8;
+
+pub trait Credential {
+    fn get(&self, url: &LocalUrl) -> io::Result<Passphrase>;
+    fn put(&mut self, url: &LocalUrl, passphrase: Passphrase) -> io::Result<()>;
+}
+
+pub struct Git {
+    git_dir: PathBuf,
+}
+
+impl Git {
+    pub fn new(git_dir: &Path) -> Self {
+        Self {
+            git_dir: git_dir.to_path_buf(),
+        }
+    }
+
+    pub fn get(&self, url: &LocalUrl) -> io::Result<Passphrase> {
+        let mut child = Command::new("git")
+            .env("GIT_DIR", &self.git_dir)
+            .envs(env::vars().filter(|(key, _)| key.starts_with("GIT_TRACE")))
+            .args(&["credential", "fill"])
+            .current_dir(&self.git_dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+
+        {
+            let stdin = child.stdin.as_mut().expect("could not obtain stdin");
+            stdin.write_all(format!("url={}\nusername=radicle\n\n", url).as_bytes())?;
+        }
+
+        let output = child.wait_with_output()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let passphrase = stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("password=").map(Passphrase::from));
+
+        passphrase
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "couldn't obtain passphrase"))
+    }
+
+    pub fn put(&mut self, url: &LocalUrl, passphrase: Passphrase) -> io::Result<()> {
+        let mut child = Command::new("git")
+            .env("GIT_DIR", &self.git_dir)
+            .envs(env::vars().filter(|(key, _)| key.starts_with("GIT_TRACE")))
+            .args(&["credential", "approve"])
+            .current_dir(&self.git_dir)
+            .stdin(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .spawn()?;
+
+        let stdin = child.stdin.as_mut().expect("could not obtain stdin");
+        stdin.write_all(
+            format!(
+                "url={}\nusername=radicle\npassword={}",
+                url,
+                passphrase.unsecure()
+            )
+            .as_bytes(),
+        )?;
+
+        Ok(())
+    }
+}
+
+impl Credential for Git {
+    fn get(&self, url: &LocalUrl) -> io::Result<Passphrase> {
+        self.get(url)
+    }
+
+    fn put(&mut self, url: &LocalUrl, passphrase: Passphrase) -> io::Result<()> {
+        self.put(url, passphrase)
+    }
+}

--- a/git-helpers/src/lib.rs
+++ b/git-helpers/src/lib.rs
@@ -1,0 +1,22 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![feature(str_strip)]
+
+extern crate radicle_keystore as keystore;
+
+pub mod credential;

--- a/git-helpers/tests/remote.rs
+++ b/git-helpers/tests/remote.rs
@@ -1,0 +1,196 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![feature(str_strip)]
+
+extern crate radicle_keystore as keystore;
+
+use std::{
+    env,
+    fs::{self, Permissions},
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use futures::executor::block_on;
+use keystore::{pinentry::SecUtf8, Keystore};
+use tempfile::tempdir;
+
+use librad::{
+    git::{local::url::LocalUrl, storage::Storage},
+    keys::{PublicKey, SecretKey},
+    meta::entity::Signatory,
+    paths::Paths,
+    uri::RadUrn,
+};
+use librad_test::{
+    logging,
+    rad::entity::{Alice, Radicle},
+};
+use radicle_git_helpers::credential;
+
+const PASSPHRASE: &str = "123";
+
+#[test]
+fn smoke() {
+    logging::init();
+
+    let rad_dir = tempdir().unwrap();
+    let rad_paths = Paths::from_root(rad_dir.path()).unwrap();
+    let key = SecretKey::new();
+
+    let urn = block_on(setup_entity(&rad_paths, key.clone())).unwrap();
+    setup_keystore(rad_paths.keys_dir(), key).unwrap();
+    let path = setup_path().unwrap();
+
+    let credentials_cache_dir = tempdir().unwrap();
+    fs::set_permissions(credentials_cache_dir.path(), Permissions::from_mode(0o700)).unwrap();
+    let credentials_cache_socket = credentials_cache_dir.path().join("socket");
+
+    // Push something to `urn`
+    {
+        let repo_dir = tempdir().unwrap();
+        setup_repo(repo_dir.path(), &credentials_cache_socket, &urn).unwrap();
+
+        let mut child = Command::new("git")
+            .args(&["push", "origin", "master"])
+            .current_dir(repo_dir.path())
+            .env("PATH", &path)
+            .env("RAD_HOME", rad_dir.path())
+            .env("GIT_DIR", repo_dir.path().join(".git"))
+            .envs(env::vars().filter(|(key, _)| key.starts_with("GIT_TRACE")))
+            .spawn()
+            .unwrap();
+
+        let status = child.wait().unwrap();
+        assert!(status.success())
+    }
+
+    // Clone from `urn` into a fresh repo
+    {
+        let repo_dir = tempdir().unwrap();
+        let mut child = Command::new("git")
+            .arg("-c")
+            .arg(format!(
+                "credential.helper=cache --timeout 10 --socket {}",
+                credentials_cache_socket.to_string_lossy()
+            ))
+            .arg("clone")
+            .arg(LocalUrl::from(urn).to_string())
+            .arg(repo_dir.path())
+            .env("PATH", &path)
+            .env("RAD_HOME", rad_dir.path())
+            .envs(env::vars().filter(|(key, _)| key.starts_with("GIT_TRACE")))
+            .spawn()
+            .unwrap();
+
+        let status = child.wait().unwrap();
+        assert!(status.success())
+    }
+}
+
+async fn setup_entity(paths: &Paths, key: SecretKey) -> anyhow::Result<RadUrn> {
+    let mut alice = Alice::new(key.public());
+    let mut radicle = Radicle::new(&alice);
+    {
+        let resolves_to_alice = alice.clone();
+        alice
+            .sign(&key, &Signatory::OwnedKey, &resolves_to_alice)
+            .await?;
+        radicle
+            .sign(&key, &Signatory::User(alice.urn()), &resolves_to_alice)
+            .await?;
+
+        let store = Storage::open_or_init(&paths, key)?;
+        store.create_repo(&alice)?;
+        store.create_repo(&radicle)?;
+    }
+
+    Ok(radicle.urn())
+}
+
+fn setup_keystore(dir: &Path, key: SecretKey) -> anyhow::Result<()> {
+    let mut keystore = keystore::FileStorage::<_, PublicKey, _, _>::new(
+        &dir.join("librad.key"),
+        keystore::crypto::Pwhash::new(SecUtf8::from(PASSPHRASE)),
+    );
+    keystore.put_key(key)?;
+
+    Ok(())
+}
+
+fn setup_repo(path: &Path, credentials_cache_socket: &Path, origin: &RadUrn) -> anyhow::Result<()> {
+    let repo = git2::Repository::init(path)?;
+    let blob = repo.blob(b"do you know who I am?")?;
+    let tree = {
+        let mut builder = repo.treebuilder(None)?;
+        builder.insert("README", blob, 0o100_644)?;
+        let oid = builder.write()?;
+        repo.find_tree(oid)
+    }?;
+    let author = git2::Signature::now("Charlie H.", "ch@iohk.io")?;
+    repo.commit(
+        Some("refs/heads/master"),
+        &author,
+        &author,
+        "Initial commit",
+        &tree,
+        &[],
+    )?;
+
+    repo.set_head("refs/heads/master")?;
+    repo.remote("origin", &LocalUrl::from(origin).to_string())?;
+
+    let mut config = repo.config()?;
+    setup_credential_cache(repo.path(), credentials_cache_socket, &mut config, origin)
+}
+
+fn setup_credential_cache(
+    git_dir: &Path,
+    credentials_cache_socket: &Path,
+    config: &mut git2::Config,
+    urn: &RadUrn,
+) -> anyhow::Result<()> {
+    config.set_str(
+        "credential.helper",
+        &format!(
+            "cache --timeout=10 --socket {}",
+            credentials_cache_socket.display()
+        ),
+    )?;
+
+    credential::Git::new(&git_dir).put(&urn.into(), SecUtf8::from(PASSPHRASE))?;
+
+    Ok(())
+}
+
+fn setup_path() -> anyhow::Result<PathBuf> {
+    let helper_path = env!("CARGO_BIN_EXE_git-remote-rad");
+    let helper_path = Path::new(helper_path.strip_suffix("git-remote-rad").unwrap());
+    let path = match env::var_os("PATH") {
+        None => env::join_paths(Some(helper_path)),
+        Some(path) => {
+            let mut paths = env::split_paths(&path).collect::<Vec<_>>();
+            paths.push(helper_path.to_path_buf());
+            paths.reverse();
+            env::join_paths(paths)
+        },
+    }?;
+
+    Ok(PathBuf::from(path))
+}

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -65,7 +65,7 @@ features = ["tls-rustls"]
 
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-keystore"
-rev = "a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
+rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
 
 [dependencies.rustls]
 version = "0.17"


### PR DESCRIPTION
Builds on top of the local transport, allowing interaction with the storage
backend via the git CLI. Noteworthy is the use of git's credential helper
infrastructure to prompt for the keystore passphrase.

Note that it is not yet clear how to set HEAD (the default branch) for the
logical repository, rendering the clone without a checked-out working copy.
Configuring the remote tracking branches as actual remotes in the work tree is
not part of this patch either.
