### PR TITLE
Identity spec implementation

### DIFF
--- a/librad/src/git/ext/oid.rs
+++ b/librad/src/git/ext/oid.rs
@@ -20,7 +20,7 @@ use std::{fmt, ops::Deref};
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Serializable [`git2::Oid`]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Oid(pub git2::Oid);
 
 impl Serialize for Oid {
@@ -29,6 +29,12 @@ impl Serialize for Oid {
         S: Serializer,
     {
         self.0.to_string().serialize(serializer)
+    }
+}
+
+impl std::fmt::Display for Oid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0.to_string())
     }
 }
 

--- a/librad/src/meta.rs
+++ b/librad/src/meta.rs
@@ -17,6 +17,7 @@
 
 pub mod common;
 pub mod entity;
+pub mod identity;
 pub mod profile;
 pub mod project;
 pub mod user;

--- a/librad/src/meta/identity.rs
+++ b/librad/src/meta/identity.rs
@@ -496,7 +496,7 @@ impl IdentityBuilder {
         }
     }
 
-    pub fn sign(mut self, key: SecretKey) -> Self {
+    pub fn sign(mut self, key: &SecretKey) -> Self {
         self.signatures
             .insert(key.public(), key.sign(self.revision.as_bytes()));
         self

--- a/librad/src/meta/identity.rs
+++ b/librad/src/meta/identity.rs
@@ -376,7 +376,7 @@ impl IdentityBuilder {
         }
     }
 
-    pub fn merge(parent: &Identity, other: &Identity) -> Self {
+    pub fn duplicate_other(parent: &Identity, other: &Identity) -> Self {
         IdentityBuilder {
             previous: Some(parent.commit.clone()),
             merged: Some(other.commit.clone()),
@@ -413,7 +413,7 @@ impl IdentityBuilder {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Identity {
     previous: Option<ContentId>,
     merged: Option<ContentId>,
@@ -612,6 +612,12 @@ impl<'a> IdentityStore<'a> {
             doc: builder.doc,
             signatures: builder.signatures,
         })
+    }
+
+    pub fn get_parent_identity(&self, identity: &Identity) -> Option<Identity> {
+        identity
+            .previous()
+            .and_then(|id| self.get_identity(id).ok())
     }
 }
 #[cfg(test)]

--- a/librad/src/meta/identity.rs
+++ b/librad/src/meta/identity.rs
@@ -1,0 +1,589 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::Into,
+};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::{de::from_slice as from_json_slice, value::Value as JsonValue};
+use thiserror::Error;
+
+use crate::{
+    git::ext::Oid,
+    internal::canonical::{Cjson, CjsonError},
+    keys::{PublicKey, SecretKey, Signature},
+};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Wrong delegation type")]
+    MismatchedDelegation,
+
+    #[error("Key not present")]
+    KeyNotPresent,
+
+    #[error("Invalid revision tree entry {0}")]
+    InvalidRevisionTreeEntry(Revision),
+
+    #[error(transparent)]
+    Cjson(#[from] CjsonError),
+
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::error::Error),
+
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Revision(Oid);
+
+impl std::ops::Deref for Revision {
+    type Target = git2::Oid;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<git2::Oid> for Revision {
+    fn as_ref(&self) -> &git2::Oid {
+        self
+    }
+}
+
+impl From<Revision> for git2::Oid {
+    fn from(rev: Revision) -> Self {
+        *rev.0.as_ref()
+    }
+}
+
+impl From<&Revision> for git2::Oid {
+    fn from(rev: &Revision) -> Self {
+        *rev.0.as_ref()
+    }
+}
+
+impl From<git2::Oid> for Revision {
+    fn from(oid: git2::Oid) -> Self {
+        Self(Oid(oid))
+    }
+}
+
+impl std::fmt::Display for Revision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ContentId(Oid);
+
+impl std::ops::Deref for ContentId {
+    type Target = git2::Oid;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<git2::Oid> for ContentId {
+    fn as_ref(&self) -> &git2::Oid {
+        self
+    }
+}
+
+impl From<ContentId> for git2::Oid {
+    fn from(rev: ContentId) -> Self {
+        *rev.0.as_ref()
+    }
+}
+
+impl From<&ContentId> for git2::Oid {
+    fn from(rev: &ContentId) -> Self {
+        *rev.0.as_ref()
+    }
+}
+
+impl From<git2::Oid> for ContentId {
+    fn from(oid: git2::Oid) -> Self {
+        Self(Oid(oid))
+    }
+}
+
+impl std::fmt::Display for ContentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum Delegations {
+    Keys(BTreeSet<PublicKey>),
+    Users(BTreeMap<PublicKey, Revision>),
+}
+
+pub enum DelegationsKeys<'a> {
+    Keys(std::collections::btree_set::Iter<'a, PublicKey>),
+    Users(std::collections::btree_map::Iter<'a, PublicKey, Revision>),
+}
+
+impl<'a> Iterator for DelegationsKeys<'a> {
+    type Item = &'a PublicKey;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            DelegationsKeys::Keys(keys) => keys.next(),
+            DelegationsKeys::Users(users) => users.next().map(|(k, _)| k),
+        }
+    }
+}
+
+impl Delegations {
+    pub fn empty_keys() -> Self {
+        Delegations::Keys(BTreeSet::new())
+    }
+
+    pub fn empty_users() -> Self {
+        Delegations::Users(BTreeMap::new())
+    }
+
+    pub fn has_key(&self, key: &PublicKey) -> bool {
+        match self {
+            Delegations::Keys(keys) => keys.contains(key),
+            Delegations::Users(users) => users.contains_key(key),
+        }
+    }
+
+    pub fn keys<'a>(&'a self) -> DelegationsKeys<'a> {
+        match self {
+            Delegations::Keys(keys) => DelegationsKeys::Keys(keys.iter()),
+            Delegations::Users(users) => DelegationsKeys::Users(users.iter()),
+        }
+    }
+
+    pub fn add_key(&mut self, key: PublicKey) -> Result<(), Error> {
+        if let Delegations::Keys(keys) = self {
+            keys.insert(key);
+            Ok(())
+        } else {
+            Err(Error::MismatchedDelegation)
+        }
+    }
+
+    pub fn add_user_key(&mut self, key: PublicKey, user: Revision) -> Result<(), Error> {
+        if let Delegations::Users(keys) = self {
+            keys.insert(key, user);
+            Ok(())
+        } else {
+            Err(Error::MismatchedDelegation)
+        }
+    }
+
+    pub fn remove_key(&mut self, key: &PublicKey) -> Result<(), Error> {
+        let removed = match self {
+            Delegations::Keys(keys) => keys.remove(key),
+            Delegations::Users(users) => users.remove(key).is_some(),
+        };
+        if removed {
+            Ok(())
+        } else {
+            Err(Error::KeyNotPresent)
+        }
+    }
+
+    pub fn add_user_keys(
+        &mut self,
+        user_keys: &Self,
+        user_revision: &Revision,
+    ) -> Result<(), Error> {
+        if let (Delegations::Users(keys), Delegations::Keys(user_keys)) = (self, user_keys) {
+            for k in user_keys.into_iter() {
+                keys.insert(k.clone(), user_revision.clone());
+            }
+            Ok(())
+        } else {
+            Err(Error::MismatchedDelegation)
+        }
+    }
+
+    pub fn remove_keys(&mut self, delegations: &Self) {
+        for k in delegations.keys() {
+            self.remove_key(k).ok();
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Doc {
+    replaces: Option<Revision>,
+    payload: JsonValue,
+    delegations: Delegations,
+}
+
+impl Doc {
+    pub fn replaces(&self) -> Option<&Revision> {
+        self.replaces.as_ref()
+    }
+
+    pub fn json_payload(&self) -> &JsonValue {
+        &self.payload
+    }
+
+    pub fn delegations(&self) -> &Delegations {
+        &self.delegations
+    }
+
+    pub fn payload<T>(&self) -> Result<T, Error>
+    where
+        T: DeserializeOwned,
+    {
+        serde_json::value::from_value(self.payload.clone()).map_err(Error::SerdeJson)
+    }
+
+    pub fn serialize(&self) -> Result<Vec<u8>, Error> {
+        Ok(Cjson(self).canonical_form()?)
+    }
+}
+
+pub struct DocBuilder {
+    replaces: Option<Revision>,
+    delegations: Delegations,
+}
+
+impl DocBuilder {
+    pub fn new_user() -> Self {
+        Self {
+            replaces: None,
+            delegations: Delegations::empty_keys(),
+        }
+    }
+
+    pub fn new_project() -> Self {
+        Self {
+            replaces: None,
+            delegations: Delegations::empty_users(),
+        }
+    }
+
+    pub fn replaces(&mut self, revision: Revision) -> &mut Self {
+        self.replaces = Some(revision);
+        self
+    }
+
+    pub fn add_key(&mut self, key: PublicKey) -> Result<&mut Self, Error> {
+        self.delegations.add_key(key)?;
+        Ok(self)
+    }
+
+    pub fn add_user_key(&mut self, key: PublicKey, user: Revision) -> Result<&mut Self, Error> {
+        self.delegations.add_user_key(key, user)?;
+        Ok(self)
+    }
+
+    pub fn remove_key(&mut self, key: &PublicKey) -> Result<&mut Self, Error> {
+        self.delegations.remove_key(key)?;
+        Ok(self)
+    }
+
+    pub fn add_user_keys(
+        &mut self,
+        user_keys: &Delegations,
+        user_revision: &Revision,
+    ) -> Result<&mut Self, Error> {
+        self.delegations.add_user_keys(user_keys, user_revision)?;
+        Ok(self)
+    }
+
+    pub fn remove_keys(&mut self, delegations: &Delegations) -> &mut Self {
+        self.delegations.remove_keys(delegations);
+        self
+    }
+
+    pub fn build<T>(&self, payload: T) -> Result<Doc, Error>
+    where
+        T: Serialize,
+    {
+        Ok(Doc {
+            replaces: self.replaces.clone(),
+            payload: serde_json::value::to_value(payload)?,
+            delegations: self.delegations.clone(),
+        })
+    }
+}
+
+pub struct IdentityBuilder {
+    previous: Option<ContentId>,
+    merged: Option<ContentId>,
+    root: Revision,
+    revision: Revision,
+    doc: Doc,
+    signatures: BTreeMap<PublicKey, Signature>,
+}
+
+impl IdentityBuilder {
+    pub fn new(revision: Revision, doc: Doc) -> Self {
+        IdentityBuilder {
+            previous: None,
+            merged: None,
+            root: revision.clone(),
+            revision,
+            doc,
+            signatures: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_parent(parent: &Identity, revision: Revision, doc: Doc) -> Self {
+        IdentityBuilder {
+            previous: Some(parent.commit.clone()),
+            merged: None,
+            root: parent.root.clone(),
+            revision,
+            doc,
+            signatures: BTreeMap::new(),
+        }
+    }
+
+    pub fn duplicate(parent: &Identity) -> Self {
+        IdentityBuilder {
+            previous: Some(parent.commit.clone()),
+            merged: None,
+            root: parent.root.clone(),
+            revision: parent.revision.clone(),
+            doc: parent.doc.clone(),
+            signatures: parent.signatures.clone(),
+        }
+    }
+
+    pub fn merge(parent: &Identity, other: &Identity) -> Self {
+        IdentityBuilder {
+            previous: Some(parent.commit.clone()),
+            merged: Some(other.commit.clone()),
+            root: parent.root.clone(),
+            revision: other.revision.clone(),
+            doc: other.doc.clone(),
+            signatures: other.signatures.clone(),
+        }
+    }
+
+    pub fn sign(mut self, key: SecretKey) -> Self {
+        self.signatures
+            .insert(key.public().clone(), key.sign(self.revision.as_bytes()));
+        self
+    }
+
+    pub fn previous(&self) -> Option<&ContentId> {
+        self.previous.as_ref()
+    }
+    pub fn merged(&self) -> Option<&ContentId> {
+        self.merged.as_ref()
+    }
+    pub fn root(&self) -> &Revision {
+        &self.root
+    }
+    pub fn revision(&self) -> &Revision {
+        &self.revision
+    }
+    pub fn doc(&self) -> &Doc {
+        &self.doc
+    }
+    pub fn signatures(&self) -> &BTreeMap<PublicKey, Signature> {
+        &self.signatures
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Identity {
+    previous: Option<ContentId>,
+    merged: Option<ContentId>,
+    commit: ContentId,
+    root: Revision,
+    revision: Revision,
+    doc: Doc,
+    signatures: BTreeMap<PublicKey, Signature>,
+}
+
+impl Identity {
+    pub fn previous(&self) -> Option<&ContentId> {
+        self.previous.as_ref()
+    }
+    pub fn merged(&self) -> Option<&ContentId> {
+        self.merged.as_ref()
+    }
+    pub fn commit(&self) -> &ContentId {
+        &self.commit
+    }
+    pub fn root(&self) -> &Revision {
+        &self.root
+    }
+    pub fn revision(&self) -> &Revision {
+        &self.revision
+    }
+    pub fn doc(&self) -> &Doc {
+        &self.doc
+    }
+    pub fn signatures(&self) -> &BTreeMap<PublicKey, Signature> {
+        &self.signatures
+    }
+}
+
+const RAD_SIGNATURE_TRAILER_NAME: &'static str = "x-rad-signature";
+
+fn append_signatures(buf: &mut String, sigs: &BTreeMap<PublicKey, Signature>) {
+    buf.push_str("\n");
+    for (k, s) in sigs {
+        buf.push_str(&format!(
+            "{}: {} {}\n",
+            RAD_SIGNATURE_TRAILER_NAME,
+            k.to_bs58(),
+            s.to_bs58()
+        ));
+    }
+}
+
+fn match_signature(line: &str) -> Option<(PublicKey, Signature)> {
+    let mut tokens = line
+        .strip_prefix(RAD_SIGNATURE_TRAILER_NAME)
+        .and_then(|line| line.strip_prefix(": "))?
+        .split(" ");
+
+    let key_text = tokens.next()?;
+    let sig_text = tokens.next()?;
+    if tokens.next().is_some() {
+        return None;
+    }
+
+    Some((
+        PublicKey::from_bs58(key_text)?,
+        Signature::from_bs58(sig_text)?,
+    ))
+}
+
+pub fn parse_signatures(buf: Option<&str>) -> BTreeMap<PublicKey, Signature> {
+    let mut sigs = BTreeMap::new();
+    if let Some(buf) = buf {
+        for line in buf.split("\n") {
+            if let Some((k, s)) = match_signature(line) {
+                sigs.insert(k, s);
+            }
+        }
+    }
+    sigs
+}
+
+pub struct IdentityStore<'a> {
+    repo: &'a git2::Repository,
+}
+
+const ROOT_TREE_ENTRY_NAME: &'static str = "ROOT";
+
+impl<'a> IdentityStore<'a> {
+    pub fn new(repo: &'a git2::Repository) -> Self {
+        Self { repo }
+    }
+
+    pub fn get_doc(&self, revision: &Revision) -> Result<(Doc, Revision), Error> {
+        let tree = self.repo.find_tree(revision.into())?;
+        let root_entry = tree
+            .get(0)
+            .ok_or_else(|| Error::InvalidRevisionTreeEntry(revision.clone()))?;
+        let root_name = root_entry
+            .name()
+            .ok_or_else(|| Error::InvalidRevisionTreeEntry(revision.clone()))?;
+        let root_revision = if root_name == ROOT_TREE_ENTRY_NAME {
+            revision.clone()
+        } else {
+            Revision::from(git2::Oid::from_str(root_name)?)
+        };
+        let doc = self
+            .repo
+            .find_blob(root_entry.id())
+            .map_err(Error::Git)
+            .and_then(|blob| from_json_slice(blob.content()).map_err(Error::SerdeJson))?;
+        Ok((doc, root_revision))
+    }
+
+    pub fn store_doc(
+        &self,
+        doc: &Doc,
+        root_revision: Option<&Revision>,
+    ) -> Result<Revision, Error> {
+        let doc_bytes = doc.serialize()?;
+        let blob_oid = self.repo.blob(&doc_bytes)?;
+        let mut tree = self.repo.treebuilder(None)?;
+        tree.insert(
+            match root_revision {
+                Some(rev) => rev.to_string(),
+                None => ROOT_TREE_ENTRY_NAME.to_string(),
+            },
+            blob_oid,
+            0o100644,
+        )?;
+        Ok(Revision::from(tree.write()?))
+    }
+
+    pub fn get_identity(&self, id: &ContentId) -> Result<Identity, Error> {
+        let commit = self.repo.find_commit(id.into())?;
+        let mut previous = None;
+        let mut merged = None;
+        for (index, parent) in commit.parents().enumerate() {
+            match index {
+                0 => previous = Some(parent.id().into()),
+                1 => merged = Some(parent.id().into()),
+                _ => break,
+            }
+        }
+        let revision = Revision::from(commit.tree_id());
+        let (doc, root) = self.get_doc(&revision)?;
+        Ok(Identity {
+            previous,
+            merged,
+            commit: commit.id().into(),
+            root,
+            revision,
+            doc,
+            signatures: parse_signatures(commit.message()),
+        })
+    }
+
+    pub fn store_identity(&self, builder: IdentityBuilder) -> Result<Identity, Error> {
+        let mut message = format!("RAD ID {} REV {}\n", builder.root, builder.revision);
+        append_signatures(&mut message, &builder.signatures);
+
+        let git_sig = self.repo.signature()?;
+        let tree = self.repo.find_tree(builder.revision().into())?;
+
+        let previous_commit = match builder.previous() {
+            Some(id) => Some(self.repo.find_commit(id.into())?),
+            None => None,
+        };
+        let merged_commit = match builder.merged() {
+            Some(id) => Some(self.repo.find_commit(id.into())?),
+            None => None,
+        };
+        let mut parents = Vec::new();
+        if let Some(commit) = previous_commit.as_ref() {
+            parents.push(commit);
+        }
+        if let Some(commit) = merged_commit.as_ref() {
+            parents.push(commit);
+        }
+
+        let id = self
+            .repo
+            .commit(None, &git_sig, &git_sig, &message, &tree, &parents)?;
+
+        Ok(Identity {
+            previous: builder.previous().cloned(),
+            merged: builder.merged().cloned(),
+            commit: id.into(),
+            root: builder.root,
+            revision: builder.revision,
+            doc: builder.doc,
+            signatures: builder.signatures,
+        })
+    }
+}
+#[cfg(test)]
+mod test;

--- a/librad/src/meta/identity/cache.rs
+++ b/librad/src/meta/identity/cache.rs
@@ -1,0 +1,58 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::{Doc, Error, Revision, Verified};
+
+pub trait VerificationCache {
+    fn is_verified(&self, rev: &Revision) -> bool;
+    fn register_verified(&mut self, doc: &Doc<Verified>, rev: &Revision) -> Result<(), Error>;
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    pub struct NullVerificationCache {}
+
+    impl VerificationCache for NullVerificationCache {
+        fn is_verified(&self, _rev: &Revision) -> bool {
+            false
+        }
+        fn register_verified(
+            &mut self,
+            _doc: &Doc<Verified>,
+            _rev: &Revision,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    pub struct TrueVerificationCache {}
+
+    impl VerificationCache for TrueVerificationCache {
+        fn is_verified(&self, _rev: &Revision) -> bool {
+            true
+        }
+        fn register_verified(
+            &mut self,
+            _doc: &Doc<Verified>,
+            _rev: &Revision,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+}

--- a/librad/src/meta/identity/cache.rs
+++ b/librad/src/meta/identity/cache.rs
@@ -15,11 +15,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::{Doc, Error, Revision, Verified};
+use super::{Error, Identity, Revision, Verified};
 
 pub trait VerificationCache {
     fn is_verified(&self, rev: &Revision) -> bool;
-    fn register_verified(&mut self, doc: &Doc<Verified>, rev: &Revision) -> Result<(), Error>;
+    fn register_verified(&mut self, id: &Identity<Verified>) -> Result<(), Error>;
 }
 
 #[cfg(test)]
@@ -32,11 +32,7 @@ pub mod test {
         fn is_verified(&self, _rev: &Revision) -> bool {
             false
         }
-        fn register_verified(
-            &mut self,
-            _doc: &Doc<Verified>,
-            _rev: &Revision,
-        ) -> Result<(), Error> {
+        fn register_verified(&mut self, _id: &Identity<Verified>) -> Result<(), Error> {
             Ok(())
         }
     }
@@ -47,11 +43,7 @@ pub mod test {
         fn is_verified(&self, _rev: &Revision) -> bool {
             true
         }
-        fn register_verified(
-            &mut self,
-            _doc: &Doc<Verified>,
-            _rev: &Revision,
-        ) -> Result<(), Error> {
+        fn register_verified(&mut self, _id: &Identity<Verified>) -> Result<(), Error> {
             Ok(())
         }
     }

--- a/librad/src/meta/identity/test.rs
+++ b/librad/src/meta/identity/test.rs
@@ -19,8 +19,28 @@ use super::*;
 
 use git2::Repository;
 use serde::{Deserialize, Serialize};
+use sodiumoxide::crypto::sign::ed25519::Seed;
 
 use librad_test::tempdir::WithTmpDir;
+
+const SEED: Seed = Seed([
+    20, 21, 6, 102, 102, 57, 20, 67, 219, 198, 236, 108, 148, 15, 182, 52, 167, 27, 29, 81, 181,
+    134, 74, 88, 174, 254, 78, 69, 84, 149, 84, 167,
+]);
+
+fn new_key_from_seed(seed_value: u8) -> SecretKey {
+    let mut seed = SEED;
+    seed.0[0] = seed_value;
+    SecretKey::from_seed(&seed)
+}
+
+lazy_static! {
+    pub static ref K1: SecretKey = new_key_from_seed(1);
+    pub static ref K2: SecretKey = new_key_from_seed(2);
+    pub static ref K3: SecretKey = new_key_from_seed(3);
+    pub static ref K4: SecretKey = new_key_from_seed(4);
+    pub static ref K5: SecretKey = new_key_from_seed(5);
+}
 
 type TmpRepository = WithTmpDir<Repository>;
 
@@ -73,5 +93,48 @@ fn store_and_get_identity() {
         .store_identity(IdentityBuilder::new(rev, doc))
         .unwrap();
     let id2 = store.get_identity(id1.commit()).unwrap();
+    assert_eq!(id1, id2);
+}
+
+#[test]
+fn encode_and_decode_signatures() {
+    let data = vec![42, 3, 7, 9];
+
+    let mut sigs1 = BTreeMap::new();
+    sigs1.insert(K1.public(), K1.sign(&data));
+    sigs1.insert(K2.public(), K2.sign(&data));
+    sigs1.insert(K3.public(), K3.sign(&data));
+
+    let mut text = "some random text\n\nand some more\n".to_string();
+    append_signatures(&mut text, &sigs1);
+    text.push_str("\neven more random babble\n");
+    let sigs2 = parse_signatures(Some(&text));
+
+    assert_eq!(sigs1.len(), 3);
+    assert!(sigs1.contains_key(&K1.public()));
+    assert!(sigs1.contains_key(&K2.public()));
+    assert!(sigs1.contains_key(&K3.public()));
+    assert_eq!(sigs1, sigs2);
+}
+
+#[test]
+fn sign_and_store_identity() {
+    let repo = repo();
+    let store = IdentityStore::new(&repo);
+
+    let doc = DocBuilder::new_user().build(Payload::new("text")).unwrap();
+    let rev = store.store_doc(&doc, None).unwrap();
+
+    let id1 = store
+        .store_identity(
+            IdentityBuilder::new(rev, doc)
+                .sign(K1.clone())
+                .sign(K2.clone()),
+        )
+        .unwrap();
+    let id2 = store.get_identity(id1.commit()).unwrap();
+    assert_eq!(id1.signatures().len(), 2);
+    id1.check_signatures().unwrap();
+    id2.check_signatures().unwrap();
     assert_eq!(id1, id2);
 }

--- a/librad/src/meta/identity/test.rs
+++ b/librad/src/meta/identity/test.rs
@@ -138,3 +138,114 @@ fn sign_and_store_identity() {
     id2.check_signatures().unwrap();
     assert_eq!(id1, id2);
 }
+
+#[test]
+fn collaborate_on_identity() {
+    let repo = repo();
+    let store = IdentityStore::new(&repo);
+
+    // Create and store doc 1
+    let doc1 = DocBuilder::new_user().build(Payload::new("T1")).unwrap();
+    let rev1 = store.store_doc(&doc1, None).unwrap();
+    let root = rev1.clone();
+
+    // Create and store doc 2
+    let doc2 = DocBuilder::new_user()
+        .replaces(rev1.clone())
+        .build(Payload::new("T2"))
+        .unwrap();
+    let rev2 = store.store_doc(&doc2, Some(&root)).unwrap();
+
+    // Create and store doc 3
+    let doc3 = DocBuilder::new_user()
+        .replaces(rev2.clone())
+        .build(Payload::new("T3"))
+        .unwrap();
+    let rev3 = store.store_doc(&doc3, Some(&root)).unwrap();
+
+    // Desired history:
+    // (id names are id{R}_{B} where R is the doc revision and B is the branch)
+    //
+    // DOC      BR1      BR2
+    //           |        |
+    // doc3     id3_1_    |
+    //           |    \__ |
+    // doc3      |       id3_2
+    //           |        |
+    // doc2      |      _id2_2
+    //           |   __/
+    // doc2     id2_1
+    //           |
+    // doc1     id1
+
+    // Store Doc1 on branch 1
+    let id1 = store
+        .store_identity(IdentityBuilder::new(rev1.clone(), doc1.clone()))
+        .unwrap();
+
+    // Store Doc2 on branch 1 (use `with_parent`)
+    let id2_1 = store
+        .store_identity(IdentityBuilder::with_parent(
+            &id1,
+            rev2.clone(),
+            doc2.clone(),
+        ))
+        .unwrap();
+
+    // Store Doc2 on branch 2 taking it from branch 1 (use `duplicate`)
+    let id2_2 = store
+        .store_identity(IdentityBuilder::duplicate(&id2_1))
+        .unwrap();
+
+    // Store Doc3 on branch 2 (use `with_parent`)
+    let id3_2 = store
+        .store_identity(IdentityBuilder::with_parent(
+            &id2_2,
+            rev3.clone(),
+            doc3.clone(),
+        ))
+        .unwrap();
+
+    // Store Doc3 on branch 1 merging it from branch 2 (use `duplicate_other`)
+    let id3_1 = store
+        .store_identity(IdentityBuilder::duplicate_other(&id2_1, &id3_2))
+        .unwrap();
+
+    assert_eq!(id1.root(), &root);
+    assert_eq!(id1.revision(), &rev1);
+    assert_eq!(id1.previous(), None);
+    assert_eq!(id1.merged(), None);
+
+    assert_eq!(id2_1.root(), &root);
+    assert_eq!(id2_1.revision(), &rev2);
+    assert_eq!(id2_1.previous(), Some(id1.commit()));
+    assert_eq!(id2_1.merged(), None);
+
+    assert_eq!(id2_2.root(), &root);
+    assert_eq!(id2_2.revision(), &rev2);
+    assert_eq!(id2_2.previous(), Some(id2_1.commit()));
+    assert_eq!(id2_2.merged(), None);
+
+    assert_eq!(id3_2.root(), &root);
+    assert_eq!(id3_2.revision(), &rev3);
+    assert_eq!(id3_2.previous(), Some(id2_2.commit()));
+    assert_eq!(id3_2.merged(), None);
+
+    assert_eq!(id3_1.root(), &root);
+    assert_eq!(id3_1.revision(), &rev3);
+    assert_eq!(id3_1.previous(), Some(id2_1.commit()));
+    assert_eq!(id3_1.merged(), Some(id3_2.commit()));
+
+    assert_eq!(store.get_identity(id3_1.commit()).unwrap(), id3_1);
+    assert_eq!(store.get_identity(id3_2.commit()).unwrap(), id3_2);
+    assert_eq!(store.get_identity(id2_1.commit()).unwrap(), id2_1);
+    assert_eq!(store.get_identity(id2_2.commit()).unwrap(), id2_2);
+    assert_eq!(store.get_identity(id1.commit()).unwrap(), id1);
+
+    assert_eq!(store.get_parent_identity(&id3_1).unwrap(), id2_1);
+    assert_eq!(store.get_parent_identity(&id3_2).unwrap(), id2_2);
+    assert_eq!(store.get_parent_identity(&id2_2).unwrap(), id2_1);
+    assert_eq!(store.get_parent_identity(&id2_1).unwrap(), id1);
+
+    assert_eq!(store.get_identity(id3_1.merged().unwrap()).unwrap(), id3_2);
+}

--- a/librad/src/meta/identity/test.rs
+++ b/librad/src/meta/identity/test.rs
@@ -180,16 +180,12 @@ fn collaborate_on_identity() {
 
     // Store Doc1 on branch 1
     let id1 = store
-        .store_identity(IdentityBuilder::new(rev1.clone(), doc1.clone()))
+        .store_identity(IdentityBuilder::new(rev1.clone(), doc1))
         .unwrap();
 
     // Store Doc2 on branch 1 (use `with_parent`)
     let id2_1 = store
-        .store_identity(IdentityBuilder::with_parent(
-            &id1,
-            rev2.clone(),
-            doc2.clone(),
-        ))
+        .store_identity(IdentityBuilder::with_parent(&id1, rev2.clone(), doc2))
         .unwrap();
 
     // Store Doc2 on branch 2 taking it from branch 1 (use `duplicate`)
@@ -199,11 +195,7 @@ fn collaborate_on_identity() {
 
     // Store Doc3 on branch 2 (use `with_parent`)
     let id3_2 = store
-        .store_identity(IdentityBuilder::with_parent(
-            &id2_2,
-            rev3.clone(),
-            doc3.clone(),
-        ))
+        .store_identity(IdentityBuilder::with_parent(&id2_2, rev3.clone(), doc3))
         .unwrap();
 
     // Store Doc3 on branch 1 merging it from branch 2 (use `duplicate_other`)

--- a/librad/src/meta/identity/test.rs
+++ b/librad/src/meta/identity/test.rs
@@ -1,0 +1,77 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use git2::Repository;
+use serde::{Deserialize, Serialize};
+
+use librad_test::tempdir::WithTmpDir;
+
+type TmpRepository = WithTmpDir<Repository>;
+
+fn repo() -> TmpRepository {
+    WithTmpDir::new(|path| {
+        Repository::init(path).map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Cannot init temporary git repo: {}", err),
+            )
+        })
+    })
+    .unwrap()
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+struct Payload {
+    pub text: String,
+}
+
+impl Payload {
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.to_owned(),
+        }
+    }
+}
+
+#[test]
+fn store_and_get_doc() {
+    let repo = repo();
+    let store = IdentityStore::new(&repo);
+
+    let doc1 = DocBuilder::new_user().build(Payload::new("text")).unwrap();
+    let rev = store.store_doc(&doc1, None).unwrap();
+    let (doc2, root) = store.get_doc(&rev).unwrap();
+    assert_eq!(doc1, doc2);
+    assert_eq!(rev, root);
+}
+
+#[test]
+fn store_and_get_identity() {
+    let repo = repo();
+    let store = IdentityStore::new(&repo);
+
+    let doc = DocBuilder::new_user().build(Payload::new("text")).unwrap();
+    let rev = store.store_doc(&doc, None).unwrap();
+
+    let id1 = store
+        .store_identity(IdentityBuilder::new(rev, doc))
+        .unwrap();
+    let id2 = store.get_identity(id1.commit()).unwrap();
+    assert_eq!(id1, id2);
+}


### PR DESCRIPTION
This is an implementation of PR #248.

It has been coded in a self contained way to avoid conflicts if the review period is long.

The following types reflect the spec as closely as possible:

* `Revision` and `ContentId` are wrappers on git OIDs, they have the same meaning as in the spec.
* `Doc` and `Identity` are also represent their spec counterparts.
* Verification stages are represented with phantom types.

There are a few additional utility types:

* `DocBuilder` and `IdentityBuilder` are used to create the contents of documents and identities before storing them.
  - `DocBuilder` can create new documents (with no parent) or documents that replace a previous one (with one parent)
  - `IdentityBuilder` has different methods to create new identities, duplicate them to add signatures, or merge them from different branches.
* `IdentityStore` is a thin wrapper around a git `Repository`, providing methods to retrieve and store `Doc` and `Identity` instances, and to walk an identity history to verify it.

The idea is that the `IdentityStore` API should be integrated into `Storage`, replacing `Entity` with `Identity`.

There is also a caching system for verification results in the `cache` module, providing two dummy test caches (one that does not cache anything and another that lies and reports everything as verified) and a working in-memory cache.
The in-memory cache can also detect non-linear identity document histories (called branches) and reports them as errors, without traversing both histories checking for reachability.

There are two implementation differences WRT the spec:

* `Delegations` is a union type used instead of type parameter `D` in `Doc` to avoid the deserialization problem we had with entities.
* In `Doc` the payload type parameter `T` is not present, it is possible to store and extract arbitrary documents using generic methods.

The consequence is that `Doc` is not generic (apart from the verification type witness), and it is possible to deserialize it from arbitrary URNs without knowledge of the target type.
