### PR TITLE
Introduced typed API for creating git symbolic refs (fixes #204).

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -573,9 +573,9 @@ impl Storage<WithSigner> {
                 .try_for_each(|(src, target)| {
                     self.symbolic_reference()
                         .source(&src)
-                        .target(&target)
+                        .target(&target)?
                         .force(true)
-                        .build()
+                        .create()
                         .and(Ok(()))
                 });
 
@@ -726,9 +726,9 @@ impl Storage<WithSigner> {
                         let certifier_id = Reference::rad_id(certifier_hash);
                         self.symbolic_reference()
                             .source(&certifier_here)
-                            .target(&certifier_id)
+                            .target(&certifier_id)?
                             .force(false)
-                            .build()
+                            .create()
                             .and(Ok(()))
                     },
                 }
@@ -796,9 +796,9 @@ impl Storage<WithSigner> {
 
                 self.symbolic_reference()
                     .source(&src)
-                    .target(&target)
+                    .target(&target)?
                     .force(true)
-                    .build()
+                    .create()
                     .and(Ok(()))
                     .map_err(Error::from)
             },

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -573,7 +573,7 @@ impl Storage<WithSigner> {
                 .try_for_each(|(src, target)| {
                     self.symbolic_reference()
                         .source(&src)
-                        .target(&target)?
+                        .target(&target)
                         .force(true)
                         .create()
                         .and(Ok(()))
@@ -726,7 +726,7 @@ impl Storage<WithSigner> {
                         let certifier_id = Reference::rad_id(certifier_hash);
                         self.symbolic_reference()
                             .source(&certifier_here)
-                            .target(&certifier_id)?
+                            .target(&certifier_id)
                             .force(false)
                             .create()
                             .and(Ok(()))
@@ -796,7 +796,7 @@ impl Storage<WithSigner> {
 
                 self.symbolic_reference()
                     .source(&src)
-                    .target(&target)?
+                    .target(&target)
                     .force(true)
                     .create()
                     .and(Ok(()))

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -217,7 +217,7 @@ impl<'a> SymbolicReference<'a> {
 /// Intermediate symbolic reference builder
 impl<'a> SymbolicReferenceSource<'a> {
     /// Specify the symbolic reference target
-    /// (checks that the ref exists and fails otherwise)
+    /// (`create` will fail if the reference does not exist)
     pub fn target(self, target: &'a Reference) -> SymbolicReferenceTarget {
         SymbolicReferenceTarget {
             repo: self.repo,
@@ -227,7 +227,8 @@ impl<'a> SymbolicReferenceSource<'a> {
     }
 
     /// Specify the symbolic reference target using a `git2::Reference` that we
-    /// trust to exist (fails if its `name` is not a valid string)
+    /// trust to exist
+    /// ('create' will fail if its `name` is not a valid string)
     pub fn target_ref(self, target: &'a git2::Reference) -> SymbolicReferenceTarget<'a> {
         SymbolicReferenceTarget {
             repo: self.repo,

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -153,6 +153,72 @@ impl<'a> Into<ext::blob::Branch<'a>> for &'a Reference {
     }
 }
 
+pub struct SymbolicReference<'a> {
+    repo: &'a git2::Repository,
+}
+
+pub struct SymbolicReferenceSource<'a> {
+    repo: &'a git2::Repository,
+    source: &'a Reference,
+}
+
+pub struct SymbolicReferenceTarget<'a> {
+    repo: &'a git2::Repository,
+    source: &'a Reference,
+    target: &'a Reference,
+}
+
+pub struct SymbolicReferenceForce<'a> {
+    repo: &'a git2::Repository,
+    source: &'a Reference,
+    target: &'a Reference,
+    force_value: bool,
+}
+
+impl<'a> SymbolicReference<'a> {
+    pub fn new(repo: &'a git2::Repository) -> Self {
+        Self { repo }
+    }
+
+    pub fn source(self, source: &'a Reference) -> SymbolicReferenceSource {
+        SymbolicReferenceSource {
+            repo: self.repo,
+            source,
+        }
+    }
+}
+
+impl<'a> SymbolicReferenceSource<'a> {
+    pub fn target(self, target: &'a Reference) -> SymbolicReferenceTarget {
+        SymbolicReferenceTarget {
+            repo: self.repo,
+            source: self.source,
+            target,
+        }
+    }
+}
+
+impl<'a> SymbolicReferenceTarget<'a> {
+    pub fn force(self, force: bool) -> SymbolicReferenceForce<'a> {
+        SymbolicReferenceForce {
+            repo: self.repo,
+            source: self.source,
+            target: self.target,
+            force_value: force,
+        }
+    }
+}
+
+impl<'a> SymbolicReferenceForce<'a> {
+    pub fn build(self) -> Result<git2::Reference<'a>, git2::Error> {
+        let name = self.source.to_string();
+        let target = self.target.to_string();
+        let message = format!("creating symref {} -> {}", name, target);
+        self.repo
+            .reference_symbolic(&name, &target, self.force_value, &message)
+    }
+}
+
 #[derive(Clone)]
 pub struct Refspec {
     pub remote: Reference,


### PR DESCRIPTION
This is the most rust-idiomatic way of doing this I could think of.

Invocations could save one line if the `force` method also directly did the `build` and returned the Result but IMHO leaving it explicit is clearer (and less surprising).