### PR TITLE
Check Has is what we Want

### DIFF
--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -105,6 +105,13 @@ pub struct Has<A> {
     val: A,
 }
 
+impl<A> Has<A> {
+    /// Look at the value of the `Has`.
+    pub fn val(&self) -> &A {
+        &self.val
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MembershipParams {
     /// Maximum number of active connections.

--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -28,6 +28,7 @@ use std::{
     iter,
     marker::PhantomData,
     num::NonZeroU32,
+    ops::Deref,
     sync::{
         atomic::{self, AtomicBool},
         Arc,
@@ -105,9 +106,10 @@ pub struct Has<A> {
     val: A,
 }
 
-impl<A> Has<A> {
-    /// Look at the value of the `Has`.
-    pub fn val(&self) -> &A {
+impl<A> Deref for Has<A> {
+    type Target = A;
+
+    fn deref(&self) -> &Self::Target {
         &self.val
     }
 }

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -200,7 +200,7 @@ where
             .zip(futures::stream::repeat(want))
             .filter_map(|(evt, wanted)| async move {
                 match evt {
-                    gossip::ProtocolEvent::Info(gossip::Info::Has(has)) if wanted == *has.val() => {
+                    gossip::ProtocolEvent::Info(gossip::Info::Has(has)) if wanted == *has => {
                         Some(has)
                     },
                     _ => None,

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -194,18 +194,17 @@ where
         A: PartialEq + Clone,
     {
         self.gossip.query(want.clone()).await;
-        self.gossip
-            .subscribe()
-            .await
-            .zip(futures::stream::repeat(want))
-            .filter_map(|(evt, wanted)| async move {
+        self.gossip.subscribe().await.filter_map(move |evt| {
+            let wanted = want.clone();
+            async move {
                 match evt {
                     gossip::ProtocolEvent::Info(gossip::Info::Has(has)) if wanted == *has => {
                         Some(has)
                     },
                     _ => None,
                 }
-            })
+            }
+        })
     }
 
     /// Open a QUIC stream which is upgraded to expect the git protocol


### PR DESCRIPTION
Fixes #252 

When we query the network for some `A` we get back a stream of `Has of
A`. We never checked that it indeed was the `A` we wanted. This change
introduces the check to see if they're equal.