### PR TITLE
Entity signatures refactor

### DIFF
--- a/librad-test/src/rad/resolver.rs
+++ b/librad-test/src/rad/resolver.rs
@@ -33,6 +33,7 @@ pub struct ConstResolver<A, S> {
 impl<A, S> ConstResolver<A, S>
 where
     A: Clone + Default + Serialize + DeserializeOwned + EntityInfoExt,
+    S: Clone,
 {
     pub fn new(entity: Entity<A, S>) -> Self {
         let urn = entity.urn();

--- a/librad/src/hash.rs
+++ b/librad/src/hash.rs
@@ -54,6 +54,10 @@ impl Hash {
     pub fn as_ref(&self) -> HashRef {
         HashRef(&self.0)
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
 }
 
 impl Hasher for Hash {

--- a/librad/src/meta/project.rs
+++ b/librad/src/meta/project.rs
@@ -26,6 +26,7 @@ use crate::{
             data::{EntityData, EntityInfoExt, EntityKind},
             Draft,
             Entity,
+            EntityTimestamp,
             Error,
         },
     },
@@ -147,8 +148,8 @@ impl<ST> Project<ST>
 where
     ST: Clone,
 {
-    pub fn maintainers(&self) -> &std::collections::HashSet<RadUrn> {
-        self.certifiers()
+    pub fn maintainers(&self) -> impl Iterator<Item = &RadUrn> {
+        self.certifiers().iter().map(|(k, _)| k)
     }
 
     pub fn description(&self) -> &Option<String> {
@@ -164,7 +165,7 @@ where
     }
 
     pub fn create(name: String, owner: RadUrn) -> Result<Project<Draft>, Error> {
-        ProjectData::default()
+        ProjectData::new(EntityTimestamp::current_time())
             .set_name(name)
             .set_revision(1)
             .add_certifier(owner)
@@ -196,7 +197,7 @@ pub mod tests {
             proptest::collection::vec(gen_relation(), 0..16),
         )
             .prop_map(|(name, description, branch, maintainers, rels)| {
-                ProjectData::default()
+                ProjectData::new(EntityTimestamp::current_time())
                     .set_revision(1)
                     .set_name(name)
                     .set_optional_description(description)

--- a/librad/src/meta/user.rs
+++ b/librad/src/meta/user.rs
@@ -26,6 +26,7 @@ use crate::{
             data::{EntityData, EntityInfoExt, EntityKind},
             Draft,
             Entity,
+            EntityTimestamp,
             Error,
         },
         profile::{Geo, ProfileImage, UserProfile},
@@ -175,7 +176,7 @@ where
     ST: Clone,
 {
     pub fn create(name: String, key: PublicKey) -> Result<User<Draft>, Error> {
-        UserData::default()
+        UserData::new(EntityTimestamp::current_time())
             .set_name(name)
             .set_revision(1)
             .add_key(key)
@@ -224,7 +225,7 @@ pub mod tests {
     pub fn gen_user() -> impl Strategy<Value = User<Draft>> {
         (proptest::option::of(gen_profile_ref()), gen_largefiles()).prop_map(
             |(profile, largefiles)| {
-                UserData::default()
+                UserData::new(EntityTimestamp::current_time())
                     .set_name("foo".to_owned())
                     .set_revision(1)
                     .add_key(K1.public())

--- a/librad/src/test.rs
+++ b/librad/src/test.rs
@@ -36,6 +36,7 @@ pub struct ConstResolver<A, S> {
 impl<A, S> ConstResolver<A, S>
 where
     A: Clone + Default + Serialize + DeserializeOwned + EntityInfoExt,
+    S: Clone,
 {
     pub fn new(entity: Entity<A, S>) -> Self {
         let urn = entity.urn();

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use futures::{future, stream::StreamExt};
 
 use librad::{
-    meta::{entity::Signatory, project::ProjectInfo},
+    meta::project::ProjectInfo,
     net::peer::{FetchInfo, Gossip, PeerEvent, Rev},
     uri::{self, RadUrn},
 };
@@ -47,18 +47,9 @@ async fn can_clone() {
         let mut alice = Alice::new(peer1_key.public());
         let mut radicle = Radicle::new(&alice);
         {
-            let resolves_to_alice = alice.clone();
-            alice
-                .sign(&peer1_key, &Signatory::OwnedKey, &resolves_to_alice)
-                .await
-                .unwrap();
+            alice.sign_owned(&peer1_key).unwrap();
             radicle
-                .sign(
-                    &peer1_key,
-                    &Signatory::User(alice.urn()),
-                    &resolves_to_alice,
-                )
-                .await
+                .sign_by_user(&peer1_key, &(*alice).as_verified())
                 .unwrap();
         }
 
@@ -91,18 +82,9 @@ async fn fetches_on_gossip_notify() {
         let mut alice = Alice::new(peer1_key.public());
         let mut radicle = Radicle::new(&alice);
         {
-            let resolves_to_alice = alice.clone();
-            alice
-                .sign(&peer1_key, &Signatory::OwnedKey, &resolves_to_alice)
-                .await
-                .unwrap();
+            alice.sign_owned(&peer1_key).unwrap();
             radicle
-                .sign(
-                    &peer1_key,
-                    &Signatory::User(alice.urn()),
-                    &resolves_to_alice,
-                )
-                .await
+                .sign_by_user(&peer1_key, &(*alice).as_verified())
                 .unwrap();
         }
 


### PR DESCRIPTION
With this refactor entity signatures are not stored in a separated property.

Instead, the two  sets of owned keys and certifier URNs become maps that contain `Option`s that in turn contain the signatures.

This makes various checks simpler:

* it is not possible to sign the entity with a not owned key
* it is not possible to certify the entity with an unlisted certifier
* the async `sign` method disappears and is replaced by two synchronous methods that do not require resolvers:
  - `sign_owned` to sign with an owned key
  - `sign_by_user` to sign with a key belonging to a certifier
* checking that the entity is fully signed becomes a matter of iterating over those two maps, verifying that they do not contain `None` entries, and verifying every signature

Another change is that we now sign the entity hash and not the full content.
This speeds up verification because we verify the hash correctness only once (in `from_data`, just after deserializing), and we can trust it after that (it is immutable).
When verifying each signature we just use the hash (which we already have) instead of having to recompute the "canonical data" all the time.

This refactor is essentially the same thing as the 1st commit of PR #218 which @FintanH has already reviewed.
It has been extracted and rebased on top of master.

It is proposed here because we are considering whether moving signatures away from the entity blob and into the commit message (as commit trailers) or if we want to keep using this approach.