### PR TITLE
Don't update FETCH_HEAD when fetching

### DIFF
--- a/librad/src/git/storage/fetch.rs
+++ b/librad/src/git/storage/fetch.rs
@@ -189,7 +189,7 @@ impl<'a> Fetcher<'a> {
 
         let mut fos = git2::FetchOptions::new();
         fos.prune(git2::FetchPrune::Off)
-            .update_fetchhead(true)
+            .update_fetchhead(false)
             .download_tags(git2::AutotagOption::None)
             .remote_callbacks(cbs);
 

--- a/librad/src/git/storage/fetch.rs
+++ b/librad/src/git/storage/fetch.rs
@@ -178,12 +178,12 @@ impl<'a> Fetcher<'a> {
     // TODO: allow users to supply callbacks
     fn fetch_options(&self) -> git2::FetchOptions<'a> {
         let mut cbs = git2::RemoteCallbacks::new();
-        cbs.sideband_progress(|prog| {
-            tracing::trace!("{}", unsafe { std::str::from_utf8_unchecked(prog) });
+        cbs.transfer_progress(|prog| {
+            tracing::trace!("Fetch: received {} bytes", prog.received_bytes());
             true
         })
         .update_tips(|name, old, new| {
-            tracing::debug!("{}: {} -> {}", name, old, new);
+            tracing::debug!("Fetch: updating tip {}: {} -> {}", name, old, new);
             true
         });
 


### PR DESCRIPTION
We do not actually need it, and it may cause a segfault in libgit2 when a custom
transport is used and the URL contains a port number. Also, make fetch tracing
more legible.
