### PR TITLE
Identities: generic types and verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "e742194e0f43fc932bcb801708c2b279d3ec8f527e3acda05a6a9f342c5ef764"
 dependencies = [
  "argh_shared",
  "heck",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -95,9 +95,9 @@ version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -307,8 +307,8 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
 dependencies = [
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -347,7 +347,7 @@ checksum = "8d2d6daefd5f1d4b74a891a5d2ab7dccba028d423107c074232a0c5dc0d40a9e"
 dependencies = [
  "data-encoding",
  "proc-macro-hack",
- "syn 1.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -420,10 +420,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "rustversion",
- "syn 1.0.38",
+ "syn",
  "synstructure",
 ]
 
@@ -486,9 +486,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f150175e6832600500334550e00e4dc563a0b32f58a9d1ad407f6473378c839"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -532,9 +532,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -840,7 +840,6 @@ dependencies = [
  "percent-encoding 2.1.0",
  "pretty_assertions",
  "proptest",
- "proptest-derive",
  "quinn",
  "radicle-keystore",
  "rand",
@@ -961,9 +960,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3436a67b46fbf4b5cc25a37341b3daf0371496dac1161422b96225dde8f603ee"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1224,9 +1223,9 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1272,9 +1271,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -1284,8 +1283,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "version_check",
 ]
 
@@ -1303,20 +1302,11 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1337,17 +1327,6 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
-]
-
-[[package]]
-name = "proptest-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d9d20dbe9e9dfe594328b6eaab72ccf571fee818991dd1c1ba5469b5f32d4"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
 ]
 
 [[package]]
@@ -1400,20 +1379,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1668,9 +1638,9 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1766,9 +1736,9 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1887,24 +1857,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "unicode-xid 0.2.1",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1913,10 +1872,10 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
- "unicode-xid 0.2.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1957,9 +1916,9 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2017,9 +1976,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2054,9 +2013,9 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fe233f4227389ab7df5b32649239da7ebe0b281824b4e84b342d04d3fd8c25e"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2149,12 +2108,6 @@ name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -2252,9 +2205,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2264,7 +2217,7 @@ version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
 dependencies = [
- "quote 1.0.7",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2274,9 +2227,9 @@ version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -104,7 +104,6 @@ futures-await-test = "0"
 futures_ringbuf = "0"
 pretty_assertions = "0"
 proptest = "0"
-proptest-derive = "0"
 tempfile = "3.1"
 
 [dev-dependencies.librad-test]

--- a/librad/src/identities.rs
+++ b/librad/src/identities.rs
@@ -15,5 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod delegation;
+pub mod generic;
 pub mod payload;
+pub mod sign;
 pub mod urn;
+
+mod sealed;

--- a/librad/src/identities/delegation.rs
+++ b/librad/src/identities/delegation.rs
@@ -1,0 +1,76 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::BTreeSet;
+
+use crate::keys::PublicKey;
+
+use super::{generic, payload, sealed};
+
+pub mod direct;
+pub mod indirect;
+
+pub use direct::Direct;
+pub use indirect::Indirect;
+
+/// Types which define trust delegations.
+pub trait Delegations: sealed::Sealed {
+    type Error;
+
+    /// Given a set of votes (ie. signatures validated by the caller), return
+    /// the subset which is valid for this delegation set.
+    fn eligible(&self, votes: BTreeSet<&PublicKey>) -> Result<BTreeSet<&PublicKey>, Self::Error>;
+
+    /// The threshold of [`Delegations::eligible`] votes required to form a
+    /// quorum.
+    ///
+    /// Nb.: "threshold" means that there must be `quorum_threshold() + 1` votes
+    /// to form a quorum.
+    fn quorum_threshold(&self) -> usize;
+}
+
+//// Forwarding impls for `Doc` and `Identity`
+
+impl<T, D, R> Delegations for generic::Doc<T, D, R>
+where
+    D: Delegations,
+{
+    type Error = D::Error;
+
+    fn eligible(&self, votes: BTreeSet<&PublicKey>) -> Result<BTreeSet<&PublicKey>, Self::Error> {
+        self.delegations.eligible(votes)
+    }
+
+    fn quorum_threshold(&self) -> usize {
+        self.delegations.quorum_threshold()
+    }
+}
+
+impl<T, R, C> Delegations for generic::Identity<T, R, C>
+where
+    T: Delegations,
+{
+    type Error = T::Error;
+
+    fn eligible(&self, votes: BTreeSet<&PublicKey>) -> Result<BTreeSet<&PublicKey>, Self::Error> {
+        self.doc.eligible(votes)
+    }
+
+    fn quorum_threshold(&self) -> usize {
+        self.doc.quorum_threshold()
+    }
+}

--- a/librad/src/identities/delegation/direct.rs
+++ b/librad/src/identities/delegation/direct.rs
@@ -1,0 +1,81 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::{btree_set, BTreeSet};
+
+use crate::keys::PublicKey;
+
+use super::{payload, sealed, Delegations};
+
+/// [`Delegations`] which delegate directly to a set of [`PublicKey`]s.
+///
+/// The only way to construct a [`Direct`] value is `From`
+/// [`payload::UserDelegations`], which ensures that duplicates in the source
+/// document translate to an error.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Direct(BTreeSet<PublicKey>);
+
+impl Direct {
+    pub fn eligible(&self, votes: BTreeSet<&PublicKey>) -> BTreeSet<&PublicKey> {
+        self.0.iter().filter(|pk| votes.contains(pk)).collect()
+    }
+}
+
+impl Delegations for Direct {
+    type Error = !;
+
+    fn eligible(&self, votes: BTreeSet<&PublicKey>) -> Result<BTreeSet<&PublicKey>, Self::Error> {
+        Ok(self.eligible(votes))
+    }
+
+    fn quorum_threshold(&self) -> usize {
+        self.0.len() / 2
+    }
+}
+
+impl sealed::Sealed for Direct {}
+
+impl From<payload::UserDelegations> for Direct {
+    fn from(payload: payload::UserDelegations) -> Self {
+        Self(payload.into())
+    }
+}
+
+#[cfg(test)]
+impl From<BTreeSet<PublicKey>> for Direct {
+    fn from(set: BTreeSet<PublicKey>) -> Self {
+        Self(set)
+    }
+}
+
+impl<'a> IntoIterator for &'a Direct {
+    type Item = &'a PublicKey;
+    type IntoIter = btree_set::Iter<'a, PublicKey>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for Direct {
+    type Item = PublicKey;
+    type IntoIter = btree_set::IntoIter<PublicKey>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}

--- a/librad/src/identities/delegation/indirect.rs
+++ b/librad/src/identities/delegation/indirect.rs
@@ -1,0 +1,228 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    collections::{
+        btree_map::{self, Entry},
+        BTreeMap,
+        BTreeSet,
+    },
+    fmt::{Debug, Display},
+};
+
+use either::Either;
+
+use crate::keys::PublicKey;
+
+use super::{generic, sealed, Delegations, Direct};
+
+pub mod error {
+    use std::fmt::{Debug, Display};
+
+    use thiserror::Error;
+
+    use super::PublicKey;
+
+    #[derive(Debug, Error)]
+    pub enum FromIter<R: Display + Debug> {
+        #[error("duplicate key `{0}`")]
+        DuplicateKey(PublicKey),
+
+        #[error("duplicate identity with root `{0}`")]
+        DuplicateIdentity(R),
+    }
+
+    #[derive(Debug, Error, Eq, PartialEq)]
+    #[error("double vote")]
+    pub struct DoubleVote;
+}
+
+pub type IndirectlyDelegating<T, R, C> = generic::Identity<generic::Doc<T, Direct, R>, R, C>;
+
+/// [`Delegations`] to either a [`PublicKey`]s directly, or another identity
+/// (which itself must only contain [`Direct`] delegations).
+#[derive(Clone, Debug, PartialEq)]
+pub struct Indirect<T, R, C> {
+    identities: Vec<IndirectlyDelegating<T, R, C>>,
+    delegations: BTreeMap<PublicKey, Option<usize>>,
+}
+
+impl<T, R, C> Indirect<T, R, C> {
+    /// Build `Self` from an iterator of either [`PublicKey`]s or
+    /// [`IndirectlyDelegating`] identities.
+    ///
+    /// # Errors
+    ///
+    /// * If a duplicate [`PublicKey`] is encountered (regardless of whether it
+    ///   is a direct or indirect delegation ).
+    /// * If a [`IndirectlyDelegating`] is encountered which refers to the same
+    ///   root revision as a previous one.
+    pub fn try_from_iter<I>(iter: I) -> Result<Self, error::FromIter<R>>
+    where
+        I: IntoIterator<Item = Either<PublicKey, IndirectlyDelegating<T, R, C>>>,
+        R: Clone + Display + Debug + Ord,
+    {
+        use error::FromIter::*;
+
+        let mut ids = Vec::new();
+        let mut dels = BTreeMap::new();
+        let mut roots = BTreeSet::new();
+
+        let mut insert = |key: PublicKey, pos: Option<usize>| match dels.entry(key) {
+            Entry::Vacant(entry) => {
+                entry.insert(pos);
+                Ok(())
+            },
+            Entry::Occupied(entry) => Err(DuplicateKey(entry.key().clone())),
+        };
+
+        for d in iter {
+            match d {
+                Either::Left(key) => insert(key, None)?,
+                Either::Right(id) => {
+                    if !roots.insert(id.root.clone()) {
+                        return Err(DuplicateIdentity(id.root));
+                    }
+
+                    ids.push(id);
+                    let pos = ids.len() - 1;
+
+                    for key in &ids[pos].doc.delegations {
+                        insert(key.clone(), Some(pos))?
+                    }
+                },
+            }
+        }
+
+        Ok(Self {
+            identities: ids,
+            delegations: dels,
+        })
+    }
+
+    /// Get the owning [`generic::Identity`] of the given key, if any.
+    pub fn owner(&self, key: &PublicKey) -> Option<&IndirectlyDelegating<T, R, C>> {
+        self.delegations
+            .get(key)
+            .and_then(|idx| idx.map(|idx| &self.identities[idx]))
+    }
+
+    /// In addition to checking whether the given [`PublicKey`]s are in the set
+    /// of delegations, this also ensures that no two keys owned by the same
+    /// indirect delegations are being used.
+    ///
+    /// If this is found to be the case, a [`error::DoubleVote`] error is
+    /// returned.
+    pub fn eligible(
+        &self,
+        votes: BTreeSet<&PublicKey>,
+    ) -> Result<BTreeSet<&PublicKey>, error::DoubleVote> {
+        let mut id_votes = BTreeSet::new();
+        self.delegations
+            .iter()
+            .filter(|(k, _)| votes.contains(k))
+            .try_fold(BTreeSet::new(), |mut acc, (k, idx)| {
+                if let Some(id) = idx {
+                    if !id_votes.insert(id) {
+                        return Err(error::DoubleVote);
+                    }
+                }
+
+                acc.insert(k);
+                Ok(acc)
+            })
+    }
+}
+
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub struct Iter<'a, T, R, C> {
+    inner: btree_map::Iter<'a, PublicKey, Option<usize>>,
+    identities: &'a [IndirectlyDelegating<T, R, C>],
+}
+
+impl<'a, T, R, C> Iterator for Iter<'a, T, R, C> {
+    type Item = Either<&'a PublicKey, &'a IndirectlyDelegating<T, R, C>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(key, pos)| match pos {
+            None => Either::Left(key),
+            Some(pos) => Either::Right(&self.identities[*pos]),
+        })
+    }
+}
+
+impl<'a, T, R, C> IntoIterator for &'a Indirect<T, R, C> {
+    type Item = Either<&'a PublicKey, &'a IndirectlyDelegating<T, R, C>>;
+    type IntoIter = Iter<'a, T, R, C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Iter {
+            inner: self.delegations.iter(),
+            identities: &self.identities,
+        }
+    }
+}
+
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub struct IntoIter<T, R, C> {
+    inner: btree_map::IntoIter<PublicKey, Option<usize>>,
+    identities: Vec<IndirectlyDelegating<T, R, C>>,
+}
+
+impl<T: Clone, R: Clone, C: Clone> Iterator for IntoIter<T, R, C> {
+    type Item = Either<PublicKey, IndirectlyDelegating<T, R, C>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(key, pos)| match pos {
+            None => Either::Left(key),
+            Some(pos) => Either::Right(self.identities[pos].clone()),
+        })
+    }
+}
+
+impl<T: Clone, R: Clone, C: Clone> IntoIterator for Indirect<T, R, C> {
+    type Item = Either<PublicKey, IndirectlyDelegating<T, R, C>>;
+    type IntoIter = IntoIter<T, R, C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.delegations.into_iter(),
+            identities: self.identities,
+        }
+    }
+}
+
+impl<T, R, C> Delegations for Indirect<T, R, C> {
+    type Error = error::DoubleVote;
+
+    fn eligible(&self, votes: BTreeSet<&PublicKey>) -> Result<BTreeSet<&PublicKey>, Self::Error> {
+        self.eligible(votes)
+    }
+
+    fn quorum_threshold(&self) -> usize {
+        let direct = self
+            .delegations
+            .iter()
+            .filter(|(_, idx)| idx.is_none())
+            .count();
+        let indirect = self.identities.len();
+
+        (direct + indirect) / 2
+    }
+}
+
+impl<T, R, C> sealed::Sealed for Indirect<T, R, C> {}

--- a/librad/src/identities/generic.rs
+++ b/librad/src/identities/generic.rs
@@ -1,0 +1,543 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![allow(clippy::type_complexity)]
+
+use std::{
+    fmt::{Debug, Display},
+    marker::PhantomData,
+    ops::Deref,
+};
+
+use serde::ser::SerializeStruct;
+
+use super::{delegation::Delegations, sealed, sign::Signatures, urn::Urn};
+
+pub mod error;
+
+#[cfg(test)]
+pub(crate) mod gen;
+#[cfg(test)]
+pub(crate) mod tests;
+
+/// The identity document, carrying metadata `T` and trust delegations `D`.
+///
+/// In `git`, this is represented as a `blob`, where the previous revision
+/// `replaces` is a `tree` oid.
+#[derive(Clone, Debug, PartialEq, serde::Deserialize)]
+pub struct Doc<T, D, Revision> {
+    /// Protocol version. Always serialised as `0` (zero).
+    pub version: u8,
+    pub replaces: Option<Revision>,
+    pub payload: T,
+    pub delegations: D,
+}
+
+impl<T, D, Revision> serde::Serialize for Doc<T, D, Revision>
+where
+    T: serde::Serialize,
+    D: serde::Serialize,
+    Revision: serde::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut doc = serializer.serialize_struct("Doc", 4)?;
+        doc.serialize_field("version", &0)?;
+        doc.serialize_field("replaces", &self.replaces)?;
+        doc.serialize_field("payload", &self.payload)?;
+        doc.serialize_field("delegations", &self.delegations)?;
+        doc.end()
+    }
+}
+
+impl<T, D, R> Doc<T, D, R> {
+    /// Bifunctorial map.
+    ///
+    /// Map over the payload `T` and the delegations `D` at the same time.
+    pub fn bimap<F, U, G, E>(self, f: F, g: G) -> Doc<U, E, R>
+    where
+        F: FnOnce(T) -> U,
+        G: FnOnce(D) -> E,
+    {
+        Doc {
+            version: self.version,
+            replaces: self.replaces,
+            payload: f(self.payload),
+            delegations: g(self.delegations),
+        }
+    }
+
+    /// Map covariantly over `T`.
+    pub fn first<F, U>(self, f: F) -> Doc<U, D, R>
+    where
+        F: FnOnce(T) -> U,
+    {
+        self.bimap(f, |x| x)
+    }
+
+    /// Map covariantly over `D`.
+    pub fn second<G, E>(self, g: G) -> Doc<T, E, R>
+    where
+        G: FnOnce(D) -> E,
+    {
+        self.bimap(|x| x, g)
+    }
+
+    /// Map a fallible function over `T`.
+    ///
+    /// Like `bitraverse id pure . first` in Haskell.
+    pub fn try_first<F, U, Error>(self, f: F) -> Result<Doc<U, D, R>, Error>
+    where
+        F: FnOnce(T) -> Result<U, Error>,
+    {
+        let doc = self.first(f);
+        Ok(Doc {
+            version: doc.version,
+            replaces: doc.replaces,
+            payload: doc.payload?,
+            delegations: doc.delegations,
+        })
+    }
+
+    /// Map a fallible function of `D`.
+    ///
+    /// Like `bitraverse pure id . second` in Haskell.
+    pub fn try_second<G, E, Error>(self, g: G) -> Result<Doc<T, E, R>, Error>
+    where
+        G: FnOnce(D) -> Result<E, Error>,
+    {
+        let doc = self.second(g);
+        Ok(Doc {
+            version: doc.version,
+            replaces: doc.replaces,
+            payload: doc.payload,
+            delegations: doc.delegations?,
+        })
+    }
+}
+
+impl<T, D, R> sealed::Sealed for Doc<T, D, R> {}
+
+/// An identity attestation.
+///
+/// An [`Identity`] is content-addressable by `ContentId`, and signed by at
+/// least one [`super::sign::Signature`] over the `revision` (this invariant is
+/// maintained by [`Verifying::signed`]). It carries the root (or initial)
+/// `Revision` of the identity document `T` (usually a [`Doc`]), which is also
+/// the stable identifier which forms the identity's [`Urn`].
+///
+/// In `git`, an [`Identity`] is represented by a `commit`, where the
+/// `content_id` is the commit `oid`, the `root` is the `blob` hash of the
+/// initial version of the `doc`, and the [`Signatures`] are over the commit's
+/// `tree` hash. The signatures are encoded in the commit message as [trailers].
+///
+/// [trailers]: https://git-scm.com/docs/git-interpret-trailers
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Identity<T, Revision, ContentId> {
+    pub content_id: ContentId,
+    pub root: Revision,
+    pub revision: Revision,
+    pub doc: T,
+    pub signatures: Signatures,
+}
+
+impl<T, R, C> Identity<T, R, C> {
+    /// The stable identifier of this identity.
+    pub fn urn(&self) -> Urn<&R> {
+        Urn::new(&self.root)
+    }
+
+    /// Functorial map.
+    ///
+    /// Map a function over the identity document `T`.
+    pub fn map<F, U>(self, f: F) -> Identity<U, R, C>
+    where
+        F: FnOnce(T) -> U,
+    {
+        Identity {
+            content_id: self.content_id,
+            root: self.root,
+            revision: self.revision,
+            doc: f(self.doc),
+            signatures: self.signatures,
+        }
+    }
+}
+
+impl<T, R, C, Error> Identity<Result<T, Error>, R, C> {
+    /// Transposes an `Identity<Result<T, E>, _, _>` into a `Result<Identity<T,
+    /// _, _>, E>`.
+    ///
+    /// Allows to pass a fallible function to [`Self::map`], and "extract" the
+    /// error.
+    pub fn transpose(self) -> Result<Identity<T, R, C>, Error> {
+        Ok(Identity {
+            content_id: self.content_id,
+            root: self.root,
+            revision: self.revision,
+            doc: self.doc?,
+            signatures: self.signatures,
+        })
+    }
+}
+
+impl<T, R, C> AsRef<T> for Identity<T, R, C> {
+    fn as_ref(&self) -> &T {
+        &self.doc
+    }
+}
+
+impl<T, R, C> sealed::Sealed for Identity<T, R, C> {}
+
+/// Ad-hoc trait which allows us to keep the `T` parameter of [`Identity`]
+/// polymorphic for verification.
+pub trait Replaces: sealed::Sealed {
+    type Revision;
+
+    fn replaces(&self) -> Option<&Self::Revision>;
+}
+
+impl<T, D, R> Replaces for Doc<T, D, R> {
+    type Revision = R;
+
+    fn replaces(&self) -> Option<&Self::Revision> {
+        self.replaces.as_ref()
+    }
+}
+
+/// Untrusted, well-formed input.
+#[derive(Clone, Copy, Debug)]
+pub struct Untrusted;
+
+/// Well-formed and signed by at least one key delegation.
+#[derive(Clone, Copy, Debug)]
+pub struct Signed;
+
+/// Signed by a quorum of the **current** key delegations.
+#[derive(Clone, Copy, Debug)]
+pub struct Quorum;
+
+/// Signed by a quorum of the **current** key delegations **AND** a quorum
+/// of the **parent**'s key delegations.
+#[derive(Clone, Copy, Debug)]
+pub struct Verified;
+
+/// An identity `T` under verification.
+///
+/// The verification status (ie. which predicates where successfully applied to
+/// `T`) is tracked on the type level, as intermediate states may have meaning
+/// elsewhere.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Verifying<T, S> {
+    inner: T,
+    state: PhantomData<S>,
+}
+
+impl<T, S> Deref for Verifying<T, S> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T, S> Verifying<T, S> {
+    /// Create a [`Verifying`] from arbitrary input `T`.
+    ///
+    /// Type inference is usually better when using `Verifying::from`.
+    pub fn from_untrusted(t: T) -> Verifying<T, Untrusted> {
+        Verifying {
+            inner: t,
+            state: PhantomData,
+        }
+    }
+
+    /// Strip the [`Verifying`] wrapper from `T`.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    fn coerce<U>(self) -> Verifying<T, U> {
+        Verifying {
+            inner: self.inner,
+            state: PhantomData,
+        }
+    }
+}
+
+impl<T> From<T> for Verifying<T, Untrusted> {
+    fn from(t: T) -> Self {
+        Self::from_untrusted(t)
+    }
+}
+
+impl<T, R, C> Verifying<Identity<T, R, C>, Untrusted> {
+    /// Attempt to transition an [`Untrusted`] [`Identity`] to the [`Signed`]
+    /// state.
+    ///
+    /// Will retain only the valid and [`Delegations::eligible`] signatures in
+    /// `T`.
+    ///
+    /// # Errors
+    ///
+    /// If the set of valid and eligible signatures is empty.
+    pub fn signed<E>(
+        self,
+    ) -> Result<Verifying<Identity<T, R, C>, Signed>, error::Verify<R, C, T::Error, E>>
+    where
+        T: Delegations,
+        T::Error: std::error::Error + 'static,
+
+        E: std::error::Error + 'static,
+        R: Debug + Display + AsRef<[u8]>,
+        C: Debug + Display,
+    {
+        let Identity {
+            content_id,
+            root,
+            revision,
+            doc,
+            mut signatures,
+            ..
+        } = self.inner;
+
+        let eligible = doc
+            .eligible(signatures.keys().collect())
+            .map_err(error::Verify::Delegation)?;
+        // `drain_filter` is such a strange API:
+        //
+        // "If the closure returns true, the element is removed from the map and
+        // yielded. If the closure returns false, or panics, the element remains
+        // in the map and will not be yielded.
+        //
+        // [...]
+        //
+        // If the iterator is only partially consumed or not consumed at all,
+        // each of the remaining elements will still be subjected to the closure
+        // and removed and dropped if it returns true."
+        //
+        // So, if we drop the iterator, it behaves like `HashMap::retain`, only
+        // with the predicate reversed.
+        signatures
+            .drain_filter(|pk, sig| !(eligible.contains(&pk) && sig.verify(revision.as_ref(), pk)));
+
+        if !signatures.is_empty() {
+            Ok(Verifying {
+                inner: Identity {
+                    content_id,
+                    root,
+                    revision,
+                    doc,
+                    signatures,
+                },
+                state: PhantomData,
+            })
+        } else {
+            Err(error::Verify::NoValidSignatures(revision, content_id))
+        }
+    }
+
+    /// Attempt to transition from [`Untrusted`] to [`Quorum`]
+    ///
+    /// Convenience for when [`Signed`] is not interesting.
+    pub fn quorum<E>(
+        self,
+    ) -> Result<Verifying<Identity<T, R, C>, Quorum>, error::Verify<R, C, T::Error, E>>
+    where
+        T: Delegations,
+        T::Error: std::error::Error + 'static,
+
+        E: std::error::Error + 'static,
+        R: Debug + Display + AsRef<[u8]>,
+        C: Debug + Display,
+    {
+        self.signed()?.quorum()
+    }
+
+    /// Attempt to transition from [`Untrusted`] straight to [`Verified`].
+    ///
+    /// Convenience for when the intermediate states are not interesting.
+    pub fn verified<E>(
+        self,
+        parent: Option<&Verifying<Identity<T, R, C>, Verified>>,
+    ) -> Result<Verifying<Identity<T, R, C>, Verified>, error::Verify<R, C, T::Error, E>>
+    where
+        T: Delegations + Replaces<Revision = R>,
+        T::Error: std::error::Error + 'static,
+
+        E: std::error::Error + 'static,
+        R: Clone + Debug + Display + PartialEq + AsRef<[u8]>,
+        C: Clone + Debug + Display,
+    {
+        self.signed()?.quorum()?.verified(parent)
+    }
+}
+
+impl<T, R, C> Verifying<Identity<T, R, C>, Signed> {
+    /// Attempt to transition a [`Signed`] [`Identity`] to the [`Quorum`] state.
+    ///
+    /// # Errors
+    ///
+    /// If the number of signatures does not reach the
+    /// [`Delegations::quorum_threshold`].
+    pub fn quorum<E>(
+        self,
+    ) -> Result<Verifying<Identity<T, R, C>, Quorum>, error::Verify<R, C, T::Error, E>>
+    where
+        T: Delegations,
+        T::Error: std::error::Error + 'static,
+
+        E: std::error::Error + 'static,
+        R: Debug + Display,
+        C: Debug + Display,
+    {
+        if self.signatures.len() > self.doc.quorum_threshold() {
+            Ok(self.coerce())
+        } else {
+            Err(error::Verify::Quorum)
+        }
+    }
+}
+
+impl<T, R, C> Verifying<Identity<T, R, C>, Quorum> {
+    /// Attempt to transition a [`Quorum`] [`Identity`] to the [`Verified`]
+    /// state.
+    ///
+    /// This requires to supply the parent identity, ie. an [`Identity`] with
+    /// the same `root` and a `revision` matching the `replaces` attribute
+    /// of the identity [`Doc`]. If `self` is the initial revision (ie.
+    /// `replaces` is `None`), the parent MUST be `None`.
+    ///
+    /// # Errors
+    ///
+    /// * `self` and `parent` don't point to the same `root`
+    /// * `parent` is `Some`, but `self` does not have a previous revision
+    /// * `parent` is `None`, but `self` **does** have a previous revision
+    /// * the `parent` revision doesn't match `replaces`
+    /// * `self`'s signatures do not reach a quorum of the `parent`'s
+    ///   delegations. In other words,
+    ///   `parent.eligible(self.signatures.keys()).len() >
+    ///   parent.doc.quorum_threshold()`
+    /// * `parent.eligible(self.signatures.keys())` returns an error
+    pub fn verified<E>(
+        self,
+        parent: Option<&Verifying<Identity<T, R, C>, Verified>>,
+    ) -> Result<Verifying<Identity<T, R, C>, Verified>, error::Verify<R, C, T::Error, E>>
+    where
+        T: Delegations + Replaces<Revision = R>,
+        T::Error: std::error::Error + 'static,
+
+        E: std::error::Error + 'static,
+        R: Clone + Debug + Display + PartialEq + AsRef<[u8]>,
+        C: Clone + Debug + Display,
+    {
+        match (self.doc.replaces(), parent) {
+            (_, Some(parent)) if parent.root != self.root => Err(error::Verify::RootMismatch {
+                expected: self.inner.root,
+                actual: parent.root.clone(),
+            }),
+
+            (None, Some(parent)) => Err(error::Verify::DanglingParent(
+                self.content_id.to_owned(),
+                parent.content_id.to_owned(),
+            )),
+            (Some(replaces), None) => Err(error::Verify::MissingParent(replaces.to_owned())),
+
+            (None, None) => Ok(self.coerce()),
+
+            (Some(replaces), Some(ref parent)) => {
+                if replaces != &parent.revision {
+                    Err(error::Verify::ParentMismatch {
+                        expected: replaces.to_owned(),
+                        actual: parent.revision.to_owned(),
+                    })
+                } else {
+                    let votes = parent
+                        .doc
+                        .eligible(self.signatures.keys().collect())
+                        .map_err(error::Verify::Delegation)?
+                        .len();
+
+                    if votes > parent.doc.quorum_threshold() {
+                        Ok(self.coerce())
+                    } else {
+                        Err(error::Verify::Quorum)
+                    }
+                }
+            },
+        }
+    }
+}
+
+/// The result of running [`Verifying::verify`].
+///
+/// In addition to the most recent verified [`Identity`], the parent used to
+/// call [`Verifying::verified`] is retained.
+#[derive(Clone, Debug)]
+pub struct Folded<T, R, C> {
+    pub head: Verifying<Identity<T, R, C>, Verified>,
+    pub parent: Option<Verifying<Identity<T, R, C>, Verified>>,
+}
+
+impl<T, R, C> Verifying<Identity<T, R, C>, Verified> {
+    /// Starting from a [`Verified`] base [`Identity`], and its progeny, attempt
+    /// to verify each identity in the progeny until either verification
+    /// fails, or we find no more identities, in which case the most recent one
+    /// is returned.
+    ///
+    /// Conceptually, this is a right-fold over the hash-linked history of
+    /// identity attestations. In order to simplify implementations, we do
+    /// not, however, constrain the iterator to be a
+    /// [`DoubleEndedIterator`]. This means that it is up to the caller to
+    /// ensure that the [`Iterator`] yields elements in reverse order.
+    ///
+    /// [`Signed`] identities in the progeny, which do not pass [`Quorum`] are
+    /// skipped. This is to allow proposals to be made over the same protocol.
+    pub fn verify<E>(
+        self,
+        mut progeny: impl Iterator<Item = Result<Verifying<Identity<T, R, C>, Untrusted>, E>>,
+    ) -> Result<Folded<T, R, C>, error::Verify<R, C, T::Error, E>>
+    where
+        T: Delegations + Replaces<Revision = R>,
+        <T as Delegations>::Error: std::error::Error + 'static,
+
+        E: std::error::Error + 'static,
+        R: Clone + Debug + Display + PartialEq + AsRef<[u8]>,
+        C: Clone + Debug + Display,
+    {
+        progeny.try_fold(
+            Folded {
+                head: self,
+                parent: None,
+            },
+            |acc, cur| {
+                // Not signed is an error
+                let signed = cur.map_err(error::Verify::Iter)?.signed()?;
+                match signed.quorum::<E>() {
+                    // Not reaching quorum is ok, skip
+                    Err(_) => Ok(acc),
+                    Ok(quorum) => quorum.verified(Some(&acc.head)).map(|verified| Folded {
+                        head: verified,
+                        parent: Some(acc.head),
+                    }),
+                }
+            },
+        )
+    }
+}

--- a/librad/src/identities/generic/error.rs
+++ b/librad/src/identities/generic/error.rs
@@ -1,0 +1,63 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::fmt::{Debug, Display};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Verify<Revision, ContentId, Delegation, Iter>
+where
+    Revision: Display + Debug + 'static,
+    ContentId: Display + Debug + 'static,
+    Delegation: std::error::Error + 'static,
+    Iter: std::error::Error + 'static,
+{
+    #[error("no valid signatures over {0} in {1}")]
+    NoValidSignatures(Revision, ContentId),
+
+    #[error("quorum not reached")]
+    Quorum,
+
+    #[error("expected parent {expected}, found {actual}")]
+    ParentMismatch {
+        expected: Revision,
+        actual: Revision,
+    },
+
+    #[error("unexpected parent of {0}: {1}")]
+    DanglingParent(ContentId, ContentId),
+
+    #[error("parent revision `{0}` missing")]
+    MissingParent(Revision),
+
+    #[error("identities do not refer to the same root")]
+    RootMismatch {
+        expected: Revision,
+        actual: Revision,
+    },
+
+    #[error("empty history")]
+    EmptyHistory,
+
+    #[error("non-eligible delegation")]
+    Delegation(#[source] Delegation),
+
+    #[error("error traversing the identity history")]
+    Iter(#[source] Iter),
+}

--- a/librad/src/identities/generic/gen.rs
+++ b/librad/src/identities/generic/gen.rs
@@ -24,7 +24,6 @@ use std::{
 use either::Either::{self, *};
 use nonempty::NonEmpty;
 use proptest::prelude::*;
-use proptest_derive::Arbitrary;
 
 use super::*;
 use crate::{
@@ -33,8 +32,17 @@ use crate::{
 };
 
 /// A completely irrelevant value.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Arbitrary)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Boring;
+
+impl Arbitrary for Boring {
+    type Parameters = ();
+    type Strategy = fn() -> Self;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        || Boring
+    }
+}
 
 impl Display for Boring {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -74,8 +82,17 @@ where
 }
 
 /// A revision that looks a bit like a git SHA1, but is faster to generate.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Arbitrary)]
-pub struct Revision(#[proptest(regex = "[a-z0-9]{40}")] String);
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Revision(String);
+
+impl Arbitrary for Revision {
+    type Parameters = ();
+    type Strategy = prop::strategy::Map<&'static str, fn(String) -> Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        "[a-z0-9]{40}".prop_map(Self)
+    }
+}
 
 impl AsRef<[u8]> for Revision {
     fn as_ref(&self) -> &[u8] {

--- a/librad/src/identities/generic/gen.rs
+++ b/librad/src/identities/generic/gen.rs
@@ -1,0 +1,409 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::{self, Display},
+    iter,
+};
+
+use either::Either::{self, *};
+use nonempty::NonEmpty;
+use proptest::prelude::*;
+use proptest_derive::Arbitrary;
+
+use super::*;
+use crate::{
+    identities::delegation,
+    keys::{tests::gen_secret_key, PublicKey, SecretKey, Signature},
+};
+
+/// A completely irrelevant value.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Arbitrary)]
+pub struct Boring;
+
+impl Display for Boring {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("Boring")
+    }
+}
+
+impl AsRef<[u8]> for Boring {
+    fn as_ref(&self) -> &[u8] {
+        b"oring"
+    }
+}
+
+/// [`Vec`] with at least 2 elements.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VecOf2<T>(Vec<T>);
+
+impl<T> From<VecOf2<T>> for Vec<T> {
+    fn from(vo2: VecOf2<T>) -> Self {
+        vo2.0
+    }
+}
+
+impl<T> Deref for VecOf2<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub fn gen_vecof2<T>(element: T, max: usize) -> impl Strategy<Value = VecOf2<T::Value>>
+where
+    T: Strategy,
+{
+    prop::collection::vec(element, 2..max).prop_map(VecOf2)
+}
+
+/// A revision that looks a bit like a git SHA1, but is faster to generate.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Arbitrary)]
+pub struct Revision(#[proptest(regex = "[a-z0-9]{40}")] String);
+
+impl AsRef<[u8]> for Revision {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl Display for Revision {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// "Existentialised" delegations.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SomeDelegations<T, R, C> {
+    Direct(delegation::Direct),
+    Indirect(delegation::Indirect<T, R, C>),
+}
+
+impl<T, R, C> Delegations for SomeDelegations<T, R, C> {
+    type Error = Either<
+        <delegation::Direct as Delegations>::Error,
+        <delegation::Indirect<T, R, C> as Delegations>::Error,
+    >;
+
+    fn eligible(&self, votes: BTreeSet<&PublicKey>) -> Result<BTreeSet<&PublicKey>, Self::Error> {
+        match self {
+            SomeDelegations::Direct(direct) => Ok(direct.eligible(votes)),
+            SomeDelegations::Indirect(indirect) => indirect.eligible(votes).map_err(Right),
+        }
+    }
+
+    fn quorum_threshold(&self) -> usize {
+        match self {
+            SomeDelegations::Direct(direct) => direct.quorum_threshold(),
+            SomeDelegations::Indirect(indirect) => indirect.quorum_threshold(),
+        }
+    }
+}
+
+impl<T, R, C> sealed::Sealed for SomeDelegations<T, R, C> {}
+
+/// Official radicle presence of [The Most Interesting Man In The World].
+///
+/// [The Most Interesting Man In The World]: https://imgflip.com/i/4dlpj1
+pub fn boring<D>(
+    delegations: D,
+    signatures: Signatures,
+) -> Identity<Doc<Boring, D, Boring>, Boring, Boring>
+where
+    D: Delegations,
+{
+    Identity {
+        content_id: Boring,
+        root: Boring,
+        revision: Boring,
+        doc: Doc {
+            version: 0,
+            replaces: None,
+            payload: Boring,
+            delegations,
+        },
+        signatures,
+    }
+}
+
+pub type ArbitraryIdentity<R> =
+    Identity<Doc<Boring, SomeDelegations<Boring, R, Boring>, R>, R, Boring>;
+
+/// Very random [`Identity`].
+pub fn gen_identity<R>() -> impl Strategy<Value = ArbitraryIdentity<R>>
+where
+    R: Arbitrary + Clone + Debug + Display + Ord + AsRef<[u8]>,
+{
+    (
+        gen_signing_keys(),
+        any::<R>(),
+        any::<R>(),
+        any::<Option<R>>(),
+    )
+        .prop_flat_map(|(signing_keys, root, revision, replaces)| {
+            gen_identity_with(signing_keys, root, revision, replaces)
+        })
+}
+
+/// [`Identity`] with some fixed values.
+pub fn gen_identity_with<R>(
+    signing_keys: VecOf2<SecretKey>,
+    root: R,
+    revision: R,
+    replaces: Option<R>,
+) -> impl Strategy<Value = ArbitraryIdentity<R>>
+where
+    R: Arbitrary + Clone + Debug + Display + Ord + AsRef<[u8]>,
+{
+    (
+        Just((root, revision.clone(), replaces)),
+        gen_delegations_with(signing_keys, revision),
+    )
+        .prop_map(
+            |((root, revision, replaces), (signatures, delegations))| Identity {
+                content_id: Boring,
+                root,
+                revision,
+                doc: Doc {
+                    version: 0,
+                    replaces,
+                    payload: Boring,
+                    delegations,
+                },
+                signatures,
+            },
+        )
+}
+
+/// [`Identity`] which replaces nothing.
+pub fn gen_root_identity<R>() -> impl Strategy<Value = ArbitraryIdentity<R>>
+where
+    R: Arbitrary + Clone + Debug + Display + Ord + AsRef<[u8]>,
+{
+    gen_signing_keys().prop_flat_map(gen_root_identity_with)
+}
+
+/// Like [`gen_root_identity`], but with a fixed set of keys.
+pub fn gen_root_identity_with<R>(
+    signing_keys: VecOf2<SecretKey>,
+) -> impl Strategy<Value = ArbitraryIdentity<R>>
+where
+    R: Arbitrary + Clone + Debug + Display + Ord + AsRef<[u8]>,
+{
+    (Just(signing_keys), any::<R>(), any::<R>()).prop_flat_map(|(signing_keys, root, revision)| {
+        gen_identity_with(signing_keys, root, revision, None)
+    })
+}
+
+/// An identity history of length `len` (plus the root revision), which should
+/// pass verification.
+///
+/// Note that the `content_id` is still `Boring`, only the `Doc` hash-links are
+/// relevant for verification.
+///
+/// To reach quorum at each revision, we just sign with the same set of keys,
+/// meaning that the delegations don't actually change -- an exercise for the
+/// future maintainer to randomise this as well.
+///
+/// The history is in reverse order, ie. starts with the root revision.
+pub fn gen_history(
+    len: impl Into<prop::collection::SizeRange>,
+) -> impl Strategy<Value = NonEmpty<ArbitraryIdentity<Revision>>> {
+    (Just(len.into()), gen_signing_keys()).prop_ind_flat_map(move |(len, keys)| {
+        (
+            Just(keys.clone()),
+            gen_root_identity_with(keys),
+            prop::collection::vec(any::<Revision>(), len),
+        )
+            .prop_map(|(keys, root, revisions)| {
+                let keys = keys
+                    .iter()
+                    .map(|sk| (sk.public(), sk))
+                    .collect::<BTreeMap<_, _>>();
+
+                let tail = revisions
+                    .into_iter()
+                    .fold((Vec::new(), root.clone()), |(mut acc, parent), revision| {
+                        let signatures = parent
+                            .signatures
+                            .iter()
+                            .map(|(pk, _)| {
+                                let sk = keys.get(pk).unwrap();
+                                (pk.clone(), sk.sign(revision.as_ref()))
+                            })
+                            .collect::<BTreeMap<_, _>>()
+                            .into();
+
+                        let next = Identity {
+                            revision,
+                            signatures,
+                            ..parent.clone()
+                        }
+                        .map(|doc| Doc {
+                            replaces: Some(parent.revision.clone()),
+                            ..doc
+                        });
+
+                        acc.push(next.clone());
+                        (acc, next)
+                    })
+                    .0;
+
+                NonEmpty { head: root, tail }
+            })
+    })
+}
+
+fn mk_direct(
+    signing_keys: &[SecretKey],
+    data_to_sign: impl AsRef<[u8]>,
+) -> (Signatures, delegation::Direct) {
+    let signatures: Signatures = signing_keys
+        .iter()
+        .map(|key| (key.public(), key.sign(data_to_sign.as_ref())))
+        .collect::<BTreeMap<_, _>>()
+        .into();
+
+    let delegations: delegation::Direct = signatures
+        .iter()
+        .map(|(pk, _)| pk.clone())
+        .collect::<BTreeSet<_>>()
+        .into();
+
+    (signatures, delegations)
+}
+
+fn mk_indirect_with<R>(
+    signing_keys: VecOf2<SecretKey>,
+    revision_to_sign: R,
+    inner_root: R,
+    inner_revision: R,
+    inner_replaces: Option<R>,
+    num_keys_indirect: usize,
+) -> (Signatures, delegation::Indirect<Boring, R, Boring>)
+where
+    R: Clone + Debug + Display + Ord + AsRef<[u8]>,
+{
+    // First chunk shall be indirect
+    let (inner_keys, direct_keys) = signing_keys.split_at(num_keys_indirect);
+
+    let (indirect_signatures, indirect_delegations): (
+        (PublicKey, Signature),
+        delegation::indirect::IndirectlyDelegating<Boring, R, Boring>,
+    ) = {
+        let (signatures, delegations) = mk_direct(inner_keys, revision_to_sign.clone());
+
+        // Pick the first signature to be used for the `Identity` containing our
+        // delegations -- we can use only one to not cause a double-vote
+        let sig = signatures
+            .iter()
+            .next()
+            .map(|(k, s)| (k.clone(), s.clone()))
+            .unwrap();
+        let inner = Identity {
+            content_id: Boring,
+            root: inner_root,
+            revision: inner_revision,
+            doc: Doc {
+                version: 0,
+                replaces: inner_replaces,
+                payload: Boring,
+                delegations,
+            },
+            signatures,
+        };
+
+        (sig, inner)
+    };
+
+    // Rest shall be direct
+    let (mut signatures, direct_delegations) = mk_direct(direct_keys, revision_to_sign);
+    signatures.insert(indirect_signatures.0, indirect_signatures.1);
+
+    let delegations: delegation::Indirect<Boring, _, _> = delegation::Indirect::try_from_iter(
+        iter::once(Right(indirect_delegations)).chain(direct_delegations.into_iter().map(Left)),
+    )
+    .unwrap();
+
+    (signatures, delegations)
+}
+
+/// [`delegation::Indirect`] from a set of signing keys and some data to sign.
+///
+/// Returns the [`Signatures`] made, maintaining the invariant that only one of
+/// them is owned by the [`delegation::Indirect`] (ie. no
+/// [`delegation::indirect::error::DoubleVote`] can occur).
+pub fn gen_indirect<R>(
+    signing_keys: VecOf2<SecretKey>,
+    revision_to_sign: R,
+) -> impl Strategy<Value = (Signatures, delegation::Indirect<Boring, R, Boring>)>
+where
+    R: Arbitrary + Clone + Debug + Display + Ord + AsRef<[u8]>,
+{
+    let num_keys = signing_keys.len();
+    (
+        Just(signing_keys),
+        Just(revision_to_sign),
+        any::<R>(),
+        any::<R>(),
+        any::<Option<R>>(),
+        1..num_keys,
+    )
+        .prop_map(
+            |(
+                signing_keys,
+                revision_to_sign,
+                inner_root,
+                inner_revision,
+                inner_replaces,
+                num_keys_indirect,
+            )| {
+                mk_indirect_with(
+                    signing_keys,
+                    revision_to_sign,
+                    inner_root,
+                    inner_revision,
+                    inner_replaces,
+                    num_keys_indirect,
+                )
+            },
+        )
+}
+
+/// Delegations of some type, with fixed parameters.
+pub fn gen_delegations_with<R>(
+    signing_keys: VecOf2<SecretKey>,
+    revision: R,
+) -> impl Strategy<Value = (Signatures, SomeDelegations<Boring, R, Boring>)>
+where
+    R: Arbitrary + Clone + Debug + Display + Ord + AsRef<[u8]>,
+{
+    prop_oneof![
+        Just({
+            let (signatures, delegations) = mk_direct(&signing_keys, &revision);
+            (signatures, SomeDelegations::Direct(delegations))
+        }),
+        gen_indirect(signing_keys, revision).prop_map(|(s, d)| (s, SomeDelegations::Indirect(d)))
+    ]
+}
+
+pub fn gen_signing_keys() -> impl Strategy<Value = VecOf2<SecretKey>> {
+    gen_vecof2(gen_secret_key(), 8)
+}

--- a/librad/src/identities/generic/tests.rs
+++ b/librad/src/identities/generic/tests.rs
@@ -1,0 +1,209 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use nonempty::NonEmpty;
+use proptest::prelude::*;
+
+use super::{gen::*, *};
+use crate::{identities::delegation, keys::tests::gen_secret_key};
+
+proptest! {
+    #[test]
+    fn signed_empty_delegations(
+        signing_keys in prop::collection::vec(gen_secret_key(), 1..3).no_shrink(),
+    ) {
+        let signatures = signing_keys
+            .into_iter()
+            .map(|key| (key.public(), key.sign(Boring.as_ref())))
+            .collect::<BTreeMap<_, _>>()
+            .into();
+
+        assert!(matches!(
+            Verifying::from(boring(
+                delegation::Direct::from(BTreeSet::new()),
+                signatures
+            ))
+            .signed::<!>(),
+            Err(error::Verify::NoValidSignatures(_, _))
+        ))
+    }
+
+    #[test]
+    fn signed(id in gen_identity::<Boring>()) {
+        assert_eq!(
+            Verifying::from(id.clone())
+                .signed::<!>()
+                .unwrap()
+                .into_inner(),
+            id
+        )
+    }
+
+    #[test]
+    fn quorum_below_threshold(
+        (id, num_sigs) in
+            gen_identity::<Boring>().prop_flat_map(|id| {
+                let threshold = id.quorum_threshold();
+                (Just(id), 1..=threshold)
+            })
+    ) {
+        let signatures: Signatures = BTreeMap::from(id.signatures)
+            .into_iter()
+            .take(num_sigs)
+            .collect::<BTreeMap<_, _>>()
+            .into();
+
+        let id = Identity {
+            signatures,
+            ..id
+        };
+
+        assert!(matches!(
+            Verifying::from(id).quorum::<!>(),
+            Err(error::Verify::Quorum)
+        ))
+    }
+
+    #[test]
+    fn quorum(id in gen_identity::<Boring>()) {
+        assert_eq!(
+            Verifying::from(id.clone())
+                .quorum::<!>()
+                .unwrap()
+                .into_inner(),
+            id
+        )
+    }
+
+    #[test]
+    fn verified_root(id in gen_root_identity::<Revision>()) {
+        assert_eq!(
+            Verifying::from(id.clone())
+                .verified::<!>(None)
+                .unwrap()
+                .into_inner(),
+            id
+        )
+    }
+
+    #[test]
+    fn verified(NonEmpty { head, tail } in gen_history(1)) {
+        match tail.as_slice() {
+            [next] => {
+                let parent = Verifying::from(head).verified::<!>(None).unwrap();
+                let child = Verifying::from(next.clone())
+                    .verified::<!>(Some(&parent))
+                    .unwrap()
+                    .into_inner();
+
+                assert_eq!(&child, next)
+            },
+
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn verified_dangling_parent(parent in gen_root_identity::<Revision>()) {
+        let parent = Verifying::from(parent).verified::<!>(None).unwrap();
+        let child = Verifying::from(parent.clone().into_inner().map(|doc| Doc {
+            replaces: None,
+            ..doc
+        }))
+        .verified::<!>(Some(&parent));
+
+        assert!(matches!(child, Err(error::Verify::DanglingParent { .. })))
+    }
+
+    #[test]
+    fn verified_root_mismatch(
+        id in gen_root_identity::<Revision>(),
+        parent_root in any::<Revision>(),
+    ) {
+        let parent = Verifying::from(Identity {
+            root: parent_root,
+            ..id.clone()
+        })
+        .verified::<!>(None)
+        .unwrap();
+        let child = Verifying::from(id).verified::<!>(Some(&parent));
+
+        assert!(matches!(child, Err(error::Verify::RootMismatch { .. })))
+    }
+
+    #[test]
+    fn verified_parent_mismatch(
+        parent in gen_root_identity::<Revision>(),
+        bogus_replaces in any::<Revision>()
+    ) {
+        let parent = Verifying::from(parent).verified::<!>(None).unwrap();
+        let child = Verifying::from(parent.clone().into_inner().map(|doc| Doc {
+            replaces: Some(bogus_replaces),
+            ..doc
+        })).verified::<!>(Some(&parent));
+
+        assert!(matches!(child, Err(error::Verify::ParentMismatch { .. })))
+    }
+
+    #[test]
+    fn verified_parent_quorum_below_threshold(
+        (NonEmpty { head, tail }, num_sigs) in
+            gen_history(1).prop_flat_map(|hist| {
+                let threshold = hist.tail[0].quorum_threshold();
+                (Just(hist), 1..=threshold)
+            })
+    ) {
+        match tail.as_slice() {
+            [next] => {
+                let parent = Verifying::from(head).verified::<!>(None).unwrap();
+                let next = Identity {
+                    signatures: BTreeMap::from(next.signatures.clone())
+                        .into_iter()
+                        .take(num_sigs)
+                        .collect::<BTreeMap<_, _>>()
+                        .into(),
+                    ..next.clone()
+                };
+
+                assert!(matches!(
+                    Verifying::from(next).verified::<!>(Some(&parent)),
+                    Err(error::Verify::Quorum)
+                ))
+            },
+
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn verify(history in gen_history(0..10)) {
+        let NonEmpty { head, tail } = history;
+        let root = Verifying::from(head).verified::<!>(None).unwrap();
+        let expected = if tail.is_empty() {
+            root.clone().into_inner()
+        } else {
+            tail[tail.len() - 1].clone()
+        };
+        let folded = root
+            .verify(tail.into_iter().map(|x| Ok::<_, !>(Verifying::from(x))))
+            .unwrap();
+
+        assert_eq!(folded.head.into_inner(), expected)
+    }
+}

--- a/librad/src/identities/payload.rs
+++ b/librad/src/identities/payload.rs
@@ -337,6 +337,12 @@ impl DerefMut for UserDelegations {
     }
 }
 
+impl From<UserDelegations> for BTreeSet<PublicKey> {
+    fn from(UserDelegations(set): UserDelegations) -> Self {
+        set
+    }
+}
+
 impl<'de> serde::Deserialize<'de> for UserDelegations {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/librad/src/identities/payload.rs
+++ b/librad/src/identities/payload.rs
@@ -15,9 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-// clippy complains about the `Arbitrary` derive macro
-#![allow(clippy::unit_arg)]
-
 use std::{
     collections::{btree_map::Entry, BTreeMap, BTreeSet},
     convert::TryFrom,
@@ -37,7 +34,7 @@ use crate::{internal::canonical::Cstring, keys::PublicKey};
 use super::urn::{HasProtocol, Urn};
 
 #[cfg(test)]
-use proptest_derive::Arbitrary;
+use proptest::prelude::*;
 
 lazy_static! {
     /// Base [`Url`] for [`User`]
@@ -66,19 +63,57 @@ lazy_static! {
 /// Structure `radicle-link` expects to be part of a [`Payload`] describing a
 /// personal identity.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(test, derive(Arbitrary))]
 pub struct User {
     pub name: Cstring,
+}
+
+#[cfg(test)]
+impl Arbitrary for User {
+    type Parameters = ();
+    type Strategy = prop::strategy::Map<<Cstring as Arbitrary>::Strategy, fn(Cstring) -> Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any::<Cstring>().prop_map(|name| User { name })
+    }
 }
 
 /// Structure `radicle-link` expects to be part of a [`Payload`] describing a
 /// project identity.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(test, derive(Arbitrary))]
 pub struct Project {
     pub name: Cstring,
     pub description: Option<Cstring>,
     pub default_branch: Option<Cstring>,
+}
+
+#[cfg(test)]
+impl Arbitrary for Project {
+    type Parameters = ();
+    // Silly clippy: this _is_ a type definition
+    #[allow(clippy::type_complexity)]
+    type Strategy = prop::strategy::Map<
+        (
+            <Cstring as Arbitrary>::Strategy,
+            <Option<Cstring> as Arbitrary>::Strategy,
+            <Option<Cstring> as Arbitrary>::Strategy,
+        ),
+        fn((Cstring, Option<Cstring>, Option<Cstring>)) -> Self,
+    >;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        Strategy::prop_map(
+            (
+                any::<Cstring>(),
+                any::<Option<Cstring>>(),
+                any::<Option<Cstring>>(),
+            ),
+            |(name, description, default_branch)| Project {
+                name,
+                description,
+                default_branch,
+            },
+        )
+    }
 }
 
 /// Namespace attached to a member type of the [`Payload`] "open" coproduct.
@@ -503,8 +538,6 @@ mod tests {
 
     use librad_test::roundtrip::*;
     use pretty_assertions::assert_eq;
-    use proptest::prelude::*;
-    use proptest_derive::Arbitrary;
 
     use crate::{
         git::ext::oid::{tests::gen_oid, Oid},
@@ -518,10 +551,19 @@ mod tests {
             Url::parse("https://radicle.xyz/upstream/project/v1").unwrap();
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Arbitrary)]
+    #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
     struct UpstreamUser {
         #[serde(rename = "radicle-registry-name")]
         registered_as: Cstring,
+    }
+
+    impl Arbitrary for UpstreamUser {
+        type Parameters = ();
+        type Strategy = prop::strategy::Map<<Cstring as Arbitrary>::Strategy, fn(Cstring) -> Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            any::<Cstring>().prop_map(|registered_as| Self { registered_as })
+        }
     }
 
     impl HasNamespace for UpstreamUser {
@@ -530,10 +572,19 @@ mod tests {
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Arbitrary)]
+    #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
     struct UpstreamProject {
         #[serde(rename = "radicle-registry-name")]
         registered_as: Cstring,
+    }
+
+    impl Arbitrary for UpstreamProject {
+        type Parameters = ();
+        type Strategy = prop::strategy::Map<<Cstring as Arbitrary>::Strategy, fn(Cstring) -> Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            any::<Cstring>().prop_map(|registered_as| Self { registered_as })
+        }
     }
 
     impl HasNamespace for UpstreamProject {

--- a/librad/src/identities/sealed.rs
+++ b/librad/src/identities/sealed.rs
@@ -15,33 +15,4 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![feature(bool_to_option)]
-#![feature(btree_drain_filter)]
-#![feature(never_type)]
-
-#[macro_use]
-extern crate async_trait;
-#[macro_use]
-extern crate lazy_static;
-
-extern crate radicle_keystore as keystore;
-extern crate sodiumoxide;
-
-pub mod git;
-pub mod hash;
-pub mod identities;
-pub mod internal;
-pub mod keys;
-pub mod meta;
-pub mod net;
-pub mod paths;
-pub mod peer;
-pub mod signer;
-pub mod uri;
-
-#[cfg(test)]
-mod test;
-
-#[cfg(test)]
-#[macro_use]
-extern crate futures_await_test;
+pub trait Sealed {}

--- a/librad/src/identities/sign.rs
+++ b/librad/src/identities/sign.rs
@@ -1,0 +1,201 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    collections::BTreeMap,
+    convert::TryFrom,
+    iter::FromIterator,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{
+    de::{value::StrDeserializer, IntoDeserializer},
+    Deserialize,
+};
+
+use crate::{
+    git::trailer::{self, Token, Trailer},
+    keys::{self, PublicKey},
+};
+
+pub mod error;
+
+const TRAILER_TOKEN: &str = "X-Rad-Signature";
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Signature {
+    key: PublicKey,
+    sig: keys::Signature,
+}
+
+impl From<(PublicKey, keys::Signature)> for Signature {
+    fn from((key, sig): (PublicKey, keys::Signature)) -> Self {
+        Self { key, sig }
+    }
+}
+
+impl TryFrom<Trailer<'_>> for Signature {
+    type Error = error::Signature;
+
+    fn try_from(Trailer { values, .. }: Trailer) -> Result<Self, Self::Error> {
+        let mut iter = values.iter().flat_map(|val| val.split_whitespace());
+
+        let key = iter
+            .next()
+            .ok_or(error::Signature::Missing("public key"))
+            .and_then(|key| {
+                PublicKey::deserialize(
+                    key.deref().into_deserializer() as StrDeserializer<serde::de::value::Error>
+                )
+                .map_err(|e| e.into())
+            })?;
+        let sig = iter
+            .next()
+            .ok_or(error::Signature::Missing("signature"))
+            .and_then(|sig| {
+                keys::Signature::deserialize(
+                    sig.deref().into_deserializer() as StrDeserializer<serde::de::value::Error>
+                )
+                .map_err(|e| e.into())
+            })?;
+
+        Ok(Self { key, sig })
+    }
+}
+
+/// Lets us avoid writing `impl From<(&PublicKey, &keys::Signature)> for
+/// Trailer`. While that isn't an orphan because `Trailer` is defined in this
+/// crate, it is quite confusing nevertheless, and breaks modularity.
+struct SignatureRef<'a> {
+    key: &'a PublicKey,
+    sig: &'a keys::Signature,
+}
+
+impl<'a> From<&'a Signature> for SignatureRef<'a> {
+    fn from(Signature { key, sig }: &'a Signature) -> Self {
+        Self { key, sig }
+    }
+}
+
+impl<'a> From<(&'a PublicKey, &'a keys::Signature)> for SignatureRef<'a> {
+    fn from((key, sig): (&'a PublicKey, &'a keys::Signature)) -> Self {
+        Self { key, sig }
+    }
+}
+
+impl<'a> From<&'a Signature> for Trailer<'_> {
+    fn from(sig: &'a Signature) -> Self {
+        Self::from(SignatureRef::from(sig))
+    }
+}
+
+impl From<Signature> for Trailer<'_> {
+    fn from(sig: Signature) -> Self {
+        Self::from(SignatureRef::from(&sig))
+    }
+}
+
+impl<'a> From<SignatureRef<'a>> for Trailer<'_> {
+    fn from(SignatureRef { key, sig }: SignatureRef<'a>) -> Self {
+        Self {
+            token: Token::try_from(TRAILER_TOKEN).unwrap(),
+            values: vec![key.to_string().into(), sig.to_string().into()],
+        }
+    }
+}
+
+// FIXME(kim): This should really be a HashMap with a no-op Hasher -- PublicKey
+// collisions are catastrophic
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Signatures(BTreeMap<PublicKey, keys::Signature>);
+
+impl Signatures {
+    pub fn from_trailers(message: &str) -> Result<Self, error::Signatures> {
+        Self::try_from(trailer::parse(message, ":")?)
+    }
+}
+
+impl Deref for Signatures {
+    type Target = BTreeMap<PublicKey, keys::Signature>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Signatures {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<BTreeMap<PublicKey, keys::Signature>> for Signatures {
+    fn from(map: BTreeMap<PublicKey, keys::Signature>) -> Self {
+        Self(map)
+    }
+}
+
+impl From<Signatures> for BTreeMap<PublicKey, keys::Signature> {
+    fn from(s: Signatures) -> Self {
+        s.0
+    }
+}
+
+impl TryFrom<Vec<Trailer<'_>>> for Signatures {
+    type Error = error::Signatures;
+
+    fn try_from(trailers: Vec<Trailer>) -> Result<Self, Self::Error> {
+        trailers
+            .into_iter()
+            .filter(|t| t.token.deref() == TRAILER_TOKEN)
+            .map(|trailer| {
+                Signature::try_from(trailer)
+                    .map(|Signature { key, sig }| (key, sig))
+                    .map_err(error::Signatures::from)
+            })
+            .collect()
+    }
+}
+
+impl FromIterator<(PublicKey, keys::Signature)> for Signatures {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (PublicKey, keys::Signature)>,
+    {
+        Self(BTreeMap::from_iter(iter))
+    }
+}
+
+impl<'a> From<&'a Signatures> for Vec<Trailer<'a>> {
+    fn from(sigs: &'a Signatures) -> Self {
+        sigs.deref()
+            .iter()
+            .map(SignatureRef::from)
+            .map(Trailer::from)
+            .collect()
+    }
+}
+
+impl From<Signatures> for Vec<Trailer<'_>> {
+    fn from(sigs: Signatures) -> Self {
+        sigs.0
+            .into_iter()
+            .map(Signature::from)
+            .map(Trailer::from)
+            .collect()
+    }
+}

--- a/librad/src/identities/sign/error.rs
+++ b/librad/src/identities/sign/error.rs
@@ -15,33 +15,24 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![feature(bool_to_option)]
-#![feature(btree_drain_filter)]
-#![feature(never_type)]
+use thiserror::Error;
 
-#[macro_use]
-extern crate async_trait;
-#[macro_use]
-extern crate lazy_static;
+use crate::git::trailer;
 
-extern crate radicle_keystore as keystore;
-extern crate sodiumoxide;
+#[derive(Debug, Error)]
+pub enum Signature {
+    #[error("missing {0}")]
+    Missing(&'static str),
 
-pub mod git;
-pub mod hash;
-pub mod identities;
-pub mod internal;
-pub mod keys;
-pub mod meta;
-pub mod net;
-pub mod paths;
-pub mod peer;
-pub mod signer;
-pub mod uri;
+    #[error(transparent)]
+    Serde(#[from] serde::de::value::Error),
+}
 
-#[cfg(test)]
-mod test;
+#[derive(Debug, Error)]
+pub enum Signatures {
+    #[error(transparent)]
+    Trailer(#[from] trailer::Error),
 
-#[cfg(test)]
-#[macro_use]
-extern crate futures_await_test;
+    #[error(transparent)]
+    Signature(#[from] Signature),
+}

--- a/librad/src/internal/canonical.rs
+++ b/librad/src/internal/canonical.rs
@@ -26,6 +26,9 @@ use serde_bytes::ByteBuf;
 use thiserror::Error;
 use unicode_normalization::UnicodeNormalization;
 
+#[cfg(test)]
+use proptest::prelude::*;
+
 pub mod formatter;
 
 /// Types which have a canonical representation
@@ -148,14 +151,16 @@ where
 /// [Unicode Standard Annex #15]: http://www.unicode.org/reports/tr15/
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
 #[serde(transparent)]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub struct Cstring(#[cfg_attr(test, proptest(strategy(gen_cstring)))] String);
+pub struct Cstring(String);
 
 #[cfg(test)]
-fn gen_cstring() -> impl proptest::strategy::Strategy<Value = String> {
-    use proptest::prelude::*;
+impl Arbitrary for Cstring {
+    type Parameters = ();
+    type Strategy = prop::strategy::Map<&'static str, fn(String) -> Self>;
 
-    ".*".prop_map(|s| s.nfc().collect())
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        ".*".prop_map(|s| Cstring(s.nfc().collect()))
+    }
 }
 
 impl<'de> serde::Deserialize<'de> for Cstring {
@@ -239,10 +244,8 @@ mod tests {
 
     use librad_test::roundtrip::*;
     use pretty_assertions::assert_eq;
-    use proptest::prelude::*;
-    use proptest_derive::Arbitrary;
 
-    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, Arbitrary)]
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
     struct T {
         #[serde(deserialize_with = "string::deserialize")]
         field: String,
@@ -254,6 +257,10 @@ mod tests {
                 field: self.field.nfc().collect(),
             }
         }
+    }
+
+    fn gen_t() -> impl Strategy<Value = T> {
+        ".*".prop_map(|field| T { field })
     }
 
     proptest! {
@@ -273,7 +280,7 @@ mod tests {
         }
 
         #[test]
-        fn any_string_roundtrip_json(t in any::<T>()) {
+        fn any_string_roundtrip_json(t in gen_t()) {
             let ser = serde_json::to_string(&t).unwrap();
             let de = serde_json::from_str(&ser).unwrap();
 
@@ -281,7 +288,7 @@ mod tests {
         }
 
         #[test]
-        fn any_string_roundtrip_cjson(t in any::<T>()) {
+        fn any_string_roundtrip_cjson(t in gen_t()) {
             let canonical = Cjson(&t).canonical_form().unwrap();
 
             assert_eq!(t.normalised(), serde_json::from_slice(&canonical).unwrap())


### PR DESCRIPTION
Aims to define all git-independent aspects of the identities system
generically, such that we can reason about it sans IO. The respective
modules are not part of the surface API of `librad`, and may later be
hidden (modulo `rustdoc` rendering).
