### PR TITLE
Adds 'libiconv' to Nix shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,11 +5,10 @@ let
   moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/4521bc61c2332f41e18664812a808294c8c78580.tar.gz);
   pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
 in
-  with pkgs;
-  stdenv.mkDerivation {
+  pkgs.stdenv.mkDerivation {
     name = "clang-env-with-nightly-rust";
-    buildInputs = [
-      (pkgs.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust
+    buildInputs = with pkgs; [
+      (rustChannelOf { rustToolchain = ./rust-toolchain; }).rust
       clang
       llvmPackages.libclang
       olm

--- a/default.nix
+++ b/default.nix
@@ -18,6 +18,7 @@ in
       m4
       libiconv
       cargo-watch
+      cacert
     ];
     # why do we need to set the library path manually?
     shellHook = ''

--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,7 @@ in
       gmp
       m4
       libiconv
+      cargo-watch
     ];
     # why do we need to set the library path manually?
     shellHook = ''

--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,7 @@ in
       openssl
       gmp
       m4
+      libiconv
     ];
     # why do we need to set the library path manually?
     shellHook = ''


### PR DESCRIPTION
I tried building this repository on macOS for the first time and I ran into a compilation error when building the 
`libgit2-sys` crate:

<details>
<summary>Cargo Error Log Snippet</summary>
<p>

```
TARGET = Some("x86_64-apple-darwin")
OPT_LEVEL = Some("0")
HOST = Some("x86_64-apple-darwin")
CC_x86_64-apple-darwin = None
CC_x86_64_apple_darwin = None
HOST_CC = None
CC = Some("clang")
CFLAGS_x86_64-apple-darwin = None
CFLAGS_x86_64_apple_darwin = None
HOST_CFLAGS = None
CFLAGS = None
CRATE_CC_NO_DEFAULTS = None
DEBUG = Some("true")
running: "clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=x86_64-apple-darwin" "-I" "/Users/jkachmar/src/radicle-link/target/debug/build/libgit2-sys-bec8595a366d44df/out/include" "-I" "libgit2/src" "-I" "libgit2/deps/http-parser" "-I" "libgit2/deps/pcre" "-I" "/Users/jkachmar/src/radicle-link/target/debug/build/libz-sys-c4af3bc80a8004b2/out/include" "-fvisibility=hidden" "-DGIT_REGEX_BUILTIN=1" "-DHAVE_STDINT_H=1" "-DHAVE_MEMMOVE=1" "-DNO_RECURSE=1" "-DNEWLINE=10" "-DPOSIX_MALLOC_THRESHOLD=10" "-DLINK_SIZE=2" "-DPARENS_NEST_LIMIT=250" "-DMATCH_LIMIT=10000000" "-DMATCH_LIMIT_RECURSION=MATCH_LIMIT" "-DMAX_NAME_SIZE=32" "-DMAX_NAME_COUNT=10000" "-DSHA1DC_NO_STANDARD_INCLUDES=1" "-DSHA1DC_CUSTOM_INCLUDE_SHA1_C=\"common.h\"" "-DSHA1DC_CUSTOM_INCLUDE_UBC_CHECK_C=\"common.h\"" "-o" "/Users/jkachmar/src/radicle-link/target/debug/build/libgit2-sys-bec8595a366d44df/out/build/libgit2/src/commit_list.o" "-c" "libgit2/src/commit_list.c"
running: "clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=x86_64-apple-darwin" "-I" "/Users/jkachmar/src/radicle-link/target/debug/build/libgit2-sys-bec8595a366d44df/out/include" "-I" "libgit2/src" "-I" "libgit2/deps/http-parser" "-I" "libgit2/deps/pcre" "-I" "/Users/jkachmar/src/radicle-link/target/debug/build/libz-sys-c4af3bc80a8004b2/out/include" "-fvisibility=hidden" "-DGIT_REGEX_BUILTIN=1" "-DHAVE_STDINT_H=1" "-DHAVE_MEMMOVE=1" "-DNO_RECURSE=1" "-DNEWLINE=10" "-DPOSIX_MALLOC_THRESHOLD=10" "-DLINK_SIZE=2" "-DPARENS_NEST_LIMIT=250" "-DMATCH_LIMIT=10000000" "-DMATCH_LIMIT_RECURSION=MATCH_LIMIT" "-DMAX_NAME_SIZE=32" "-DMAX_NAME_COUNT=10000" "-DSHA1DC_NO_STANDARD_INCLUDES=1" "-DSHA1DC_CUSTOM_INCLUDE_SHA1_C=\"common.h\"" "-DSHA1DC_CUSTOM_INCLUDE_UBC_CHECK_C=\"common.h\"" "-o" "/Users/jkachmar/src/radicle-link/target/debug/build/libgit2-sys-bec8595a366d44df/out/build/libgit2/src/merge_driver.o" "-c" "libgit2/src/merge_driver.c"
cargo:warning=In file included from libgit2/src/commit_list.c:12:
cargo:warning=In file included from libgit2/src/odb.h:19:
cargo:warning=In file included from libgit2/src/filter.h:12:
cargo:warning=In file included from libgit2/src/attr_file.h:17:
cargo:warning=In file included from libgit2/src/futils.h:14:
cargo:warning=libgit2/src/path.h:430:10: fatal error: 'iconv.h' file not found
cargo:warning=#include <iconv.h>
cargo:warning=         ^~~~~~~~~
cargo:warning=1 error generated.
cargo:warning=In file included from libgit2/src/merge_driver.c:12:
cargo:warning=In file included from libgit2/src/merge.h:15:
cargo:warning=In file included from libgit2/src/iterator.h:15:
cargo:warning=In file included from libgit2/src/ignore.h:12:
cargo:warning=In file included from libgit2/src/repository.h:24:
cargo:warning=In file included from libgit2/src/attrcache.h:12:
cargo:warning=In file included from libgit2/src/attr_file.h:17:
cargo:warning=In file included from libgit2/src/futils.h:14:
cargo:warning=libgit2/src/path.h:430:10: fatal error: 'iconv.h' file not found
cargo:warning=#include <iconv.h>
cargo:warning=         ^~~~~~~~~
exit code: 1
running: "clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=x86_64-apple-darwin" "-I" "/Users/jkachmar/src/radicle-link/target/debug/build/libgit2-sys-bec8595a366d44df/out/include" "-I" "libgit2/src" "-I" "libgit2/deps/http-parser" "-I" "libgit2/deps/pcre" "-I" "/Users/jkachmar/src/radicle-link/target/debug/build/libz-sys-c4af3bc80a8004b2/out/include" "-fvisibility=hidden" "-DGIT_REGEX_BUILTIN=1" "-DHAVE_STDINT_H=1" "-DHAVE_MEMMOVE=1" "-DNO_RECURSE=1" "-DNEWLINE=10" "-DPOSIX_MALLOC_THRESHOLD=10" "-DLINK_SIZE=2" "-DPARENS_NEST_LIMIT=250" "-DMATCH_LIMIT=10000000" "-DMATCH_LIMIT_RECURSION=MATCH_LIMIT" "-DMAX_NAME_SIZE=32" "-DMAX_NAME_COUNT=10000" "-DSHA1DC_NO_STANDARD_INCLUDES=1" "-DSHA1DC_CUSTOM_INCLUDE_SHA1_C=\"common.h\"" "-DSHA1DC_CUSTOM_INCLUDE_UBC_CHECK_C=\"common.h\"" "-o" "/Users/jkachmar/src/radicle-link/target/debug/build/libgit2-sys-bec8595a366d44df/out/build/libgit2/src/proxy.o" "-c" "libgit2/src/proxy.c"
cargo:warning=1 error generated.
exit code: 1
```

</details>
</p>

After I added `libiconv` to Nix shell's `buildInputs` everything seemed to compile just fine (at least as far as `cargo watch -c` is concerned, I haven't tested anything more than that yet).