### PR TITLE
Use a HashMap for shared Settings ref

### DIFF
--- a/librad/src/git/local/transport.rs
+++ b/librad/src/git/local/transport.rs
@@ -96,7 +96,7 @@ impl SmartSubtransport for LocalTransportFactory {
         let settings = &*self.settings.read().unwrap();
         let url = url.parse::<LocalUrl>().map_err(into_git_err)?;
 
-        match settings.get(url.peer_id()) {
+        match settings.get(&url.local_peer_id) {
             None => Err(git2::Error::from_str("local transport unconfigured")),
             Some(settings) => {
                 let mut transport = LocalTransport::new(settings.clone()).map_err(into_git_err)?;

--- a/librad/src/git/local/url.rs
+++ b/librad/src/git/local/url.rs
@@ -30,23 +30,15 @@ use crate::{
 
 #[derive(Clone)]
 pub struct LocalUrl {
-    repo: Hash,
-    peer_id: PeerId,
+    pub repo: Hash,
+    pub local_peer_id: PeerId,
 }
 
 impl LocalUrl {
-    pub fn repo(&self) -> &Hash {
-        &self.repo
-    }
-
-    pub fn peer_id(&self) -> &PeerId {
-        &self.peer_id
-    }
-
-    pub fn from_urn(urn: RadUrn, peer_id: PeerId) -> Self {
+    pub fn from_urn(urn: RadUrn, local_peer_id: PeerId) -> Self {
         Self {
             repo: urn.id,
-            peer_id,
+            local_peer_id,
         }
     }
 }
@@ -57,7 +49,7 @@ impl Display for LocalUrl {
             f,
             "{}://{}@{}.git",
             super::URL_SCHEME,
-            self.peer_id,
+            self.local_peer_id,
             self.repo
         )
     }
@@ -100,27 +92,14 @@ impl FromStr for LocalUrl {
             .trim_end_matches(".git")
             .parse()?;
 
-        let peer_id = url.username().parse()?;
+        let local_peer_id = url.username().parse()?;
 
-        Ok(Self { repo, peer_id })
+        Ok(Self {
+            repo,
+            local_peer_id,
+        })
     }
 }
-
-/*
-impl From<RadUrn> for LocalUrl {
-    fn from(urn: RadUrn) -> Self {
-        Self { repo: urn.id }
-    }
-}
-
-impl From<&RadUrn> for LocalUrl {
-    fn from(urn: &RadUrn) -> Self {
-        Self {
-            repo: urn.id.clone(),
-        }
-    }
-}
-*/
 
 impl Into<RadUrn> for LocalUrl {
     fn into(self) -> RadUrn {

--- a/librad/src/git/types/remote.rs
+++ b/librad/src/git/types/remote.rs
@@ -41,9 +41,11 @@ impl<Url> Remote<Url> {
     ///         types::{remote::Remote, FlatRef, Force, NamespacedRef},
     ///     },
     ///     hash::Hash,
+    ///     keys::SecretKey,
     ///     uri::{Path, Protocol, RadUrn},
     /// };
     ///
+    /// let peer_id = SecretKey::new().into();
     /// let id = Hash::hash(b"geez");
     ///
     /// // The RadUrn pointing some project
@@ -66,8 +68,8 @@ impl<Url> Remote<Url> {
     ///         .into_dyn();
     /// let push = monorepo_heads.refspec(working_copy_heads, Force::False).into_dyn();
     ///
-    /// // We point the remote to `LocalUrl` which will be of the form `rad://<id>.git`.
-    /// let url: LocalUrl = urn.into();
+    /// // We point the remote to `LocalUrl` which will be of the form `rad://<peer id>@<id>.git`.
+    /// let url = LocalUrl::from_urn(urn, peer_id);
     ///
     /// // Setup the `Remote`.
     /// let mut remote = Remote::rad_remote(url, fetch);

--- a/librad/src/signer.rs
+++ b/librad/src/signer.rs
@@ -21,6 +21,8 @@ use std::error::Error;
 
 use keystore::sign;
 
+use crate::{keys, peer::PeerId};
+
 /// A blanket trait over [`sign::Signer`] that can be shared safely among
 /// threads.
 pub trait Signer: sign::Signer + Send + Sync + dyn_clone::DynClone + 'static {}
@@ -85,6 +87,10 @@ impl BoxedSigner {
         BoxedSigner {
             signer: Box::new(signer),
         }
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        keys::PublicKey::from(self.signer.public_key()).into()
     }
 }
 

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -206,7 +206,10 @@ async fn fetches_on_gossip_notify() {
                 .unwrap()
             };
             let mut origin = repo
-                .remote("origin", &LocalUrl::from(radicle.urn()).to_string())
+                .remote(
+                    "origin",
+                    &LocalUrl::from_urn(radicle.urn(), peer1.peer_id().clone()).to_string(),
+                )
                 .unwrap();
             origin.push(&["refs/heads/master"], None).unwrap();
 


### PR DESCRIPTION
The local transport was using a global mutex on `Option<Settings>`. In
concurrent runs tests would end up overwriting each other's version of
this mutex and would end up in inconsistent states.

To solve this we need to separate test case's runs. Initially, we
attempted to use another lock `Mutex<()>` and have a bracketed runner,
which would lock, fill the `Option<Settings>`, run the action, and clean
up & release the lock. This still ended up in race conditions.

This solution uses a HashMap from PeerId to Settings. This works since
we expect individual runs to have separate PeerIds. The consequence of
this is that we need a way to look up the Settings when running the git
action. We encode this in the LocalUrl, so we add the PeerId as the
username of the Url that's passed.