### PR TITLE
Add refspec constructors

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 # and Mozilla's nix overlay README
 # https://www.scala-native.org/en/latest/user/setup.html
 let
-  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/4521bc61c2332f41e18664812a808294c8c78580.tar.gz);
   pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
 in
   with pkgs;

--- a/librad/src/git/storage/fetch.rs
+++ b/librad/src/git/storage/fetch.rs
@@ -23,7 +23,7 @@ use crate::{
     git::{
         p2p::url::GitUrl,
         refs::Refs,
-        types::{Reference, Refspec, SomeReference},
+        types::{Force, Reference, Refspec},
     },
     peer::PeerId,
     uri::RadUrn,
@@ -75,21 +75,15 @@ impl<'a> Fetcher<'a> {
         // `refs/namespaces/<namespace>/refs/rad/ids/* \
         // :refs/namespaces/<namespace>/refs/remotes/<remote_peer>/rad/ids/*`
         let refspecs = [
-            Refspec {
-                remote: SomeReference::Single(remote_id.clone()),
-                local: SomeReference::Single(remote_id.with_remote(remote_peer.clone())),
-                force: false,
-            },
-            Refspec {
-                remote: SomeReference::Single(remote_self.clone()),
-                local: SomeReference::Single(remote_self.with_remote(remote_peer.clone())),
-                force: false,
-            },
-            Refspec {
-                remote: SomeReference::Multiple(remote_certifiers.clone()),
-                local: SomeReference::Multiple(remote_certifiers.with_remote(remote_peer.clone())),
-                force: false,
-            },
+            remote_id
+                .with_remote(remote_peer.clone())
+                .refspec(remote_id, Force::False),
+            remote_self
+                .with_remote(remote_peer.clone())
+                .refspec(remote_self, Force::False),
+            remote_certifiers
+                .with_remote(remote_peer.clone())
+                .refspec(remote_certifiers, Force::False),
         ]
         .iter()
         .map(|spec| spec.to_string())


### PR DESCRIPTION
It's useful to have a way of constructing a Refspec from two of the same
References. It makes it re-usable to any consumers in case they need to
create these specs themselves.

Above the table: I don't want to repeat this logic in Upstream just so I can have a safe way of setting up a remote :upside_down_face: 