### PR TITLE
Storage Tests

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -555,6 +555,10 @@ where
             uri::Path::empty(),
         );
 
+        if self.has_urn(&urn)? {
+            return Err(Error::AlreadyExists(urn));
+        }
+
         let self_sig = meta
             .signatures()
             .get(&self.signer.public_key().into())


### PR DESCRIPTION
Added tests to confirm the setting of default rad/self and checking if a URN exists when calling `create_repo` twice. Turns out there was a bug in the latter so I'm including the fix.