### PR TITLE
Include Utilities

### DIFF
--- a/librad/src/git.rs
+++ b/librad/src/git.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 pub mod ext;
+pub mod include;
 pub mod local;
 pub mod p2p;
 pub mod refs;

--- a/librad/src/git/include.rs
+++ b/librad/src/git/include.rs
@@ -1,0 +1,228 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    convert::TryFrom,
+    marker::PhantomData,
+    path::{self, PathBuf},
+};
+
+use git2::{Config, ConfigLevel};
+
+use crate::{
+    git::{
+        local::url::LocalUrl,
+        types::{remote::Remote, AsRefspec, FlatRef, Force},
+    },
+    meta::user::User,
+    peer::PeerId,
+};
+
+/// An `Include` is a representation of an include file which we want to
+/// generate for working copies.
+///
+/// When generated it will include a list of remotes of the form:
+/// ```text
+/// [remote "<handle>@<peer_id>"]
+///     url = rad://<local_peer_id>@<repo>.git
+///     fetch = refs/remotes/<peer_id>/heads/*:refs/remotes/<handle>@<peer_id>/*
+/// ```
+///
+/// This file can then be added to the working copy's `config` file as:
+/// ```text
+/// [include]
+///     path = <path>/<repo>.inc
+/// ```
+pub struct Include<Path> {
+    /// The list of remotes that will be generated for this include file.
+    pub remotes: Vec<Remote<LocalUrl>>,
+    /// The directory path where the include file will be stored.
+    pub path: Path,
+    /// The namespace and `PeerId` this include file is interested in. In other
+    /// words, the generated include file should be for some project that
+    /// lives under this namespace, of this URL, in the monorepo.
+    ///
+    /// Note that the final file name will be named after
+    /// the namespace.
+    pub local_url: LocalUrl,
+}
+
+impl<Path> Include<Path> {
+    /// Create a new `Include` with an empty set of remotes.
+    pub fn new(path: Path, local_url: LocalUrl) -> Self {
+        Include {
+            remotes: vec![],
+            path,
+            local_url,
+        }
+    }
+
+    /// Create the include file by creating a [`Config`].
+    pub fn create(self) -> Result<Config, git2::Error>
+    where
+        Path: AsRef<path::Path>,
+    {
+        git2::Config::try_from(self)
+    }
+
+    /// The full file path where this include file will be created.
+    pub fn file_path(&self) -> PathBuf
+    where
+        Path: AsRef<path::Path>,
+    {
+        self.path
+            .as_ref()
+            .to_path_buf()
+            .join(self.local_url.repo.to_string())
+            .with_extension("inc")
+    }
+
+    /// Generate an include file by giving it a `RadUrn` for a project and the
+    /// tracked `User`/`PeerId` pairs for that project.
+    ///
+    /// The tracked users are expected to be retrieved by talking to the
+    /// [`crate::git::storage::Storage`].
+    pub fn from_tracked_users<S>(
+        path: Path,
+        local_url: LocalUrl,
+        tracked: impl Iterator<Item = (User<S>, PeerId)>,
+    ) -> Self {
+        let remotes = tracked
+            .map(|(user, peer)| Remote::new(local_url.clone(), format!("{}@{}", user.name(), peer)))
+            .collect();
+        Self {
+            remotes,
+            path,
+            local_url,
+        }
+    }
+}
+
+fn remote_prefix(remote: &Remote<LocalUrl>) -> String {
+    format!("remote.{}", remote.name)
+}
+
+fn url_entry(remote: &Remote<LocalUrl>) -> (String, &LocalUrl) {
+    let key = remote_prefix(&remote);
+    (format!("{}.url", key), &remote.url)
+}
+
+fn fetch_entry(remote: &Remote<LocalUrl>) -> (String, String) {
+    let key = remote_prefix(&remote);
+    (
+        format!("{}.fetch", key),
+        match &remote.fetch_spec {
+            Some(spec) => spec.as_refspec(),
+            None => {
+                let peer_id = &remote.url.local_peer_id;
+                let heads: FlatRef<PeerId, _> = FlatRef::heads(PhantomData, Some(peer_id.clone()));
+                let heads = heads.with_name("heads/*");
+                let remotes: FlatRef<String, _> =
+                    FlatRef::heads(PhantomData, Some(remote.name.clone()));
+
+                remotes.refspec(heads, Force::True).as_refspec()
+            },
+        },
+    )
+}
+
+impl<Path> TryFrom<Include<Path>> for Config
+where
+    Path: AsRef<path::Path>,
+{
+    type Error = git2::Error;
+
+    fn try_from(include: Include<Path>) -> Result<Self, Self::Error> {
+        let mut config = Self::new()?;
+        let file = include.file_path();
+        config.add_file(&file, ConfigLevel::Local, false)?;
+
+        for remote in include.remotes {
+            let (key, url) = url_entry(&remote);
+            config.set_str(&key, &url.to_string())?;
+
+            let (key, fetch) = fetch_entry(&remote);
+            config.set_str(&key, &fetch)?;
+        }
+
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{io, path};
+
+    use git2::Config;
+
+    use super::*;
+    use crate::{git::local::url::LocalUrl, hash::Hash, keys::SecretKey, peer::PeerId};
+
+    use librad_test::tempdir::WithTmpDir;
+
+    type TempInclude = WithTmpDir<Config>;
+
+    #[derive(Debug, thiserror::Error)]
+    enum Error {
+        #[error(transparent)]
+        Io(#[from] io::Error),
+        #[error(transparent)]
+        Git(#[from] git2::Error),
+    }
+
+    fn include<F>(constructor: F) -> Result<TempInclude, Error>
+    where
+        F: FnOnce(&path::Path) -> Include<&path::Path>,
+    {
+        WithTmpDir::new::<_, Error>(|path| {
+            let include = constructor(path);
+            let config = Config::try_from(include)?;
+            Ok(config)
+        })
+    }
+
+    #[test]
+    fn can_create_trivial_include() -> Result<(), Error> {
+        let key = SecretKey::new();
+        let peer_id = PeerId::from(key);
+        let repo = Hash::hash(b"meow-meow");
+        let url = LocalUrl {
+            repo,
+            local_peer_id: peer_id.clone(),
+        };
+        let name = format!("lyla@{}", peer_id);
+        let remote = Remote::new(url.clone(), name.clone());
+
+        let config = include(|path| Include {
+            path,
+            remotes: vec![remote],
+            local_url: url.clone(),
+        })?;
+
+        let remote = Remote::new(url, name);
+        let (key, url) = url_entry(&remote);
+        assert_eq!(
+            config.get_entry(&key)?.value(),
+            Some(url.to_string().as_str())
+        );
+
+        let (key, fetch) = fetch_entry(&remote);
+        assert_eq!(config.get_entry(&key)?.value(), Some(fetch.as_str()));
+
+        Ok(())
+    }
+}

--- a/librad/src/git/local/transport.rs
+++ b/librad/src/git/local/transport.rs
@@ -319,7 +319,7 @@ impl LocalTransport {
                 // Fetching remotes is ok, pushing is not
                 self.visible_remotes(&urn)?.for_each(|remote_ref| {
                     git.arg("-c")
-                        .arg(format!("uploadpack.hiderefs=!^{}", remote_ref));
+                        .arg(format!("uploadpack.hiderefs=!{}", remote_ref));
                 });
                 git.args(&["upload-pack", "--strict", "--timeout=5"]);
             },
@@ -375,7 +375,7 @@ impl LocalTransport {
     }
 
     fn visible_remotes(&self, urn: &RadUrn) -> Result<impl Iterator<Item = String>, Error> {
-        const GLOBS: &[&str] = &["remotes/**/heads/*", "remotes/**/tags/*"];
+        const GLOBS: &[&str] = &["refs/remotes/*/heads/*", "refs/remotes/*/tags/*"];
 
         self.storage
             .lock()

--- a/librad/src/git/types/remote.rs
+++ b/librad/src/git/types/remote.rs
@@ -88,6 +88,17 @@ impl<Url> Remote<Url> {
         }
     }
 
+    /// Create a new `Remote` with the given `url` and `name`, while making the
+    /// `fetch_spec` and `push_specs` empty.
+    pub fn new(url: Url, name: String) -> Self {
+        Self {
+            url,
+            name,
+            fetch_spec: None,
+            push_specs: vec![],
+        }
+    }
+
     /// Add a series of push specs to the remote.
     pub fn add_pushes<I>(&mut self, specs: I)
     where

--- a/librad/tests/working_copy.rs
+++ b/librad/tests/working_copy.rs
@@ -1,0 +1,258 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![feature(async_closure)]
+
+use std::{convert::TryFrom, marker::PhantomData, time::Duration};
+
+use futures::{
+    future,
+    stream::{Stream, StreamExt},
+};
+
+use tempfile::tempdir;
+
+use librad::{
+    git::{
+        include::Include,
+        local::{transport, url::LocalUrl},
+        types::{remote::Remote, FlatRef, Force, NamespacedRef},
+    },
+    meta::{entity::Signatory, project::ProjectInfo},
+    net::peer::{FetchInfo, Gossip, PeerEvent, Rev},
+    peer::PeerId,
+    signer::SomeSigner,
+    uri::{self, RadUrn},
+};
+
+use librad_test::{
+    logging,
+    rad::{
+        entity::{Alice, Radicle},
+        testnet,
+    },
+};
+
+/// This integration test is to ensure that we can setup a working copy that can
+/// fetch changes. The breakdown of the test into substeps is:
+///
+/// 1. Two peers are setup: peer1 and peer2.
+/// 2. peer1 creates a project in their monorepo
+/// 3. peer2 clones it
+/// 4. peer1 creates a working copy and commits changes to it
+/// 5. peer2 receives the changes via an announcement
+/// 6. peer2 decides to create a working copy
+/// 7. peer2 creates an include file, based of the tracked users of the project
+/// i.e. peer1 8. peer2 includes this file in their working copy's config
+/// 9. peer2 fetches in the working copy and sees the commit
+#[tokio::test]
+async fn can_fetch() {
+    logging::init();
+
+    const NUM_PEERS: usize = 2;
+
+    let peers = testnet::setup(NUM_PEERS).await.unwrap();
+    testnet::run_on_testnet(peers, NUM_PEERS, async move |mut apis| {
+        let (peer1, peer1_key) = apis.pop().unwrap();
+        let (peer2, peer2_key) = apis.pop().unwrap();
+        let peer2_events = peer2.subscribe().await;
+
+        let global_settings = transport::Settings {
+            paths: peer1.paths().clone(),
+            signer: SomeSigner {
+                signer: peer1_key.clone(),
+            }
+            .into(),
+        };
+        librad::git::local::transport::register(global_settings);
+
+        let global_settings = transport::Settings {
+            paths: peer2.paths().clone(),
+            signer: SomeSigner { signer: peer2_key }.into(),
+        };
+        librad::git::local::transport::register(global_settings);
+
+        let mut alice = Alice::new(peer1_key.public());
+        let mut radicle = Radicle::new(&alice);
+        {
+            let resolves_to_alice = alice.clone();
+            alice
+                .sign(&peer1_key, &Signatory::OwnedKey, &resolves_to_alice)
+                .unwrap();
+            radicle
+                .sign(
+                    &peer1_key,
+                    &Signatory::User(alice.urn()),
+                    &resolves_to_alice,
+                )
+                .unwrap();
+            peer1.storage().create_repo(&alice).unwrap();
+            peer1.storage().create_repo(&radicle).unwrap();
+        }
+
+        let git2 = peer2.storage().reopen().unwrap();
+        let url = radicle.urn().into_rad_url(peer1.peer_id().clone());
+        let urn = radicle.urn();
+        let tracked_users = tokio::task::spawn_blocking(move || {
+            git2.clone_repo::<ProjectInfo, _>(url, None).unwrap();
+
+            git2.tracked(&urn)
+                .unwrap()
+                .map(|peer| {
+                    git2.get_rad_self_of(&urn, Some(peer.clone()))
+                        .map(|user| (user, peer))
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        })
+        .await
+        .unwrap();
+
+        let tmp = tempdir().unwrap();
+
+        // Perform commit and push to working copy on peer1
+        let repo = git2::Repository::init(tmp.path().join("peer1")).unwrap();
+        let url = LocalUrl::from_urn(radicle.urn(), peer1.peer_id().clone());
+
+        let heads = NamespacedRef::heads(radicle.urn().id, Some(peer1.peer_id().clone()));
+        let remotes: FlatRef<String, _> = FlatRef::heads(
+            PhantomData,
+            Some(format!("{}@{}", alice.name(), peer1.peer_id())),
+        );
+
+        let remote = Remote::rad_remote(url, Some(remotes.refspec(heads, Force::True).into_dyn()));
+
+        let mut remote_callbacks = git2::RemoteCallbacks::new();
+        remote_callbacks.push_update_reference(|refname, maybe_error| match maybe_error {
+            None => {
+                let rev = repo.find_reference(refname)?.target().unwrap();
+
+                futures::executor::block_on(peer1.protocol().announce(Gossip {
+                    origin: Some(peer1.peer_id().clone()),
+                    urn: RadUrn {
+                        path: uri::Path::parse(refname).unwrap(),
+                        ..radicle.urn()
+                    },
+                    rev: Some(Rev::Git(rev)),
+                }));
+
+                Ok(())
+            },
+
+            Some(err) => Err(git2::Error::from_str(&format!(
+                "Remote rejected {}: {}",
+                refname, err
+            ))),
+        });
+
+        // Push a change and wait for peer2 to receive it in their monorepo
+        let commit_id =
+            initial_commit(&repo, remote, "refs/heads/master", Some(remote_callbacks)).unwrap();
+        wait_for_event(peer2_events, peer1.peer_id()).await;
+
+        // Create working copy of project
+        let repo = git2::Repository::init(tmp.path().join("peer2")).unwrap();
+
+        // Create the include file
+        let url = LocalUrl {
+            repo: radicle.urn().id,
+            local_peer_id: peer2.peer_id().clone(),
+        };
+        let include = Include::from_tracked_users(tmp.path(), url, tracked_users.into_iter());
+        let include_file = include.file_path();
+        let _config = git2::Config::try_from(include).unwrap();
+
+        // Add the include above to include.path of the repo config
+        let mut config = repo.config().unwrap();
+        config
+            .set_str("include.path", &format!("{}", include_file.display()))
+            .unwrap();
+
+        // Fetch from the working copy and check we have the commit in the working copy
+        for remote in repo.remotes().unwrap().iter() {
+            let mut remote = repo.find_remote(remote.unwrap()).unwrap();
+            remote.connect(git2::Direction::Fetch).unwrap();
+            let remote_list = remote
+                .list()
+                .unwrap()
+                .iter()
+                .map(|head| head.name().to_string())
+                .collect::<Vec<_>>();
+            for name in remote_list {
+                remote.fetch(&[&name], None, None).unwrap();
+            }
+        }
+        assert!(repo.find_commit(commit_id).is_ok());
+    })
+    .await;
+}
+
+// Check out a working copy on peer1, add a commit, and push it
+fn initial_commit(
+    repo: &git2::Repository,
+    remote: Remote<LocalUrl>,
+    reference: &str,
+    remote_callbacks: Option<git2::RemoteCallbacks>,
+) -> Result<git2::Oid, git2::Error> {
+    let mut remote = remote.create(&repo)?;
+
+    let commit_id = {
+        let empty_tree = {
+            let mut index = repo.index()?;
+            let oid = index.write_tree()?;
+            repo.find_tree(oid).unwrap()
+        };
+        let author = git2::Signature::now("The Animal", "animal@muppets.com").unwrap();
+        repo.commit(
+            Some(reference),
+            &author,
+            &author,
+            "Initial commit",
+            &empty_tree,
+            &[],
+        )?
+    };
+
+    let mut opts = git2::PushOptions::new();
+    let opts = match remote_callbacks {
+        Some(cb) => opts.remote_callbacks(cb),
+        None => &mut opts,
+    };
+    remote.push(&[reference], Some(opts))?;
+
+    Ok(commit_id)
+}
+
+// Wait for peer2 to receive the gossip announcement
+async fn wait_for_event<S>(peer_events: S, remote: &PeerId)
+where
+    S: Stream<Item = PeerEvent> + std::marker::Unpin,
+{
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        peer_events
+            .filter(|event| match event {
+                PeerEvent::GossipFetch(FetchInfo { provider, .. }) => {
+                    future::ready(provider == remote)
+                },
+            })
+            .map(|_| ())
+            .next(),
+    )
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
Fixes #287 

Adds utilities to create an include file that has a list of remotes. This will allow upstream users to generate include files for their working directories to keep track of remotes.