### PR TITLE
Lowercase all error messages

### DIFF
--- a/librad/src/git/ext/blob.rs
+++ b/librad/src/git/ext/blob.rs
@@ -35,13 +35,13 @@ pub enum Error {
 
 #[derive(Debug, Error)]
 pub enum NotFound {
-    #[error("Blob with path {0} not found")]
+    #[error("blob with path {0} not found")]
     NoSuchBlob(String),
 
-    #[error("Branch {0} not found")]
+    #[error("branch {0} not found")]
     NoSuchBranch(String),
 
-    #[error("The supplied git2::Reference does not have a target")]
+    #[error("the supplied git2::Reference does not have a target")]
     NoRefTarget,
 }
 

--- a/librad/src/git/ext/oid.rs
+++ b/librad/src/git/ext/oid.rs
@@ -104,7 +104,7 @@ impl FromStr for Oid {
 
 #[derive(Debug, Error)]
 pub enum FromMultihashError {
-    #[error("Invalid hash algorithm: expected Sha1, got {actual:?}")]
+    #[error("invalid hash algorithm: expected Sha1, got {actual:?}")]
     AlgorithmMismatch { actual: multihash::Code },
 
     #[error(transparent)]

--- a/librad/src/git/header.rs
+++ b/librad/src/git/header.rs
@@ -69,25 +69,25 @@ impl Display for Header {
 
 #[derive(Debug, Error)]
 pub enum ParseError {
-    #[error("Missing service")]
+    #[error("missing service")]
     MissingService,
 
-    #[error("Invalid service: {0}. Must be one of `git-upload-pack` or `git-receive-pack`")]
+    #[error("invalid service: {0}. Must be one of `git-upload-pack` or `git-receive-pack`")]
     InvalidService(String),
 
-    #[error("Missing repo")]
+    #[error("missing repo")]
     MissingRepo,
 
-    #[error("Invalid repo")]
+    #[error("invalid repo")]
     InvalidRepo(#[from] uri::rad_urn::ParseError),
 
-    #[error("Missing host")]
+    #[error("missing host")]
     MissingHost,
 
-    #[error("Malformed host. Must be a PeerId")]
+    #[error("malformed host. Must be a PeerId")]
     MalformedHost(#[from] peer::conversion::Error),
 
-    #[error("Invalid mode: `{0}`. Must be `ls`, or absent")]
+    #[error("invalid mode: `{0}`. Must be `ls`, or absent")]
     InvalidMode(String),
 }
 

--- a/librad/src/git/local/transport.rs
+++ b/librad/src/git/local/transport.rs
@@ -122,13 +122,13 @@ pub enum Mode {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("No such URN: {0}")]
+    #[error("no such URN: {0}")]
     NoSuchUrn(RadUrn),
 
     #[error(transparent)]
     Storage(#[from] storage::Error),
 
-    #[error("Child exited unsuccessfully")]
+    #[error("child exited unsuccessfully")]
     Child(ExitStatus),
 
     #[error(transparent)]

--- a/librad/src/git/local/url.rs
+++ b/librad/src/git/local/url.rs
@@ -58,13 +58,13 @@ impl Display for LocalUrl {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ParseError {
-    #[error("Invalid scheme: {0}")]
+    #[error("invalid scheme: {0}")]
     InvalidScheme(String),
 
-    #[error("Cannot-be-a-base URL")]
+    #[error("cannot-be-a-base URL")]
     CannotBeABase,
 
-    #[error("Malformed URL")]
+    #[error("malformed URL")]
     Url(#[from] url::ParseError),
 
     #[error(transparent)]

--- a/librad/src/git/p2p/url.rs
+++ b/librad/src/git/p2p/url.rs
@@ -86,19 +86,19 @@ impl Display for GitUrl {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ParseError {
-    #[error("Invalid scheme: {0}")]
+    #[error("invalid scheme: {0}")]
     InvalidScheme(String),
 
-    #[error("Missing repo path")]
+    #[error("missing repo path")]
     MissingRepo,
 
-    #[error("Cannot-be-a-base URL")]
+    #[error("cannot-be-a-base URL")]
     CannotBeABase,
 
     #[error(transparent)]
     PeerId(#[from] peer::conversion::Error),
 
-    #[error("Malformed URL")]
+    #[error("malformed URL")]
     Url(#[from] url::ParseError),
 
     #[error(transparent)]

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -151,7 +151,7 @@ pub mod signed {
 
     #[derive(Debug, Error)]
     pub enum Error {
-        #[error("Invalid signature")]
+        #[error("invalid signature")]
         InvalidSignature(Refs),
 
         #[error(transparent)]

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -80,33 +80,33 @@ use fetch::Fetcher;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Already exists: {0}")]
+    #[error("already exists: {0}")]
     AlreadyExists(RadUrn),
 
-    #[error("Not found: {0}")]
+    #[error("not found: {0}")]
     NoSuchUrn(RadUrn),
 
     #[error(
-        "Identity root hash doesn't match resolved URL. Expected {expected}, actual: {actual}"
+        "identity root hash doesn't match resolved URL. Expected {expected}, actual: {actual}"
     )]
     RootHashMismatch { expected: Hash, actual: Hash },
 
-    #[error("Metadata is not signed")]
+    #[error("metadata is not signed")]
     UnsignedMetadata,
 
-    #[error("Signer key does not match key used at initialisation")]
+    #[error("signer key does not match key used at initialisation")]
     SignerKeyMismatch,
 
-    #[error("Can't refer to the local key for this operation")]
+    #[error("can't refer to the local key for this operation")]
     SelfReferential,
 
-    #[error("Metadata must be signed by local key")]
+    #[error("metadata must be signed by local key")]
     NotSignedBySelf,
 
-    #[error("Local key certifier not found: {0}")]
+    #[error("local key certifier not found: {0}")]
     NoSelf(NamespacedRef<Single>),
 
-    #[error("Missing certifier {certifier} of {urn}")]
+    #[error("missing certifier {certifier} of {urn}")]
     MissingCertifier { certifier: RadUrn, urn: RadUrn },
 
     #[error(transparent)]

--- a/librad/src/git/storage/config.rs
+++ b/librad/src/git/storage/config.rs
@@ -42,13 +42,13 @@ const CONFIG_RAD_PEER_ID: &str = "rad.peerid";
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Supplied user entity is not signed by the local key")]
+    #[error("supplied user entity is not signed by the local key")]
     NotSignedBySelf,
 
-    #[error("Entity must be  signed with an owned key")]
+    #[error("entity must be  signed with an owned key")]
     OwnedKeyRequired,
 
-    #[error("Configuration key {config_key} is not set")]
+    #[error("configuration key {config_key} is not set")]
     Unset { config_key: &'static str },
 
     #[error(transparent)]

--- a/librad/src/git/trailer.rs
+++ b/librad/src/git/trailer.rs
@@ -17,11 +17,11 @@
 
 #[derive(Debug, Clone, Eq, PartialEq, thiserror::Error)]
 pub enum Error<'a> {
-    #[error("The trailers paragraph is missing in the given message")]
+    #[error("the trailers paragraph is missing in the given message")]
     MissingParagraph,
 
     #[error(
-        "One or more trailers are not in the parseable format <token><separator><value>: '{0}'"
+        "one or more trailers are not in the parseable format <token><separator><value>: '{0}'"
     )]
     Unparsable(&'a str),
 }

--- a/librad/src/hash.rs
+++ b/librad/src/hash.rs
@@ -33,7 +33,7 @@ pub trait Hasher: PartialEq + Eq {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Error)]
-#[error("Invalid hash algorithm, expected {expected:?}, actual {actual:?}")]
+#[error("invalid hash algorithm, expected {expected:?}, actual {actual:?}")]
 pub struct AlgorithmMismatch {
     expected: multihash::Code,
     actual: multihash::Code,
@@ -339,7 +339,7 @@ mod tests {
         // Sorry, future maintainer!
         let expect_err = de.unwrap_err().to_string();
         assert!(
-            expect_err.starts_with("Invalid hash algorithm, expected Blake2b256, actual Sha3_256")
+            expect_err.starts_with("invalid hash algorithm, expected Blake2b256, actual Sha3_256")
         )
     }
 

--- a/librad/src/identities/payload.rs
+++ b/librad/src/identities/payload.rs
@@ -176,7 +176,7 @@ pub struct Payload<T> {
 
 #[derive(Debug, Error)]
 pub enum ExtError {
-    #[error("Extension namespace can not be the subject namespace")]
+    #[error("extension namespace can not be the subject namespace")]
     ExtensionIsSubject,
 
     #[error(transparent)]

--- a/librad/src/identities/urn.rs
+++ b/librad/src/identities/urn.rs
@@ -71,16 +71,16 @@ where
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ParseError<E: std::error::Error + 'static> {
-    #[error("Missing {0}")]
+    #[error("missing {0}")]
     Missing(&'static str),
 
-    #[error("Invalid namespace identifier: {0}")]
+    #[error("invalid namespace identifier: {0}")]
     InvalidNID(String),
 
-    #[error("Invalid protocol: {0}")]
+    #[error("invalid protocol: {0}")]
     InvalidProto(String),
 
-    #[error("Invalid Id")]
+    #[error("invalid Id")]
     InvalidId(#[source] E),
 
     #[error(transparent)]

--- a/librad/src/keys.rs
+++ b/librad/src/keys.rs
@@ -158,7 +158,7 @@ impl AsRef<[u8]> for SecretKey {
 
 #[derive(Debug, Error)]
 pub enum IntoSecretKeyError {
-    #[error("Invalid length")]
+    #[error("invalid length")]
     InvalidSliceLength,
 }
 

--- a/librad/src/meta/common.rs
+++ b/librad/src/meta/common.rs
@@ -85,13 +85,13 @@ pub mod email {
 
     #[derive(Debug, Error)]
     pub enum Error {
-        #[error("Email address exceeds 254 character limit")]
+        #[error("email address exceeds 254 character limit")]
         AddrTooLong,
 
-        #[error("Invalid local-part of email address")]
+        #[error("invalid local-part of email address")]
         InvalidLocalPart,
 
-        #[error("Invalid domain of email address")]
+        #[error("invalid domain of email address")]
         InvalidDomain,
     }
 }
@@ -171,7 +171,7 @@ pub mod url {
     use thiserror::Error;
 
     #[derive(Debug, Error)]
-    #[error("Error parsing Url: {0}")]
+    #[error("error parsing Url: {0}")]
     pub struct ParseError(#[source] the_url::ParseError);
 
     impl ParseError {

--- a/librad/src/meta/entity.rs
+++ b/librad/src/meta/entity.rs
@@ -46,61 +46,61 @@ use data::{EntityData, EntityInfo, EntityInfoExt, EntityKind};
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Serialization failed ({0})")]
+    #[error("serialization failed ({0})")]
     SerializationFailed(String),
 
-    #[error("Invalid UTF8 ({0})")]
+    #[error("invalid UTF8 ({0})")]
     InvalidUtf8(String),
 
-    #[error("Invalid buffer encoding ({0})")]
+    #[error("invalid buffer encoding ({0})")]
     InvalidBufferEncoding(String),
 
-    #[error("Invalid hash ({0})")]
+    #[error("invalid hash ({0})")]
     InvalidHash(String),
 
-    #[error("Wrong hash (claimed {claimed:?}, actual {actual:?})")]
+    #[error("wrong hash (claimed {claimed:?}, actual {actual:?})")]
     WrongHash { claimed: String, actual: String },
 
-    #[error("Hash parse error ({0})")]
+    #[error("hash parse error ({0})")]
     HashParseError(#[from] HashParseError),
 
-    #[error("Invalid root hash")]
+    #[error("invalid root hash")]
     InvalidRootHash,
 
-    #[error("Missing root hash")]
+    #[error("missing root hash")]
     MissingRootHash,
 
-    #[error("Invalid URI ({0})")]
+    #[error("invalid URI ({0})")]
     InvalidUri(String),
 
-    #[error("Signature already present ({0})")]
+    #[error("signature already present ({0})")]
     SignatureAlreadyPresent(PublicKey),
 
-    #[error("Invalid data ({0})")]
+    #[error("invalid data ({0})")]
     InvalidData(String),
 
-    #[error("Builder error ({0})")]
+    #[error("builder error ({0})")]
     BuilderError(&'static str),
 
-    #[error("Key not present ({0})")]
+    #[error("key not present ({0})")]
     KeyNotPresent(PublicKey),
 
-    #[error("User key not present (uri {0}, key {1})")]
+    #[error("user key not present (uri {0}, key {1})")]
     UserKeyNotPresent(RadUrn, PublicKey),
 
-    #[error("Signature missing")]
+    #[error("signature missing")]
     SignatureMissing,
 
-    #[error("Signature decoding failed")]
+    #[error("signature decoding failed")]
     SignatureDecodingFailed,
 
-    #[error("Signature verification failed")]
+    #[error("signature verification failed")]
     SignatureVerificationFailed,
 
-    #[error("Resolution failed ({0})")]
+    #[error("resolution failed ({0})")]
     ResolutionFailed(RadUrn),
 
-    #[error("Resolution at revision failed ({0}, revision {1})")]
+    #[error("resolution at revision failed ({0}, revision {1})")]
     RevisionResolutionFailed(RadUrn, u64),
 
     #[error(transparent)]
@@ -109,31 +109,31 @@ pub enum Error {
 
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum UpdateVerificationError {
-    #[error("Non monotonic revision")]
+    #[error("non monotonic revision")]
     NonMonotonicRevision,
 
-    #[error("Wrong parent hash")]
+    #[error("wrong parent hash")]
     WrongParentHash,
 
-    #[error("Wrong root hash")]
+    #[error("wrong root hash")]
     WrongRootHash,
 
-    #[error("Update without previous quorum")]
+    #[error("update without previous quorum")]
     NoPreviousQuorum,
 
-    #[error("Update without current quorum")]
+    #[error("update without current quorum")]
     NoCurrentQuorum,
 }
 
 #[derive(Debug, Error)]
 pub enum HistoryVerificationError {
-    #[error("Empty history")]
+    #[error("empty history")]
     EmptyHistory,
 
-    #[error("Error at revsion (rev {revision:?}, err {error:?})")]
+    #[error("error at revsion (rev {revision:?}, err {error:?})")]
     ErrorAtRevision { revision: u64, error: Error },
 
-    #[error("Update error (rev {revision:?}, err {error:?})")]
+    #[error("update error (rev {revision:?}, err {error:?})")]
     UpdateError {
         revision: u64,
         error: UpdateVerificationError,

--- a/librad/src/net/gossip/error.rs
+++ b/librad/src/net/gossip/error.rs
@@ -23,10 +23,10 @@ use crate::net::codec::CborCodecError;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Connection to self")]
+    #[error("connection to self")]
     SelfConnection,
 
-    #[error("Too many storage errors")]
+    #[error("too many storage errors")]
     StorageErrorRateLimitExceeded,
 
     #[error(transparent)]

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -57,7 +57,7 @@ pub use types::*;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum GitFetchError {
-    #[error("Already have {0}")]
+    #[error("already have {0}")]
     KnownObject(git2::Oid),
 
     #[error(transparent)]
@@ -67,7 +67,7 @@ pub enum GitFetchError {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum BootstrapError {
-    #[error("Failed to bind to {addr}")]
+    #[error("failed to bind to {addr}")]
     Bind {
         addr: SocketAddr,
         source: quic::Error,

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -83,7 +83,7 @@ enum Run<'a, A> {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("No connection to {0}")]
+    #[error("no connection to {0}")]
     NoConnection(PeerId),
 
     #[error(transparent)]
@@ -92,10 +92,10 @@ pub enum Error {
     #[error(transparent)]
     Cbor(#[from] CborCodecError),
 
-    #[error("Error handling gossip upgrade")]
+    #[error("error handling gossip upgrade")]
     Gossip(#[from] gossip::error::Error),
 
-    #[error("Error handling git upgrade")]
+    #[error("error handling git upgrade")]
     Git(#[source] io::Error),
 
     #[error(transparent)]

--- a/librad/src/net/quic.rs
+++ b/librad/src/net/quic.rs
@@ -39,7 +39,7 @@ use crate::{
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Remote PeerId could not be determined")]
+    #[error("remote PeerId could not be determined")]
     RemoteIdUnavailable,
 
     #[error(transparent)]

--- a/librad/src/net/upgrade.rs
+++ b/librad/src/net/upgrade.rs
@@ -85,19 +85,19 @@ pub enum UpgradeError {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Protocol mismatch: expected {expected:?}, got {actual:?}")]
+    #[error("protocol mismatch: expected {expected:?}, got {actual:?}")]
     ProtocolMismatch {
         expected: UpgradeRequest,
         actual: UpgradeRequest,
     },
 
-    #[error("Remote peer denied upgrade: {0:?}")]
+    #[error("remote peer denied upgrade: {0:?}")]
     ErrorResponse(UpgradeError),
 
-    #[error("Local peer denied upgrade: {0:?}")]
+    #[error("local peer denied upgrade: {0:?}")]
     Denied(UpgradeRequest),
 
-    #[error("No response from remote peer")]
+    #[error("no response from remote peer")]
     NoResponse,
 
     #[error(transparent)]

--- a/librad/src/peer.rs
+++ b/librad/src/peer.rs
@@ -136,16 +136,16 @@ pub mod conversion {
 
     #[derive(Debug, Error)]
     pub enum Error {
-        #[error("Unexpected input length: {0}")]
+        #[error("unexpected input length: {0}")]
         UnexpectedInputLength(usize),
 
-        #[error("Unknown version: {0}")]
+        #[error("unknown version: {0}")]
         UnknownVersion(u8),
 
-        #[error("Invalid public key")]
+        #[error("invalid public key")]
         InvalidPublicKey,
 
-        #[error("Decode error: {0}")]
+        #[error("decode error: {0}")]
         DecodeError(#[from] multibase::Error),
     }
 }

--- a/librad/src/uri.rs
+++ b/librad/src/uri.rs
@@ -86,35 +86,35 @@ impl Protocol {
 pub mod path {
     use super::*;
     #[derive(Debug, Error, PartialEq)]
-    #[error("Malformed path: {reasons:?}")]
+    #[error("malformed path: {reasons:?}")]
     pub struct ParseError {
         pub reasons: Vec<&'static ViolatesRefFormat>,
     }
 
     #[derive(Debug, Error, PartialEq)]
     pub enum ViolatesRefFormat {
-        #[error("Ends with `.lock`")]
+        #[error("ends with `.lock`")]
         EndsWithDotLock,
 
-        #[error("Starts with a dot (`.`)")]
+        #[error("starts with a dot (`.`)")]
         StartsWithDot,
 
-        #[error("Contains consecutive dots (`..`)")]
+        #[error("contains consecutive dots (`..`)")]
         ConsecutiveDots,
 
-        #[error("Contains control characters")]
+        #[error("contains control characters")]
         ControlCharacters,
 
-        #[error("Contains reserved characters (`~`, `^`, `:`, `?`, `*`, `[`, `\\`)")]
+        #[error("contains reserved characters (`~`, `^`, `:`, `?`, `*`, `[`, `\\`)")]
         ReservedCharacters,
 
-        #[error("Contains `@{{`")] // nb. double-brace is to escape format string
+        #[error("contains `@{{`")] // nb. double-brace is to escape format string
         AtOpenBrace,
 
-        #[error("Contains consecutive slashes (`//`)")]
+        #[error("contains consecutive slashes (`//`)")]
         ConsecutiveSlashes,
 
-        #[error("Consists of only the `@` character")]
+        #[error("consists of only the `@` character")]
         OnlyAt,
     }
 }
@@ -334,25 +334,25 @@ pub mod rad_urn {
     #[derive(Debug, Error)]
     #[non_exhaustive]
     pub enum ParseError {
-        #[error("Missing {0}")]
+        #[error("missing {0}")]
         Missing(&'static str),
 
-        #[error("Invalid namespace identifier: {0}")]
+        #[error("invalid namespace identifier: {0}")]
         InvalidNID(String),
 
-        #[error("Invalid protocol: {0}")]
+        #[error("invalid protocol: {0}")]
         InvalidProto(String),
 
-        #[error("Malformed path")]
+        #[error("malformed path")]
         Path(#[from] path::ParseError),
 
-        #[error("Must be UTF8")]
+        #[error("must be UTF8")]
         Utf8(#[from] Utf8Error),
 
-        #[error("Invalid encoding")]
+        #[error("invalid encoding")]
         Encoding(#[from] multibase::Error),
 
-        #[error("Invalid hash")]
+        #[error("invalid hash")]
         Hash(#[from] hash::ParseError),
     }
 }
@@ -465,31 +465,31 @@ pub mod rad_url {
     #[derive(Debug, Error)]
     #[non_exhaustive]
     pub enum ParseError {
-        #[error("Missing {0}")]
+        #[error("missing {0}")]
         Missing(&'static str),
 
-        #[error("Invalid scheme: {0}")]
+        #[error("invalid scheme: {0}")]
         InvalidScheme(String),
 
-        #[error("Invalid protocol: {0}")]
+        #[error("invalid protocol: {0}")]
         InvalidProto(String),
 
-        #[error("Invalid PeerId")]
+        #[error("invalid PeerId")]
         PeerId(#[from] peer::conversion::Error),
 
-        #[error("Malformed path")]
+        #[error("malformed path")]
         Path(#[from] path::ParseError),
 
-        #[error("Must be UTF8")]
+        #[error("must be UTF8")]
         Utf8(#[from] Utf8Error),
 
-        #[error("Invalid encoding")]
+        #[error("invalid encoding")]
         Encoding(#[from] multibase::Error),
 
-        #[error("Invalid hash")]
+        #[error("invalid hash")]
         Hash(#[from] hash::ParseError),
 
-        #[error("Malformed URL")]
+        #[error("malformed URL")]
         MalformedUrl(#[from] url::ParseError),
     }
 }

--- a/radicle-tracker/src/thread.rs
+++ b/radicle-tracker/src/thread.rs
@@ -77,14 +77,14 @@ impl<A> DataState<A> {
 pub enum Error {
     /// An attempt was made to delete the root of a thread, but the root is
     /// immutable.
-    #[error("Cannot delete the main item of the thread")]
+    #[error("cannot delete the main item of the thread")]
     DeleteRoot,
     /// An attempt was made to move to the previous item in the main thread, but
     /// the pointer is already at the root item.
-    #[error("Tried to move to previous item in the main thread, but we are at the first")]
+    #[error("tried to move to previous item in the main thread, but we are at the first")]
     PreviousOnRoot,
     ///
-    #[error("An attempt was made to move to {attempt}, but this is out of bounds where the bounds are {main:?}, {reply:?}.")]
+    #[error("an attempt was made to move to {attempt}, but this is out of bounds where the bounds are {main:?}, {reply:?}.")]
     OutOfBounds {
         ///
         attempt: Finger,


### PR DESCRIPTION
Closes #273 

To follow the Radicle convention regarding error messages [0]. Here we
only concern with ensuring the error messages start with a lowercase
character.

[0]: https://github.com/radicle-dev/radicle-decisions/pull/3