### PR TITLE
Add Remote struct

### DIFF
--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -115,10 +115,15 @@ impl<R> SymbolicRef<R> {
     }
 }
 
-/// A `Display`-like trait but only meant for `Refspec`s.
+/// If we want to be able to use a collection of [`Refspec`]s, where the remote
+/// portions don't line up, then we need to be able to talk about them using
+/// dynamically. In Rust this cab be done via `Box<dyn MyTrait>`.
 ///
-/// This allows us to treat them as opaque in collections, such a `Vec<Box<dyn
-/// AsRefspec>>`.
+/// In this case, we want to be able to turn [`Refspec`]s into `String`s. To
+/// avoid allowing anything that is `ToString` or `Display`, we opt for adding a
+/// `ToString`-like trait called `AsRefspec`.
+///
+/// **N.B.**: The only implementor of this trait should `Refspec`.
 pub trait AsRefspec {
     fn as_refspec(&self) -> String;
 }

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -123,9 +123,19 @@ impl<R> SymbolicRef<R> {
 /// avoid allowing anything that is `ToString` or `Display`, we opt for adding a
 /// `ToString`-like trait called `AsRefspec`.
 ///
-/// **N.B.**: The only implementor of this trait should `Refspec`.
-pub trait AsRefspec {
+/// **N.B.**: The only implementor of this trait should be `Refspec`. We enforce
+/// this by making `AsRefspec` a [sealed
+/// trait](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed).
+pub trait AsRefspec: sealed::Sealed {
     fn as_refspec(&self) -> String;
+}
+
+/// A private module to protect `AsRefspec` as a sealed trait.
+mod sealed {
+    use super::Refspec;
+
+    pub trait Sealed {}
+    impl<R, L> Sealed for Refspec<R, L> {}
 }
 
 #[derive(Clone)]

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -137,6 +137,13 @@ pub struct Refspec<RemoteR, LocalR> {
 }
 
 impl<R, L> Refspec<R, L> {
+    /// Allows to existentialise the `Refspec` into a dynamic `AsRefspec`. This
+    /// means we forget about the type parameters on `Refspec` and we can
+    /// then have a collection of `Refspec`s with differeing remotes.
+    ///
+    /// This function, while trivially, is useful for type-inference, since Rust
+    /// will get confused about what you're trying to do when you have a
+    /// `vec![]` of `Refspec`s with different remotes.
     pub fn into_dyn(self) -> Box<dyn AsRefspec>
     where
         R: Display + Clone + 'static,

--- a/librad/src/git/types/remote.rs
+++ b/librad/src/git/types/remote.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-
 use super::AsRefspec;
 
 pub struct Remote<Url> {
@@ -94,7 +93,10 @@ impl<Url> Remote<Url> {
     }
 
     /// Create the [`git2::Remote`] and add the specs.
-    pub fn create<'a>(&self, repo: &'a git2::Repository) -> Result<git2::Remote<'a>, git2::Error> where Url: ToString {
+    pub fn create<'a>(&self, repo: &'a git2::Repository) -> Result<git2::Remote<'a>, git2::Error>
+    where
+        Url: ToString,
+    {
         let _ = repo.remote_with_fetch(
             &self.name,
             &self.url.to_string(),

--- a/librad/src/git/types/remote.rs
+++ b/librad/src/git/types/remote.rs
@@ -144,7 +144,7 @@ mod tests {
 
             assert_eq!(
                 git_remote
-                    .fetch_refspecs().expect("failed to get fetchspecs")
+                    .fetch_refspecs().expect("failed to get the push refspecs")
                     .iter()
                     .collect::<Vec<Option<&str>>>(),
                 vec![Some("+refs/namespaces/hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try/refs/heads/*:refs/heads/*")],
@@ -152,7 +152,7 @@ mod tests {
 
             assert_eq!(
                 git_remote
-                    .push_refspecs().expect("failed to get fetchspecs")
+                    .push_refspecs().expect("failed to get the push refspecs")
                     .iter()
                     .collect::<Vec<Option<&str>>>(),
                 vec![Some("refs/heads/*:refs/namespaces/hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try/refs/heads/*")],

--- a/librad/src/git/types/remote.rs
+++ b/librad/src/git/types/remote.rs
@@ -1,0 +1,120 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::path::{Path, PathBuf};
+
+use super::AsRefspec;
+
+pub struct Remote {
+    /// The file path to the git monorepo.
+    pub monorepo: PathBuf,
+    /// Name of the remote, e.g. `"rad"`, `"origin"`.
+    pub name: String,
+    /// The set of fetch specs to add upon creation.
+    pub fetch_spec: Box<dyn AsRefspec>,
+    /// The set of push specs to add upon creation.
+    pub push_specs: Vec<Box<dyn AsRefspec>>,
+}
+
+impl Remote {
+    /// Create a `"rad"` remote with no specs.
+    pub fn rad_remote(monorepo: impl AsRef<Path>, fetch_spec: Box<dyn AsRefspec>) -> Self {
+        Self {
+            monorepo: monorepo.as_ref().to_path_buf(),
+            name: "rad".to_string(),
+            fetch_spec,
+            push_specs: vec![],
+        }
+    }
+
+    /// Add a series of push specs to the remote.
+    pub fn add_pushes<I>(&mut self, specs: I)
+    where
+        I: Iterator<Item = Box<dyn AsRefspec>>,
+    {
+        for spec in specs {
+            self.push_specs.push(spec)
+        }
+    }
+
+    /// Create the [`git2::Remote`] and add the specs.
+    pub fn create<'a>(&self, repo: &'a git2::Repository) -> Result<git2::Remote<'a>, git2::Error> {
+        let _ = repo.remote_with_fetch(
+            &self.name,
+            &format!("file://{}", self.monorepo.display()),
+            &self.fetch_spec.as_refspec(),
+        )?;
+
+        for spec in self.push_specs.iter() {
+            repo.remote_add_push(&self.name, &spec.as_refspec())?;
+        }
+
+        // To ensure that the push spec is persisted we need to call `find_remote` here.
+        // Otherwise, `remote_add_push` doesn't affect the "loaded remotes".
+        repo.find_remote("rad")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io, marker::PhantomData};
+
+    use super::*;
+    use crate::{git::types::*, hash::Hash};
+    use librad_test::tempdir::WithTmpDir;
+
+    #[test]
+    fn can_create_remote() {
+        WithTmpDir::new::<_, io::Error>(|path| {
+            let repo = git2::Repository::init(path).expect("failed to init repo");
+
+            let id = Hash::hash(b"geez");
+            let heads: FlatRef<String, _> = FlatRef::heads(PhantomData, None);
+            let namespaced_heads = NamespacedRef::heads(id, None);
+
+            let fetch = heads
+                .clone()
+                .refspec(namespaced_heads.clone(), Force::True)
+                .into_dyn();
+            let push = namespaced_heads.refspec(heads, Force::False).into_dyn();
+
+
+            let mut remote = Remote::rad_remote(path, fetch);
+            remote.add_pushes(vec![push].into_iter());
+            let git_remote = remote.create(&repo).expect("failed to create the remote");
+
+
+            assert_eq!(
+                git_remote
+                    .fetch_refspecs().expect("failed to get fetchspecs")
+                    .iter()
+                    .collect::<Vec<Option<&str>>>(),
+                vec![Some("+refs/namespaces/hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try/refs/heads/*:refs/heads/*")],
+            );
+
+            assert_eq!(
+                git_remote
+                    .push_refspecs().expect("failed to get fetchspecs")
+                    .iter()
+                    .collect::<Vec<Option<&str>>>(),
+                vec![Some("refs/heads/*:refs/namespaces/hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try/refs/heads/*")],
+            );
+
+            Ok(())
+        }).unwrap();
+    }
+}


### PR DESCRIPTION
Working on top of #270 

Add a way of setting up a rad remote to the monorepo, setting it up with
any push specs specified and the single fetch spec.
This utilises a trait to turn Refspecs into Strings, so we can have
multiple in a Vec without worrying about their types lining up.