### PR TITLE
Fire gossip announcement from git remote callback in e2e test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ checksum = "e742194e0f43fc932bcb801708c2b279d3ec8f527e3acda05a6a9f342c5ef764"
 dependencies = [
  "argh_shared",
  "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]


### PR DESCRIPTION
For demonstration purposes, mainly.

Unfortunately, I can't see a way to intercept `git-receive-pack` in such a way
that we could get at the pushed refs -- otherwise, the local transport could
handle to gossiping.

Also, async/await raises its ugly head again.
