### PR TITLE
Made entity resolvers synchronous.

### DIFF
--- a/git-helpers/tests/remote.rs
+++ b/git-helpers/tests/remote.rs
@@ -109,12 +109,8 @@ async fn setup_entity(paths: &Paths, key: SecretKey) -> anyhow::Result<RadUrn> {
     let mut radicle = Radicle::new(&alice);
     {
         let resolves_to_alice = alice.clone();
-        alice
-            .sign(&key, &Signatory::OwnedKey, &resolves_to_alice)
-            .await?;
-        radicle
-            .sign(&key, &Signatory::User(alice.urn()), &resolves_to_alice)
-            .await?;
+        alice.sign(&key, &Signatory::OwnedKey, &resolves_to_alice)?;
+        radicle.sign(&key, &Signatory::User(alice.urn()), &resolves_to_alice)?;
 
         let store = Storage::open_or_init(&paths, key)?;
         store.create_repo(&alice)?;

--- a/librad-test/src/lib.rs
+++ b/librad-test/src/lib.rs
@@ -16,8 +16,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #[macro_use]
-extern crate async_trait;
-#[macro_use]
 extern crate lazy_static;
 
 pub mod logging;

--- a/librad-test/src/rad/entity.rs
+++ b/librad-test/src/rad/entity.rs
@@ -50,13 +50,12 @@ impl DerefMut for Alice {
     }
 }
 
-#[async_trait]
 impl Resolver<User<Draft>> for Alice {
-    async fn resolve(&self, _uri: &RadUrn) -> Result<User<Draft>, Error> {
+    fn resolve(&self, _uri: &RadUrn) -> Result<User<Draft>, Error> {
         Ok(self.0.clone())
     }
 
-    async fn resolve_revision(&self, _uri: &RadUrn, _revision: u64) -> Result<User<Draft>, Error> {
+    fn resolve_revision(&self, _uri: &RadUrn, _revision: u64) -> Result<User<Draft>, Error> {
         Ok(self.0.clone())
     }
 }

--- a/librad-test/src/rad/resolver.rs
+++ b/librad-test/src/rad/resolver.rs
@@ -40,13 +40,12 @@ where
     }
 }
 
-#[async_trait]
 impl<A, S> Resolver<Entity<A, S>> for ConstResolver<A, S>
 where
     A: Clone + Send + Sync + Default + Serialize + DeserializeOwned,
     S: Clone + Send + Sync,
 {
-    async fn resolve(&self, urn: &RadUrn) -> Result<Entity<A, S>, entity::Error> {
+    fn resolve(&self, urn: &RadUrn) -> Result<Entity<A, S>, entity::Error> {
         if &self.urn == urn {
             Ok(self.entity.clone())
         } else {
@@ -54,11 +53,7 @@ where
         }
     }
 
-    async fn resolve_revision(
-        &self,
-        urn: &RadUrn,
-        revision: u64,
-    ) -> Result<Entity<A, S>, entity::Error> {
+    fn resolve_revision(&self, urn: &RadUrn, revision: u64) -> Result<Entity<A, S>, entity::Error> {
         if &self.urn == urn {
             Ok(self.entity.clone())
         } else {

--- a/librad/src/git/storage/config.rs
+++ b/librad/src/git/storage/config.rs
@@ -254,8 +254,8 @@ mod tests {
         ))
     }
 
-    #[async_test]
-    async fn test_guard_user_not_self_signed() {
+    #[test]
+    fn test_guard_user_not_self_signed() {
         let key = SecretKey::new();
         let config = setup(&key);
 
@@ -263,12 +263,7 @@ mod tests {
         {
             let bob = User::<Draft>::create("bob".to_owned(), key.public()).unwrap();
             alice
-                .sign(
-                    &key,
-                    &Signatory::User(bob.urn()),
-                    &ConstResolver::new(bob.clone()),
-                )
-                .await
+                .sign(&key, &Signatory::User(bob.urn()), &ConstResolver::new(bob))
                 .unwrap();
         }
 
@@ -278,8 +273,8 @@ mod tests {
         ))
     }
 
-    #[async_test]
-    async fn test_guard_user_valid() {
+    #[test]
+    fn test_guard_user_valid() {
         let key = SecretKey::new();
         let config = setup(&key);
 
@@ -291,7 +286,6 @@ mod tests {
                     &Signatory::OwnedKey,
                     &ConstResolver::new(alice.clone()),
                 )
-                .await
                 .unwrap();
         }
 

--- a/librad/src/git/storage/test.rs
+++ b/librad/src/git/storage/test.rs
@@ -99,8 +99,8 @@ fn test_untrack() {
     assert!(store.tracked(&urn).unwrap().next().is_none())
 }
 
-#[async_test]
-async fn test_all_metadata_heads() {
+#[test]
+fn test_all_metadata_heads() {
     let key = SecretKey::new();
     let store = storage(key.clone());
 
@@ -111,7 +111,6 @@ async fn test_all_metadata_heads() {
     let verified_user = user
         .clone()
         .check_history_status(&user_resolver, &user_resolver)
-        .await
         .unwrap();
 
     // Create and sign two projects
@@ -192,8 +191,8 @@ async fn test_all_metadata_heads() {
     assert_eq!(user_history.len(), 1);
 }
 
-#[async_test]
-async fn set_and_get_rad_self() -> Result<(), Error> {
+#[test]
+fn set_and_get_rad_self() -> Result<(), Error> {
     let key = SecretKey::new();
     let store = storage(key.clone());
 
@@ -204,7 +203,6 @@ async fn set_and_get_rad_self() -> Result<(), Error> {
     let verified_user = user
         .clone()
         .check_history_status(&user_resolver, &user_resolver)
-        .await
         .unwrap();
     store.create_repo(&user)?;
     store.set_default_rad_self(verified_user.clone())?;
@@ -243,7 +241,6 @@ async fn test_structure_of_refs() -> Result<(), Error> {
     let verified_user = user
         .clone()
         .check_history_status(&user_resolver, &user_resolver)
-        .await
         .unwrap();
     refs.push(Reference::rad_id(user.urn().id));
     refs.push(Reference::rad_refs(user.urn().id, None));

--- a/librad/src/test.rs
+++ b/librad/src/test.rs
@@ -43,13 +43,12 @@ where
     }
 }
 
-#[async_trait]
 impl<A, S> Resolver<Entity<A, S>> for ConstResolver<A, S>
 where
     A: Clone + Send + Sync + Default + Serialize + DeserializeOwned,
     S: Clone + Send + Sync,
 {
-    async fn resolve(&self, urn: &RadUrn) -> Result<Entity<A, S>, entity::Error> {
+    fn resolve(&self, urn: &RadUrn) -> Result<Entity<A, S>, entity::Error> {
         if &self.urn == urn {
             Ok(self.entity.clone())
         } else {
@@ -57,11 +56,7 @@ where
         }
     }
 
-    async fn resolve_revision(
-        &self,
-        urn: &RadUrn,
-        revision: u64,
-    ) -> Result<Entity<A, S>, entity::Error> {
+    fn resolve_revision(&self, urn: &RadUrn, revision: u64) -> Result<Entity<A, S>, entity::Error> {
         if &self.urn == urn {
             Ok(self.entity.clone())
         } else {

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -52,7 +52,6 @@ async fn can_clone() {
             let resolves_to_alice = alice.clone();
             alice
                 .sign(&peer1_key, &Signatory::OwnedKey, &resolves_to_alice)
-                .await
                 .unwrap();
             radicle
                 .sign(
@@ -60,7 +59,6 @@ async fn can_clone() {
                     &Signatory::User(alice.urn()),
                     &resolves_to_alice,
                 )
-                .await
                 .unwrap();
         }
 
@@ -96,7 +94,6 @@ async fn fetches_on_gossip_notify() {
             let resolves_to_alice = alice.clone();
             alice
                 .sign(&peer1_key, &Signatory::OwnedKey, &resolves_to_alice)
-                .await
                 .unwrap();
             radicle
                 .sign(
@@ -104,7 +101,6 @@ async fn fetches_on_gossip_notify() {
                     &Signatory::User(alice.urn()),
                     &resolves_to_alice,
                 )
-                .await
                 .unwrap();
         }
 


### PR DESCRIPTION
The `Resolver` trait for getting entities from URNs has been defined as async but the whole libgit2 API is not async.

Entity resolution at this level is not expected to use the network, only to read data from the git monorepo (through a `Storage` instance) with eventual help from a cache.

Since the whole `Storage` API is not async, making entity `Resolver`s async adds complexity for no technical reason.
If or when interaction with `Storage` will become async entity resolution will follow the same path using the same approach (it is expected to be part of the `Storage` API anyway).