### PR TITLE
PeerApi: Require timeout for providers query

### DIFF
--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -20,13 +20,15 @@ use std::{
     io,
     net::{IpAddr, SocketAddr},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use either::Either;
 use futures::{
-    future::{self, BoxFuture},
+    future::{self, BoxFuture, FutureExt},
     stream::StreamExt,
 };
+use futures_timer::Delay;
 use thiserror::Error;
 use tracing_futures::Instrument as _;
 
@@ -191,25 +193,47 @@ where
     /// [`RadUrn`] actually has it, nor that it is reachable using any of
     /// the addresses contained in [`PeerInfo`]. The implementation may
     /// change in the future to answer the query from a local cache first.
+    ///
+    /// The returned [`futures::Stream`] will be complete after the supplied
+    /// `timeout` has elapsed, whether or not any responses have been yielded
+    /// thus far. This is to prevent callers from polling the stream
+    /// indefinitely, even though no more responses can be expected. A realistic
+    /// timeout value is in the order of 10s of seconds.
     pub fn providers(
         &self,
         urn: RadUrn,
+        timeout: Duration,
     ) -> impl Future<Output = impl futures::Stream<Item = PeerInfo<IpAddr>>> {
         let span = tracing::trace_span!("PeerApi::providers", urn = %urn);
         let protocol = self.protocol.clone();
         let target_urn = urn.clone();
 
         async move {
-            let providers = protocol.subscribe().await.filter_map(move |evt| {
-                future::ready(match evt {
-                    ProtocolEvent::Gossip(gossip::Info::Has(gossip::Has { provider, val }))
-                        if val.urn == urn =>
-                    {
-                        Some(provider)
-                    },
-                    _ => None,
-                })
-            });
+            let providers = futures::stream::select(
+                futures::stream::once(
+                    async move {
+                        Delay::new(timeout).await;
+                        Err("timed out")
+                    }
+                    .boxed(),
+                ),
+                protocol
+                    .subscribe()
+                    .await
+                    .filter_map(move |evt| {
+                        future::ready(match evt {
+                            ProtocolEvent::Gossip(gossip::Info::Has(gossip::Has {
+                                provider,
+                                val,
+                            })) if val.urn == urn => Some(provider),
+                            _ => None,
+                        })
+                    })
+                    .map(Ok),
+            )
+            .take_while(|x| future::ready(x.is_ok()))
+            .map(Result::unwrap);
+
             protocol
                 .query(Gossip {
                     urn: target_urn,

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -19,8 +19,9 @@
 #[macro_use]
 extern crate async_trait;
 
+use std::{collections::HashSet, io, net::SocketAddr, path::PathBuf, time::Duration, vec};
+
 use futures::stream::StreamExt;
-use std::{collections::HashSet, io, net::SocketAddr, path::PathBuf, vec};
 use thiserror::Error;
 
 use radicle_keystore::sign::ed25519;
@@ -248,7 +249,7 @@ impl Node {
                 tracing::info!("Initializing tracker with {} URNs..", urns.len());
 
                 for urn in urns {
-                    let mut peers = api.providers(urn.clone()).await;
+                    let mut peers = api.providers(urn.clone(), Duration::from_secs(30)).await;
                     // Attempt to track until we succeed.
                     while let Some(peer) = peers.next().await {
                         if Node::track_project(&api, urn, &peer).is_ok() {


### PR DESCRIPTION
It does not make sense to poll the responses stream for more than a
couple of seconds.
