### PR TITLE
Add refs_heads functions

### DIFF
--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -21,7 +21,6 @@ use thiserror::Error;
 
 use crate::{
     git::{
-        ext::reference::References,
         refs::Refs,
         storage::{self, RadSelfSpec, Storage, WithSigner},
         types::Namespace,
@@ -75,23 +74,6 @@ impl<'a, S: Clone> Repo<'a, S> {
     /// Retrieve all directly _as well_ as transitively tracked peers
     pub fn rad_refs(&self) -> Result<Refs, Error> {
         self.storage.rad_refs(&self.urn).map_err(Error::from)
-    }
-
-    /// Get the names of the references that live under
-    /// `namespaces/<urn-id>/refs/heads/*`.
-    pub fn refs_heads(&'a self) -> Result<References<'a>, Error> {
-        self.storage.refs_heads(&self.urn).map_err(Error::from)
-    }
-
-    /// Get the names of the references that live under
-    /// `namspaces/<urn-id>/refs/remotes/<peer-id>refs/heads/*`.
-    pub fn refs_heads_of<P>(&'a self) -> Result<References<'a>, Error>
-    where
-        P: Into<Option<PeerId>>,
-    {
-        self.storage
-            .refs_heads_of(&self.urn, None)
-            .map_err(Error::from)
     }
 
     /// Get `rad/self` identity for this repo.

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -76,6 +76,23 @@ impl<'a, S: Clone> Repo<'a, S> {
         self.storage.rad_refs(&self.urn).map_err(Error::from)
     }
 
+    /// Get the names of the references that live under
+    /// `namespaces/<urn-id>/refs/heads/*`.
+    pub fn refs_heads(&self) -> Result<Vec<String>, Error> {
+        self.storage.refs_heads(&self.urn).map_err(Error::from)
+    }
+
+    /// Get the names of the references that live under
+    /// `namspaces/<urn-id>/refs/remotes/<peer-id>refs/heads/*`.
+    pub fn refs_heads_of<P>(&self) -> Result<Vec<String>, Error>
+    where
+        P: Into<Option<PeerId>>,
+    {
+        self.storage
+            .refs_heads_of(&self.urn, None)
+            .map_err(Error::from)
+    }
+
     /// Get `rad/self` identity for this repo.
     pub fn get_rad_self(&self) -> Result<User<Draft>, Error> {
         self.get_rad_self_of(None)

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -21,6 +21,7 @@ use thiserror::Error;
 
 use crate::{
     git::{
+        ext::reference::References,
         refs::Refs,
         storage::{self, RadSelfSpec, Storage, WithSigner},
         types::Namespace,
@@ -78,13 +79,13 @@ impl<'a, S: Clone> Repo<'a, S> {
 
     /// Get the names of the references that live under
     /// `namespaces/<urn-id>/refs/heads/*`.
-    pub fn refs_heads(&self) -> Result<Vec<String>, Error> {
+    pub fn refs_heads(&'a self) -> Result<References<'a>, Error> {
         self.storage.refs_heads(&self.urn).map_err(Error::from)
     }
 
     /// Get the names of the references that live under
     /// `namspaces/<urn-id>/refs/remotes/<peer-id>refs/heads/*`.
-    pub fn refs_heads_of<P>(&self) -> Result<Vec<String>, Error>
+    pub fn refs_heads_of<P>(&'a self) -> Result<References<'a>, Error>
     where
         P: Into<Option<PeerId>>,
     {

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -41,7 +41,7 @@ use crate::{
         p2p::url::{GitUrl, GitUrlRef},
         refs::{self, Refs},
         repo::Repo,
-        types::Reference,
+        types::{Reference, RefsCategory},
     },
     hash::Hash,
     internal::{
@@ -383,6 +383,32 @@ impl<S: Clone> Storage<S> {
         }?;
 
         Ok(Refs::from(signed))
+    }
+
+    /// Get the names of the references that live under
+    /// `namespaces/<urn-id>/refs/heads/*`.
+    pub fn refs_heads(&self, urn: &RadUrn) -> Result<Vec<String>, Error> {
+        self.refs_heads_of(urn, None)
+    }
+
+    /// Get the names of the references that live under
+    /// `namspaces/<urn-id>/refs/remotes/<peer-id>refs/heads/*`.
+    pub fn refs_heads_of<P>(&self, urn: &RadUrn, peer: P) -> Result<Vec<String>, Error>
+    where
+        P: Into<Option<PeerId>>,
+    {
+        let heads = Reference {
+            namespace: urn.id.clone(),
+            remote: peer.into(),
+            category: RefsCategory::Heads,
+            name: "*".to_string(),
+        };
+
+        let mut names = vec![];
+        for name in References::from_globs(&self.backend, &[heads.to_string()])?.names() {
+            names.push(name?.to_string());
+        }
+        Ok(names)
     }
 
     /// The set of all certifiers of the given identity, transitively

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -41,7 +41,7 @@ use crate::{
         p2p::url::{GitUrl, GitUrlRef},
         refs::{self, Refs},
         repo::Repo,
-        types::{Reference, RefsCategory},
+        types::Reference,
     },
     hash::Hash,
     internal::{
@@ -387,28 +387,19 @@ impl<S: Clone> Storage<S> {
 
     /// Get the names of the references that live under
     /// `namespaces/<urn-id>/refs/heads/*`.
-    pub fn refs_heads(&self, urn: &RadUrn) -> Result<Vec<String>, Error> {
+    pub fn refs_heads<'a>(&'a self, urn: &RadUrn) -> Result<References<'a>, Error> {
         self.refs_heads_of(urn, None)
     }
 
     /// Get the names of the references that live under
     /// `namspaces/<urn-id>/refs/remotes/<peer-id>refs/heads/*`.
-    pub fn refs_heads_of<P>(&self, urn: &RadUrn, peer: P) -> Result<Vec<String>, Error>
+    pub fn refs_heads_of<'a, P>(&'a self, urn: &RadUrn, peer: P) -> Result<References<'a>, Error>
     where
         P: Into<Option<PeerId>>,
     {
-        let heads = Reference {
-            namespace: urn.id.clone(),
-            remote: peer.into(),
-            category: RefsCategory::Heads,
-            name: "*".to_string(),
-        };
-
-        let mut names = vec![];
-        for name in References::from_globs(&self.backend, &[heads.to_string()])?.names() {
-            names.push(name?.to_string());
-        }
-        Ok(names)
+        Reference::heads(urn.id.clone(), peer)
+            .references(&self.backend)
+            .map_err(Error::from)
     }
 
     /// The set of all certifiers of the given identity, transitively

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -385,23 +385,6 @@ impl<S: Clone> Storage<S> {
         Ok(Refs::from(signed))
     }
 
-    /// Get the names of the references that live under
-    /// `namespaces/<urn-id>/refs/heads/*`.
-    pub fn refs_heads<'a>(&'a self, urn: &RadUrn) -> Result<References<'a>, Error> {
-        self.refs_heads_of(urn, None)
-    }
-
-    /// Get the names of the references that live under
-    /// `namspaces/<urn-id>/refs/remotes/<peer-id>refs/heads/*`.
-    pub fn refs_heads_of<'a, P>(&'a self, urn: &RadUrn, peer: P) -> Result<References<'a>, Error>
-    where
-        P: Into<Option<PeerId>>,
-    {
-        Reference::heads(urn.id.clone(), peer)
-            .references(&self.backend)
-            .map_err(Error::from)
-    }
-
     pub fn reference<'a>(
         &'a self,
         reference: Reference<Single>,

--- a/librad/src/git/storage/fetch.rs
+++ b/librad/src/git/storage/fetch.rs
@@ -23,7 +23,7 @@ use crate::{
     git::{
         p2p::url::GitUrl,
         refs::Refs,
-        types::{Reference, Refspec},
+        types::{Reference, Refspec, SomeReference},
     },
     peer::PeerId,
     uri::RadUrn,
@@ -76,20 +76,18 @@ impl<'a> Fetcher<'a> {
         // :refs/namespaces/<namespace>/refs/remotes/<remote_peer>/rad/ids/*`
         let refspecs = [
             Refspec {
-                remote: remote_id.clone().into_any(),
-                local: remote_id.with_remote(remote_peer.clone()).into_any(),
+                remote: SomeReference::Single(remote_id.clone()),
+                local: SomeReference::Single(remote_id.with_remote(remote_peer.clone())),
                 force: false,
             },
             Refspec {
-                remote: remote_self.clone().into_any(),
-                local: remote_self.with_remote(remote_peer.clone()).into_any(),
+                remote: SomeReference::Single(remote_self.clone()),
+                local: SomeReference::Single(remote_self.with_remote(remote_peer.clone())),
                 force: false,
             },
             Refspec {
-                remote: remote_certifiers.clone().into_any(),
-                local: remote_certifiers
-                    .with_remote(remote_peer.clone())
-                    .into_any(),
+                remote: SomeReference::Multiple(remote_certifiers.clone()),
+                local: SomeReference::Multiple(remote_certifiers.with_remote(remote_peer.clone())),
                 force: false,
             },
         ]

--- a/librad/src/git/storage/fetch.rs
+++ b/librad/src/git/storage/fetch.rs
@@ -76,18 +76,20 @@ impl<'a> Fetcher<'a> {
         // :refs/namespaces/<namespace>/refs/remotes/<remote_peer>/rad/ids/*`
         let refspecs = [
             Refspec {
-                remote: remote_id.clone(),
-                local: remote_id.with_remote(remote_peer.clone()),
+                remote: remote_id.clone().into_any(),
+                local: remote_id.with_remote(remote_peer.clone()).into_any(),
                 force: false,
             },
             Refspec {
-                remote: remote_self.clone(),
-                local: remote_self.with_remote(remote_peer.clone()),
+                remote: remote_self.clone().into_any(),
+                local: remote_self.with_remote(remote_peer.clone()).into_any(),
                 force: false,
             },
             Refspec {
-                remote: remote_certifiers.clone(),
-                local: remote_certifiers.with_remote(remote_peer.clone()),
+                remote: remote_certifiers.clone().into_any(),
+                local: remote_certifiers
+                    .with_remote(remote_peer.clone())
+                    .into_any(),
                 force: false,
             },
         ]

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -68,6 +68,13 @@ impl Reference {
         repo.find_reference(&self.to_string())
     }
 
+    pub fn references<'a>(
+        &self,
+        repo: &'a git2::Repository,
+    ) -> Result<ext::References<'a>, git2::Error> {
+        ext::References::from_globs(repo, &[self.to_string()])
+    }
+
     pub fn rad_id(namespace: Namespace) -> Self {
         Self {
             namespace,
@@ -119,6 +126,15 @@ impl Reference {
             remote: remote.into(),
             category: RefsCategory::Heads,
             name: name.to_owned(),
+        }
+    }
+
+    pub fn heads(namespace: Namespace, remote: impl Into<Option<PeerId>>) -> Self {
+        Self {
+            namespace,
+            remote: remote.into(),
+            category: RefsCategory::Heads,
+            name: "*".to_owned(),
         }
     }
 

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -132,6 +132,8 @@ impl Reference<Multiple> {
         ext::References::from_globs(repo, &[self.to_string()])
     }
 
+    /// Build a reference that points to
+    /// `refs/namespaces/<namespace>/refs/rad/ids/*`
     pub fn rad_ids_glob(namespace: Namespace) -> Self {
         Self {
             namespace,
@@ -142,6 +144,8 @@ impl Reference<Multiple> {
         }
     }
 
+    /// Build a reference that points to
+    /// `refs/namespaces/<namespace>/refs/rad/[peer_id]/heads/*`
     pub fn heads(namespace: Namespace, remote: impl Into<Option<PeerId>>) -> Self {
         Self {
             namespace,
@@ -158,6 +162,8 @@ impl Reference<Single> {
         repo.find_reference(&self.to_string())
     }
 
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/rad/id`
     pub fn rad_id(namespace: Namespace) -> Self {
         Self {
             namespace,
@@ -168,6 +174,8 @@ impl Reference<Single> {
         }
     }
 
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/rad/ids/<id>`
     pub fn rad_certifier(namespace: Namespace, urn: &RadUrn) -> Self {
         Self {
             namespace,
@@ -178,6 +186,9 @@ impl Reference<Single> {
         }
     }
 
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/rad/refs`
+    ///     * `refs/namespaces/<namespace>/refs/remote/<peer_id>/rad/refs`
     pub fn rad_refs(namespace: Namespace, remote: impl Into<Option<PeerId>>) -> Self {
         Self {
             namespace,
@@ -188,6 +199,9 @@ impl Reference<Single> {
         }
     }
 
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/rad/self`
+    ///     * `refs/namespaces/<namespace>/refs/remote/<peer_id>/rad/self`
     pub fn rad_self(namespace: Namespace, remote: impl Into<Option<PeerId>>) -> Self {
         Self {
             namespace,
@@ -198,6 +212,9 @@ impl Reference<Single> {
         }
     }
 
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/heads/<name>`
+    ///     * `refs/namespaces/<namespace>/refs/remote/<peer_id>/heads/<name>
     pub fn head(namespace: Namespace, remote: impl Into<Option<PeerId>>, name: &str) -> Self {
         Self {
             namespace,


### PR DESCRIPTION
Adding functions to retrieve the `refs/heads/*` references that would
live under a RadUrn for our local peer view and a remote peer view.

Fixes #239 