### PR TITLE
Use address hints to establish (git) connections if applicable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-futures",
  "url 2.1.1",
  "urltemplate",
  "webpki",
@@ -2224,6 +2225,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d593f98af59ebc017c0648f0117525db358745a8894a8d684e185ba3f45954f9"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -35,6 +35,7 @@ sodiumoxide = "0.2"
 tempfile = "3.1"
 thiserror = "1.0"
 tracing = "0.1"
+tracing-futures = "0.2"
 urltemplate = "0.1"
 webpki = "0.21"
 

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, net::SocketAddr};
 
 use thiserror::Error;
 
@@ -110,12 +110,22 @@ where
     S::Error: keys::SignError,
 {
     /// Fetch new refs and objects for this repo from [`PeerId`]
-    pub fn fetch(&self, from: &PeerId) -> Result<(), Error> {
+    ///
+    /// `addr_hints` may be supplied for the networking layer to establish a new
+    /// connection to the peer specified in the `url` if none is currently
+    /// active.
+    pub fn fetch<Addrs>(&self, from: &PeerId, addr_hints: Addrs) -> Result<(), Error>
+    where
+        Addrs: IntoIterator<Item = SocketAddr>,
+    {
         self.storage
-            .fetch_repo(RadUrl {
-                authority: from.clone(),
-                urn: self.urn.clone(),
-            })
+            .fetch_repo(
+                RadUrl {
+                    authority: from.clone(),
+                    urn: self.urn.clone(),
+                },
+                addr_hints,
+            )
             .map_err(Error::from)
     }
 

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -306,14 +306,13 @@ where
                         }
                     },
 
-                    gossip::Control::Connect { to, hello } => {
+                    gossip::Control::Connect { to } => {
                         tracing::trace!(remote.id = %to.peer_id, "Run::Rad(Connect)");
 
                         if !self.connections.lock().await.contains_key(&to.peer_id) {
                             let conn = connect_peer_info(&self.endpoint, to).await;
                             if let Some((conn, incoming)) = conn {
-                                self.handle_connect(conn, incoming.boxed(), Some(hello))
-                                    .await
+                                self.handle_connect(conn, incoming.boxed(), None).await
                             }
                         }
                     },


### PR DESCRIPTION
I ended up treating this as a proper connect, ie. add the connection to the pool, and start gossiping, because of the following:

Due to a bug in either `libgit2` or `git2-rs`, or just the way the Rust FFI works, we can't register our transport as "stateful". This means that `libgit2` will always try to open _two_ connections, one for the refs advertisement, and another one for getting the packfile. Always helpful, it will also call `close()` on our transport, so there isn't a way to know when it's done.

Although we don't incur a full TLS handshake thanks to session tickets, the connection establishment is still roughly equivalent to a TCP handshake.

Otoh, it is also semantically _correct_ to keep being connected, because if we got what we wanted from the peer, we are also interested in updates to it. This is a bit handwavy I know, but I think good for now. 