### PR TITLE
Add 'refs' component to tracked 'remotes' path

### DIFF
--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -91,7 +91,7 @@ impl<N> Display for Reference<N> {
 
         match &self.remote {
             None => write!(f, "{}/{}", self.category, self.name),
-            Some(remote) => write!(f, "remotes/{}/{}/{}", remote, self.category, self.name),
+            Some(remote) => write!(f, "remotes/{}/refs/{}/{}", remote, self.category, self.name),
         }
     }
 }

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -191,7 +191,7 @@ async fn fetches_on_gossip_notify() {
             .has_commit(
                 &RadUrn {
                     path: uri::Path::parse(format!(
-                        "refs/remotes/{}/heads/master",
+                        "refs/remotes/{}/refs/heads/master",
                         peer1.peer_id()
                     ))
                     .unwrap(),


### PR DESCRIPTION
According to the spec of the monorepo the path should take the form
`namespaces/$IDENTITY/refs/remotes/$TRACKED_PEER_ID/refs/...`. We were
missing the 'refs' portion which was causing some subtle issues. This
adds the 'refs' back and fixes the propagation test that was also
missing this portion.