### PR TITLE
Derive all Arbitrary impls by hand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "e742194e0f43fc932bcb801708c2b279d3ec8f527e3acda05a6a9f342c5ef764"
 dependencies = [
  "argh_shared",
  "heck",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -95,9 +95,9 @@ version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -307,8 +307,8 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
 dependencies = [
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -347,7 +347,7 @@ checksum = "8d2d6daefd5f1d4b74a891a5d2ab7dccba028d423107c074232a0c5dc0d40a9e"
 dependencies = [
  "data-encoding",
  "proc-macro-hack",
- "syn 1.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -420,10 +420,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "rustversion",
- "syn 1.0.38",
+ "syn",
  "synstructure",
 ]
 
@@ -486,9 +486,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f150175e6832600500334550e00e4dc563a0b32f58a9d1ad407f6473378c839"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -532,9 +532,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -840,7 +840,6 @@ dependencies = [
  "percent-encoding 2.1.0",
  "pretty_assertions",
  "proptest",
- "proptest-derive",
  "quinn",
  "radicle-keystore",
  "rand",
@@ -961,9 +960,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3436a67b46fbf4b5cc25a37341b3daf0371496dac1161422b96225dde8f603ee"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1224,9 +1223,9 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1272,9 +1271,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -1284,8 +1283,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "version_check",
 ]
 
@@ -1303,20 +1302,11 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1337,17 +1327,6 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
-]
-
-[[package]]
-name = "proptest-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d9d20dbe9e9dfe594328b6eaab72ccf571fee818991dd1c1ba5469b5f32d4"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
 ]
 
 [[package]]
@@ -1400,20 +1379,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1668,9 +1638,9 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1766,9 +1736,9 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1887,24 +1857,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "unicode-xid 0.2.1",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1913,10 +1872,10 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
- "unicode-xid 0.2.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1957,9 +1916,9 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2017,9 +1976,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2054,9 +2013,9 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fe233f4227389ab7df5b32649239da7ebe0b281824b4e84b342d04d3fd8c25e"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2149,12 +2108,6 @@ name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -2252,9 +2205,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2264,7 +2217,7 @@ version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
 dependencies = [
- "quote 1.0.7",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2274,9 +2227,9 @@ version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -104,7 +104,6 @@ futures-await-test = "0"
 futures_ringbuf = "0"
 pretty_assertions = "0"
 proptest = "0"
-proptest-derive = "0"
 tempfile = "3.1"
 
 [dev-dependencies.librad-test]

--- a/librad/src/identities/generic/gen.rs
+++ b/librad/src/identities/generic/gen.rs
@@ -24,7 +24,6 @@ use std::{
 use either::Either::{self, *};
 use nonempty::NonEmpty;
 use proptest::prelude::*;
-use proptest_derive::Arbitrary;
 
 use super::*;
 use crate::{
@@ -33,8 +32,17 @@ use crate::{
 };
 
 /// A completely irrelevant value.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Arbitrary)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Boring;
+
+impl Arbitrary for Boring {
+    type Parameters = ();
+    type Strategy = fn() -> Self;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        || Boring
+    }
+}
 
 impl Display for Boring {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -74,8 +82,17 @@ where
 }
 
 /// A revision that looks a bit like a git SHA1, but is faster to generate.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Arbitrary)]
-pub struct Revision(#[proptest(regex = "[a-z0-9]{40}")] String);
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Revision(String);
+
+impl Arbitrary for Revision {
+    type Parameters = ();
+    type Strategy = prop::strategy::Map<&'static str, fn(String) -> Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        "[a-z0-9]{40}".prop_map(Self)
+    }
+}
 
 impl AsRef<[u8]> for Revision {
     fn as_ref(&self) -> &[u8] {

--- a/librad/src/internal/canonical.rs
+++ b/librad/src/internal/canonical.rs
@@ -26,6 +26,9 @@ use serde_bytes::ByteBuf;
 use thiserror::Error;
 use unicode_normalization::UnicodeNormalization;
 
+#[cfg(test)]
+use proptest::prelude::*;
+
 pub mod formatter;
 
 /// Types which have a canonical representation
@@ -148,14 +151,16 @@ where
 /// [Unicode Standard Annex #15]: http://www.unicode.org/reports/tr15/
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
 #[serde(transparent)]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub struct Cstring(#[cfg_attr(test, proptest(strategy(gen_cstring)))] String);
+pub struct Cstring(String);
 
 #[cfg(test)]
-fn gen_cstring() -> impl proptest::strategy::Strategy<Value = String> {
-    use proptest::prelude::*;
+impl Arbitrary for Cstring {
+    type Parameters = ();
+    type Strategy = prop::strategy::Map<&'static str, fn(String) -> Self>;
 
-    ".*".prop_map(|s| s.nfc().collect())
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        ".*".prop_map(|s| Cstring(s.nfc().collect()))
+    }
 }
 
 impl<'de> serde::Deserialize<'de> for Cstring {
@@ -239,10 +244,8 @@ mod tests {
 
     use librad_test::roundtrip::*;
     use pretty_assertions::assert_eq;
-    use proptest::prelude::*;
-    use proptest_derive::Arbitrary;
 
-    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, Arbitrary)]
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
     struct T {
         #[serde(deserialize_with = "string::deserialize")]
         field: String,
@@ -254,6 +257,10 @@ mod tests {
                 field: self.field.nfc().collect(),
             }
         }
+    }
+
+    fn gen_t() -> impl Strategy<Value = T> {
+        ".*".prop_map(|field| T { field })
     }
 
     proptest! {
@@ -273,7 +280,7 @@ mod tests {
         }
 
         #[test]
-        fn any_string_roundtrip_json(t in any::<T>()) {
+        fn any_string_roundtrip_json(t in gen_t()) {
             let ser = serde_json::to_string(&t).unwrap();
             let de = serde_json::from_str(&ser).unwrap();
 
@@ -281,7 +288,7 @@ mod tests {
         }
 
         #[test]
-        fn any_string_roundtrip_cjson(t in any::<T>()) {
+        fn any_string_roundtrip_cjson(t in gen_t()) {
             let canonical = Cjson(&t).canonical_form().unwrap();
 
             assert_eq!(t.normalised(), serde_json::from_slice(&canonical).unwrap())


### PR DESCRIPTION
Derive macros somehow interfere with typechecker error reporting, for
some reason even when the type being impl'd is not related at all.
`proptest_derive::Arbitrary` is the worst offender, although `serde`
derive macros leak as well.

Henceforth, macros shallt generally be frowned upon in this library, an
`proptest_derive` permanently banned.
