### PR TITLE
Add BranchRef

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -41,7 +41,7 @@ use crate::{
         p2p::url::{GitUrl, GitUrlRef},
         refs::{self, Refs},
         repo::Repo,
-        types::{Force, Multiple, Reference, Single},
+        types::{Force, Multiple, NamespaceRef, Reference, Single},
     },
     hash::Hash,
     internal::{
@@ -103,7 +103,7 @@ pub enum Error {
     NotSignedBySelf,
 
     #[error("Local key certifier not found: {0}")]
-    NoSelf(Reference<Single>),
+    NoSelf(NamespaceRef<Single>),
 
     #[error("Missing certifier {certifier} of {urn}")]
     MissingCertifier { certifier: RadUrn, urn: RadUrn },
@@ -307,7 +307,7 @@ impl<S: Clone> Storage<S> {
         }
     }
 
-    pub fn has_ref(&self, reference: &Reference<Single>) -> Result<bool, Error> {
+    pub fn has_ref(&self, reference: &NamespaceRef<Single>) -> Result<bool, Error> {
         self.backend
             .find_reference(&reference.to_string())
             .map(|_| true)
@@ -388,18 +388,18 @@ impl<S: Clone> Storage<S> {
         Ok(Refs::from(signed))
     }
 
-    /// Get the [`Reference`] provided, if it exists.
+    /// Get the [`NamespaceRef`] provided, if it exists.
     pub fn reference<'a>(
         &'a self,
-        reference: &Reference<Single>,
+        reference: &NamespaceRef<Single>,
     ) -> Result<git2::Reference<'a>, Error> {
         reference.find(&self.backend).map_err(Error::from)
     }
 
-    /// Get the [`Reference`]s provided, if they exist.
+    /// Get the [`NamespaceRef`]s provided, if they exist.
     pub fn references<'a>(
         &'a self,
-        reference: &Reference<Multiple>,
+        reference: &NamespaceRef<Multiple>,
     ) -> Result<References<'a>, Error> {
         reference.references(&self.backend).map_err(Error::from)
     }

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -670,7 +670,7 @@ where
         // `remote_peer` said)
         {
             let local_id = NamespacedRef::rad_id(urn.id.clone());
-            let remote_id = local_id.with_remote(remote_peer);
+            let remote_id = local_id.set_remote(remote_peer);
             let remote_id_head = self.reference(&remote_id).and_then(|reference| {
                 reference
                     .target()

--- a/librad/src/git/storage/fetch.rs
+++ b/librad/src/git/storage/fetch.rs
@@ -76,13 +76,13 @@ impl<'a> Fetcher<'a> {
         // :refs/namespaces/<namespace>/refs/remotes/<remote_peer>/rad/ids/*`
         let refspecs = [
             remote_id
-                .with_remote(remote_peer.clone())
+                .set_remote(remote_peer.clone())
                 .refspec(remote_id, Force::False),
             remote_self
-                .with_remote(remote_peer.clone())
+                .set_remote(remote_peer.clone())
                 .refspec(remote_self, Force::False),
             remote_certifiers
-                .with_remote(remote_peer.clone())
+                .set_remote(remote_peer.clone())
                 .refspec(remote_certifiers, Force::False),
         ]
         .iter()

--- a/librad/src/git/storage/test.rs
+++ b/librad/src/git/storage/test.rs
@@ -20,6 +20,7 @@ use super::*;
 use std::str::FromStr;
 
 use crate::{
+    git::types::NamespaceRef,
     hash::Hash,
     keys::SecretKey,
     meta::{entity::Draft, Project, User},
@@ -151,7 +152,7 @@ fn test_all_metadata_heads() {
         assert!(ids.contains(id));
 
         // Check that we can use the URN to find the same commit
-        let commit_from_urn = Reference::rad_id(urn.id.clone())
+        let commit_from_urn = NamespaceRef::rad_id(urn.id.clone())
             .find(&store.backend)
             .unwrap()
             .target()
@@ -180,7 +181,7 @@ fn test_all_metadata_heads() {
 
     // Check user commit history length
     let user_history = {
-        let rad_id = Reference::rad_id(user.urn().id);
+        let rad_id = NamespaceRef::rad_id(user.urn().id);
 
         let mut revwalk = store.backend.revwalk().unwrap();
         revwalk.set_sorting(git2::Sort::TOPOLOGICAL).unwrap();
@@ -243,8 +244,8 @@ fn test_structure_of_refs() -> Result<(), Error> {
         .clone()
         .check_history_status(&user_resolver, &user_resolver)
         .unwrap();
-    refs.push(Reference::rad_id(user.urn().id));
-    refs.push(Reference::rad_signed_refs(user.urn().id, None));
+    refs.push(NamespaceRef::rad_id(user.urn().id));
+    refs.push(NamespaceRef::rad_signed_refs(user.urn().id, None));
     store.create_repo(&user)?;
     store.set_default_rad_self(verified_user)?;
 
@@ -256,8 +257,8 @@ fn test_structure_of_refs() -> Result<(), Error> {
             .build()?;
         project.sign_owned(&key)?;
         let namespace = project.urn().id;
-        refs.push(Reference::rad_id(namespace.clone()));
-        refs.push(Reference::rad_signed_refs(namespace, None));
+        refs.push(NamespaceRef::rad_id(namespace.clone()));
+        refs.push(NamespaceRef::rad_signed_refs(namespace, None));
         let _repo = store.create_repo(&project)?;
     }
 
@@ -269,8 +270,8 @@ fn test_structure_of_refs() -> Result<(), Error> {
             .build()?;
         project.sign_owned(&key)?;
         let namespace = project.urn().id;
-        refs.push(Reference::rad_id(namespace.clone()));
-        refs.push(Reference::rad_signed_refs(namespace, None));
+        refs.push(NamespaceRef::rad_id(namespace.clone()));
+        refs.push(NamespaceRef::rad_signed_refs(namespace, None));
         let _repo = store.create_repo(&project)?;
     }
 

--- a/librad/src/git/storage/test.rs
+++ b/librad/src/git/storage/test.rs
@@ -20,7 +20,7 @@ use super::*;
 use std::str::FromStr;
 
 use crate::{
-    git::types::NamespaceRef,
+    git::types::NamespacedRef,
     hash::Hash,
     keys::SecretKey,
     meta::{entity::Draft, Project, User},
@@ -152,7 +152,7 @@ fn test_all_metadata_heads() {
         assert!(ids.contains(id));
 
         // Check that we can use the URN to find the same commit
-        let commit_from_urn = NamespaceRef::rad_id(urn.id.clone())
+        let commit_from_urn = NamespacedRef::rad_id(urn.id.clone())
             .find(&store.backend)
             .unwrap()
             .target()
@@ -181,7 +181,7 @@ fn test_all_metadata_heads() {
 
     // Check user commit history length
     let user_history = {
-        let rad_id = NamespaceRef::rad_id(user.urn().id);
+        let rad_id = NamespacedRef::rad_id(user.urn().id);
 
         let mut revwalk = store.backend.revwalk().unwrap();
         revwalk.set_sorting(git2::Sort::TOPOLOGICAL).unwrap();
@@ -244,8 +244,8 @@ fn test_structure_of_refs() -> Result<(), Error> {
         .clone()
         .check_history_status(&user_resolver, &user_resolver)
         .unwrap();
-    refs.push(NamespaceRef::rad_id(user.urn().id));
-    refs.push(NamespaceRef::rad_signed_refs(user.urn().id, None));
+    refs.push(NamespacedRef::rad_id(user.urn().id));
+    refs.push(NamespacedRef::rad_signed_refs(user.urn().id, None));
     store.create_repo(&user)?;
     store.set_default_rad_self(verified_user)?;
 
@@ -257,8 +257,8 @@ fn test_structure_of_refs() -> Result<(), Error> {
             .build()?;
         project.sign_owned(&key)?;
         let namespace = project.urn().id;
-        refs.push(NamespaceRef::rad_id(namespace.clone()));
-        refs.push(NamespaceRef::rad_signed_refs(namespace, None));
+        refs.push(NamespacedRef::rad_id(namespace.clone()));
+        refs.push(NamespacedRef::rad_signed_refs(namespace, None));
         let _repo = store.create_repo(&project)?;
     }
 
@@ -270,8 +270,8 @@ fn test_structure_of_refs() -> Result<(), Error> {
             .build()?;
         project.sign_owned(&key)?;
         let namespace = project.urn().id;
-        refs.push(NamespaceRef::rad_id(namespace.clone()));
-        refs.push(NamespaceRef::rad_signed_refs(namespace, None));
+        refs.push(NamespacedRef::rad_id(namespace.clone()));
+        refs.push(NamespacedRef::rad_signed_refs(namespace, None));
         let _repo = store.create_repo(&project)?;
     }
 

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -142,7 +142,7 @@ impl Refspec<PeerId> {
         tracked.map(move |peer| {
             let local = Reference::rad_signed_refs(namespace.clone(), (*peer).clone());
             let remote = if peer == remote_peer {
-                local.with_remote(None)
+                local.set_remote(None)
             } else {
                 local.clone()
             };
@@ -181,7 +181,7 @@ impl Refspec<PeerId> {
                             let local =
                                 Reference::head(namespace.clone(), tracked_peer.clone(), &name);
                             let remote = if tracked_peer == remote_peer {
-                                local.with_remote(None)
+                                local.set_remote(None)
                             } else {
                                 local.clone()
                             };
@@ -197,9 +197,9 @@ impl Refspec<PeerId> {
             // `refs/namespaces/<namespace>/refs[/remotes/<peer>]/rad/id \
             // :refs/namespaces/<namespace>/refs/remotes/<peer>/rad/id`
             {
-                let local = Reference::rad_id(namespace.clone()).set_remote(tracked_peer.clone());
+                let local = Reference::rad_id(namespace.clone()).with_remote(tracked_peer.clone());
                 let remote = if tracked_peer == remote_peer {
-                    local.with_remote(None)
+                    local.set_remote(None)
                 } else {
                     local.clone()
                 };
@@ -214,7 +214,7 @@ impl Refspec<PeerId> {
             {
                 let local = Reference::rad_self(namespace.clone(), tracked_peer.clone());
                 let remote = if tracked_peer == remote_peer {
-                    local.with_remote(None)
+                    local.set_remote(None)
                 } else {
                     local.clone()
                 };
@@ -228,9 +228,9 @@ impl Refspec<PeerId> {
             // :refs/namespaces/<namespace>/refs/remotes/<peer>/rad/ids/*`
             {
                 let local =
-                    Reference::rad_ids_glob(namespace.clone()).set_remote(tracked_peer.clone());
+                    Reference::rad_ids_glob(namespace.clone()).with_remote(tracked_peer.clone());
                 let remote = if tracked_peer == remote_peer {
-                    local.with_remote(None)
+                    local.set_remote(None)
                 } else {
                     local.clone()
                 };
@@ -253,9 +253,9 @@ impl Refspec<PeerId> {
                     // id
                     {
                         let local =
-                            Reference::rad_id(urn.id.clone()).set_remote(tracked_peer.clone());
+                            Reference::rad_id(urn.id.clone()).with_remote(tracked_peer.clone());
                         let remote = if tracked_peer == remote_peer {
-                            local.with_remote(None)
+                            local.set_remote(None)
                         } else {
                             local.clone()
                         };
@@ -266,9 +266,9 @@ impl Refspec<PeerId> {
                     // rad/ids/* of id
                     {
                         let local = Reference::rad_ids_glob(urn.id.clone())
-                            .set_remote(tracked_peer.clone());
+                            .with_remote(tracked_peer.clone());
                         let remote = if tracked_peer == remote_peer {
-                            local.with_remote(None)
+                            local.set_remote(None)
                         } else {
                             local.clone()
                         };

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -44,7 +44,7 @@ impl<R: Display, N> Display for FlatRef<R, N> {
 }
 
 /// A representation of git reference that is under `refs/namespace/<namespace>`
-pub type NamespaceRef<N> = Reference<Namespace, PeerId, N>;
+pub type NamespacedRef<N> = Reference<Namespace, PeerId, N>;
 
 impl<N, R: Display> Display for Reference<Namespace, R, N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/librad/src/git/types/existential.rs
+++ b/librad/src/git/types/existential.rs
@@ -1,0 +1,96 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    fmt::{self, Display},
+    marker::PhantomData,
+};
+
+use either::Either;
+
+use super::reference::{Multiple, Namespace, Reference, Single};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SomeNamespace(Either<PhantomData<!>, Namespace>);
+
+impl From<PhantomData<!>> for SomeNamespace {
+    fn from(_: PhantomData<!>) -> Self {
+        Self(Either::Left(PhantomData))
+    }
+}
+
+impl From<Namespace> for SomeNamespace {
+    fn from(other: Namespace) -> Self {
+        Self(Either::Right(other))
+    }
+}
+
+impl<Namespaced: Clone> From<Reference<Namespaced, Single>> for SomeReference
+where
+    Namespaced: Into<SomeNamespace>,
+{
+    fn from(other: Reference<Namespaced, Single>) -> Self {
+        let namespace = other._namespace.clone().into();
+        Self::Single(other.with_namespace(namespace))
+    }
+}
+
+impl<Namespaced: Clone> From<Reference<Namespaced, Multiple>> for SomeReference
+where
+    Namespaced: Into<SomeNamespace>,
+{
+    fn from(other: Reference<Namespaced, Multiple>) -> Self {
+        let namespace = other._namespace.clone().into();
+        Self::Multiple(other.with_namespace(namespace))
+    }
+}
+
+impl<N: Clone> Reference<SomeNamespace, N> {
+    fn sequence(&self) -> Either<Reference<PhantomData<!>, N>, Reference<Namespace, N>> {
+        match &self._namespace.0 {
+            Either::Left(_) => Either::Left(self.clone().with_namespace(PhantomData)),
+
+            Either::Right(namespace) => {
+                Either::Right(self.clone().with_namespace(namespace.clone()))
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SomeReference {
+    Single(Reference<SomeNamespace, Single>),
+    Multiple(Reference<SomeNamespace, Multiple>),
+}
+
+impl<N: Clone> Display for Reference<SomeNamespace, N> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.sequence() {
+            Either::Left(reference) => write!(f, "{}", reference),
+            Either::Right(reference) => write!(f, "{}", reference),
+        }
+    }
+}
+
+impl Display for SomeReference {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Single(reference) => write!(f, "{}", reference),
+            Self::Multiple(reference) => write!(f, "{}", reference),
+        }
+    }
+}

--- a/librad/src/git/types/existential.rs
+++ b/librad/src/git/types/existential.rs
@@ -39,28 +39,28 @@ impl From<Namespace> for SomeNamespace {
     }
 }
 
-impl<Namespaced: Clone> From<Reference<Namespaced, Single>> for SomeReference
+impl<N: Clone, R: Clone> From<Reference<N, R, Single>> for SomeReference<R>
 where
-    Namespaced: Into<SomeNamespace>,
+    N: Into<SomeNamespace>,
 {
-    fn from(other: Reference<Namespaced, Single>) -> Self {
+    fn from(other: Reference<N, R, Single>) -> Self {
         let namespace = other._namespace.clone().into();
         Self::Single(other.with_namespace(namespace))
     }
 }
 
-impl<Namespaced: Clone> From<Reference<Namespaced, Multiple>> for SomeReference
+impl<N: Clone, R: Clone> From<Reference<N, R, Multiple>> for SomeReference<R>
 where
-    Namespaced: Into<SomeNamespace>,
+    N: Into<SomeNamespace>,
 {
-    fn from(other: Reference<Namespaced, Multiple>) -> Self {
+    fn from(other: Reference<N, R, Multiple>) -> Self {
         let namespace = other._namespace.clone().into();
         Self::Multiple(other.with_namespace(namespace))
     }
 }
 
-impl<N: Clone> Reference<SomeNamespace, N> {
-    fn sequence(&self) -> Either<Reference<PhantomData<!>, N>, Reference<Namespace, N>> {
+impl<N: Clone, R: Clone> Reference<SomeNamespace, R, N> {
+    fn sequence(&self) -> Either<Reference<PhantomData<!>, R, N>, Reference<Namespace, R, N>> {
         match &self._namespace.0 {
             Either::Left(_) => Either::Left(self.clone().with_namespace(PhantomData)),
 
@@ -72,12 +72,12 @@ impl<N: Clone> Reference<SomeNamespace, N> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum SomeReference {
-    Single(Reference<SomeNamespace, Single>),
-    Multiple(Reference<SomeNamespace, Multiple>),
+pub enum SomeReference<R> {
+    Single(Reference<SomeNamespace, R, Single>),
+    Multiple(Reference<SomeNamespace, R, Multiple>),
 }
 
-impl<N: Clone> Display for Reference<SomeNamespace, N> {
+impl<N: Clone, R: Clone + Display> Display for Reference<SomeNamespace, R, N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.sequence() {
             Either::Left(reference) => write!(f, "{}", reference),
@@ -86,7 +86,7 @@ impl<N: Clone> Display for Reference<SomeNamespace, N> {
     }
 }
 
-impl Display for SomeReference {
+impl<R: Clone + Display> Display for SomeReference<R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Single(reference) => write!(f, "{}", reference),

--- a/librad/src/git/types/reference.rs
+++ b/librad/src/git/types/reference.rs
@@ -1,0 +1,277 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    fmt::{self, Display},
+    marker::PhantomData,
+};
+
+use crate::{git::ext, hash::Hash, peer::PeerId, uri::RadUrn};
+
+use super::{existential::SomeNamespace, Force, Refspec, SymbolicRef};
+
+/// Type witness for a [`Reference`] that should point to a single reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Single;
+
+/// Type witness for a [`Reference`] that should point to multiple references.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Multiple;
+
+pub type Namespace = Hash;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RefsCategory {
+    Heads,
+    Rad,
+}
+
+impl Display for RefsCategory {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Heads => f.write_str("heads"),
+            Self::Rad => f.write_str("rad"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Reference<Namespaced, Cardinality> {
+    /// The remote portion of this reference.
+    pub remote: Option<PeerId>,
+    /// Where this reference falls under, i.e. `rad` or `heads`.
+    pub category: RefsCategory,
+    /// The path of the reference, e.g. `feature/123`, `dev`.
+    pub name: String,
+
+    pub(super) _namespace: Namespaced,
+    pub(super) _cardinality: PhantomData<Cardinality>,
+}
+
+// Polymorphic definitions
+impl<Namespaced: Clone, N: Clone> Reference<Namespaced, N> {
+    /// Set the remote portion of thise reference.
+    ///
+    /// Note: This is consuming.
+    pub fn set_remote(mut self, remote: impl Into<Option<PeerId>>) -> Self {
+        self.remote = remote.into();
+        self
+    }
+
+    /// Set the remote portion of thise reference.
+    ///
+    /// Note: This is not consuming.
+    pub fn with_remote(&self, remote: impl Into<Option<PeerId>>) -> Self {
+        Self {
+            remote: remote.into(),
+            ..self.clone()
+        }
+    }
+
+    /// Set the namespace of this reference to another one. Note that the
+    /// namespace does not have to be of the original namespace's type.
+    pub fn with_namespace<Other>(self, namespace: Other) -> Reference<Other, N> {
+        Reference {
+            name: self.name,
+            remote: self.remote,
+            category: self.category,
+            _namespace: namespace,
+            _cardinality: self._cardinality,
+        }
+    }
+
+    /// Set the named portion of this path.
+    ///
+    /// Note: This is consuming.
+    pub fn set_name(mut self, name: &str) -> Self {
+        self.name = name.to_owned();
+        self
+    }
+
+    /// Set the named portion of this path.
+    ///
+    /// Note: This is not consuming.
+    pub fn with_name(&self, name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            ..self.clone()
+        }
+    }
+}
+
+// References with a Single cardinality
+impl<Namespaced> Reference<Namespaced, Single> {
+    /// Find this particular reference.
+    pub fn find<'a>(&self, repo: &'a git2::Repository) -> Result<git2::Reference<'a>, git2::Error>
+    where
+        Self: ToString,
+    {
+        repo.find_reference(&self.to_string())
+    }
+
+    /// Create a [`SymbolicRef`] of the `self` parameter where the `source`
+    /// parameter will be the newly created reference.
+    ///
+    /// To create the symbolic reference itself, see [`SymbolicRef::create`].
+    pub fn symbolic_ref(&self, source: Self, force: Force) -> SymbolicRef
+    where
+        Namespaced: Into<SomeNamespace> + Clone,
+    {
+        SymbolicRef {
+            source: source.clone().with_namespace(source._namespace.into()),
+            target: self.clone().with_namespace(self._namespace.clone().into()),
+            force,
+        }
+    }
+
+    /// Create the [`Refspec`] using the LHS of this call as the `local`, and
+    /// the RHS as the `remote`.
+    pub fn refspec(self, remote: Self, force: Force) -> Refspec
+    where
+        Namespaced: Into<SomeNamespace> + Clone,
+    {
+        Refspec {
+            local: self.into(),
+            remote: remote.into(),
+            force,
+        }
+    }
+
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/rad/id`
+    pub fn rad_id(namespace: Namespaced) -> Self {
+        Self {
+            remote: None,
+            category: RefsCategory::Rad,
+            name: "id".to_owned(),
+            _namespace: namespace,
+            _cardinality: PhantomData,
+        }
+    }
+
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/rad/ids/<id>`
+    pub fn rad_certifier(namespace: Namespaced, urn: &RadUrn) -> Self {
+        Self {
+            remote: None,
+            category: RefsCategory::Rad,
+            name: format!("ids/{}", urn.id),
+            _namespace: namespace,
+            _cardinality: PhantomData,
+        }
+    }
+
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/rad/signed_refs`
+    ///     * `refs/namespaces/<namespace>/refs/remote/<peer_id>/rad/
+    ///       signed_refs`
+    pub fn rad_signed_refs(namespace: Namespaced, remote: impl Into<Option<PeerId>>) -> Self {
+        Self {
+            remote: remote.into(),
+            category: RefsCategory::Rad,
+            name: "signed_refs".to_owned(),
+            _namespace: namespace,
+            _cardinality: PhantomData,
+        }
+    }
+
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/rad/self`
+    ///     * `refs/namespaces/<namespace>/refs/remote/<peer_id>/rad/self`
+    pub fn rad_self(namespace: Namespaced, remote: impl Into<Option<PeerId>>) -> Self {
+        Self {
+            remote: remote.into(),
+            category: RefsCategory::Rad,
+            name: "self".to_owned(),
+            _namespace: namespace,
+            _cardinality: PhantomData,
+        }
+    }
+
+    /// Build a reference that points to:
+    ///     * `refs/namespaces/<namespace>/refs/heads/<name>`
+    ///     * `refs/namespaces/<namespace>/refs/remote/<peer_id>/heads/<name>
+    pub fn head(namespace: Namespaced, remote: impl Into<Option<PeerId>>, name: &str) -> Self {
+        Self {
+            remote: remote.into(),
+            category: RefsCategory::Heads,
+            name: name.to_owned(),
+            _namespace: namespace,
+            _cardinality: PhantomData,
+        }
+    }
+}
+
+// References with a Multiple cardinality
+impl<Namespaced> Reference<Namespaced, Multiple> {
+    /// Get the iterator for these references.
+    pub fn references<'a>(
+        &self,
+        repo: &'a git2::Repository,
+    ) -> Result<ext::References<'a>, git2::Error>
+    where
+        Self: ToString,
+    {
+        ext::References::from_globs(repo, &[self.to_string()])
+    }
+
+    /// Create the [`Refspec`] using the LHS of this call as the `local`, and
+    /// the RHS as the `remote`.
+    pub fn refspec(self, remote: Self, force: Force) -> Refspec
+    where
+        Namespaced: Into<SomeNamespace> + Clone,
+    {
+        Refspec {
+            local: self.into(),
+            remote: remote.into(),
+            force,
+        }
+    }
+
+    /// Build a reference that points to
+    /// `refs/namespaces/<namespace>/refs/rad/ids/*`
+    pub fn rad_ids_glob(namespace: Namespaced) -> Self {
+        Self {
+            remote: None,
+            category: RefsCategory::Rad,
+            name: "ids/*".to_owned(),
+            _namespace: namespace,
+            _cardinality: PhantomData,
+        }
+    }
+
+    /// Build a reference that points to
+    /// `refs/namespaces/<namespace>/refs/rad/[peer_id]/heads/*`
+    pub fn heads(namespace: Namespaced, remote: impl Into<Option<PeerId>>) -> Self {
+        Self {
+            remote: remote.into(),
+            category: RefsCategory::Heads,
+            name: "*".to_owned(),
+            _namespace: namespace,
+            _cardinality: PhantomData,
+        }
+    }
+}
+
+impl<'a, Namespaced> Into<ext::blob::Branch<'a>> for &'a Reference<Namespaced, Single>
+where
+    Self: ToString,
+{
+    fn into(self) -> ext::blob::Branch<'a> {
+        ext::blob::Branch::from(self.to_string())
+    }
+}

--- a/librad/src/git/types/reference.rs
+++ b/librad/src/git/types/reference.rs
@@ -67,7 +67,7 @@ impl<Namespaced: Clone, R: Clone, N: Clone> Reference<Namespaced, R, N> {
     /// Set the remote portion of thise reference.
     ///
     /// Note: This is consuming.
-    pub fn set_remote(mut self, remote: impl Into<Option<R>>) -> Self {
+    pub fn with_remote(mut self, remote: impl Into<Option<R>>) -> Self {
         self.remote = remote.into();
         self
     }
@@ -75,7 +75,7 @@ impl<Namespaced: Clone, R: Clone, N: Clone> Reference<Namespaced, R, N> {
     /// Set the remote portion of thise reference.
     ///
     /// Note: This is not consuming.
-    pub fn with_remote(&self, remote: impl Into<Option<R>>) -> Self {
+    pub fn set_remote(&self, remote: impl Into<Option<R>>) -> Self {
         Self {
             remote: remote.into(),
             ..self.clone()
@@ -97,7 +97,7 @@ impl<Namespaced: Clone, R: Clone, N: Clone> Reference<Namespaced, R, N> {
     /// Set the named portion of this path.
     ///
     /// Note: This is consuming.
-    pub fn set_name(mut self, name: &str) -> Self {
+    pub fn with_name(mut self, name: &str) -> Self {
         self.name = name.to_owned();
         self
     }
@@ -105,7 +105,7 @@ impl<Namespaced: Clone, R: Clone, N: Clone> Reference<Namespaced, R, N> {
     /// Set the named portion of this path.
     ///
     /// Note: This is not consuming.
-    pub fn with_name(&self, name: &str) -> Self {
+    pub fn set_name(&self, name: &str) -> Self {
         Self {
             name: name.to_owned(),
             ..self.clone()


### PR DESCRIPTION
We had no way of talking about references that live under `refs/heads` or
`refs/remotes`. This is useful for setting up remote fetch/push specs.

I chose a separate type rather than trying to shoe-horn it into the
existing model.