### PR TITLE
Bump keystore dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "radicle-keystore"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-keystore?rev=27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6#27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
+source = "git+https://github.com/radicle-dev/radicle-keystore?rev=3377e666bde3130a06dd19343e7df2eaa774176a#3377e666bde3130a06dd19343e7df2eaa774176a"
 dependencies = [
  "async-trait",
  "futures",

--- a/git-helpers/Cargo.toml
+++ b/git-helpers/Cargo.toml
@@ -14,7 +14,7 @@ path = "../librad"
 
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-keystore"
-rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
+rev = "3377e666bde3130a06dd19343e7df2eaa774176a"
 
 [dependencies.git2]
 version = "0"

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -66,7 +66,7 @@ features = ["tls-rustls"]
 
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-keystore"
-rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
+rev = "3377e666bde3130a06dd19343e7df2eaa774176a"
 
 # Note: this MUST always match the exact patch version `quinn` uses
 [dependencies.rustls]


### PR DESCRIPTION
Catch up with radicle-dev/radicle-keystore#6.