### PR TITLE
Bump quinn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,8 +1251,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 [[package]]
 name = "quinn"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88de58d76d8f82fb28e5c89302119c102bb5b9ce57b034186b559b63ba147a0f"
+source = "git+https://github.com/djc/quinn?rev=babb07b079e7e3ac4ff2fa7ef25b0dac5e934377#babb07b079e7e3ac4ff2fa7ef25b0dac5e934377"
 dependencies = [
  "bytes",
  "err-derive",
@@ -1269,8 +1268,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ea0a358c179c6b7af34805c675d1664a9c6a234a7acd7efdbb32d2f39d3d2a"
+source = "git+https://github.com/djc/quinn?rev=babb07b079e7e3ac4ff2fa7ef25b0dac5e934377#babb07b079e7e3ac4ff2fa7ef25b0dac5e934377"
 dependencies = [
  "bytes",
  "err-derive",
@@ -1510,10 +1508,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.17.0"
-source = "git+https://github.com/kim/rustls?rev=558405ac3c229947ca17b9285d60368ce67835ce#558405ac3c229947ca17b9285d60368ce67835ce"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac94b333ee2aac3284c5b8a1b7fb4dd11cba88c244e3fe33cdbd047af0eb693"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.12.3",
  "log",
  "ring",
  "sct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,2 @@
 [workspace]
 members = [ "librad", "librad-test", "git-helpers", "radicle-tracker" ]
-
-[patch.crates-io]
-# Ed25519 support for rustls
-#
-# This needs to be a "patch" so dependencies transitively using rustls also use
-# our version.
-#
-# See https://github.com/ctz/rustls/pull/340
-rustls = { git = "https://github.com/kim/rustls", rev = "558405ac3c229947ca17b9285d60368ce67835ce" }

--- a/deny.toml
+++ b/deny.toml
@@ -201,6 +201,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
+    "https://github.com/djc/quinn",
     "https://github.com/radicle-dev/radicle-keystore",
-    "https://github.com/kim/rustls"
 ]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -59,7 +59,8 @@ version = "0.4"
 features = ["std", "derive"]
 
 [dependencies.quinn]
-version = "0.6"
+git = "https://github.com/djc/quinn"
+rev = "babb07b079e7e3ac4ff2fa7ef25b0dac5e934377"
 default-features = false
 features = ["tls-rustls"]
 
@@ -67,8 +68,9 @@ features = ["tls-rustls"]
 git = "https://github.com/radicle-dev/radicle-keystore"
 rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
 
+# Note: this MUST always match the exact patch version `quinn` uses
 [dependencies.rustls]
-version = "0.17"
+version = "0.18.0"
 features = ["logging", "dangerous_configuration"]
 
 [dependencies.serde]


### PR DESCRIPTION
This gives us rustls 0.18 with ed25519 support, and removes the need for consumers to apply the cargo patch.

Supersedes #242 

---

Nb.: `upstream` **must** remove the `patch`, actually. I'm trying to get a `cargo update` against `upstream/proxy` going, but getting a lot of unrelated compile errors. /cc @xla 