### PR TITLE
Fix all_metadata returning remote entities

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -235,7 +235,7 @@ impl<S: Clone> Storage<S> {
     pub fn all_metadata<'a>(
         &'a self,
     ) -> Result<impl Iterator<Item = Result<GenericDraftEntity, Error>> + 'a, Error> {
-        let iter = References::from_globs(&self.backend, &["refs/namespaces/*/rad/id"])?;
+        let iter = References::from_globs(&self.backend, &["refs/namespaces/*/refs/rad/id"])?;
 
         Ok(iter.map(move |reference| self.metadata_from_reference(reference?)))
     }


### PR DESCRIPTION
Directly fixes https://github.com/radicle-dev/radicle-link/issues/250, may be a part of the wider discussion in https://github.com/radicle-dev/radicle-link/issues/266.

Diving into `libgit2` codebase sure was an interesting experience :laughing: 