### PR TITLE
Add method to paths for git includes

### DIFF
--- a/librad/src/paths.rs
+++ b/librad/src/paths.rs
@@ -80,6 +80,10 @@ impl Paths {
         &self.git_dir
     }
 
+    pub fn git_include_dir(&self) -> &Path {
+        &self.git_includes_dir
+    }
+
     pub fn all_dirs(&self) -> HashMap<&str, &Path> {
         // Nb. this pattern match is here to keep the map consistent with the
         // struct fields

--- a/librad/src/paths.rs
+++ b/librad/src/paths.rs
@@ -80,7 +80,7 @@ impl Paths {
         &self.git_dir
     }
 
-    pub fn git_include_dir(&self) -> &Path {
+    pub fn git_includes_dir(&self) -> &Path {
         &self.git_includes_dir
     }
 


### PR DESCRIPTION
As a follow-up to #329  and a more convenient way to get the underlying
`&Path` than using `all_dirs`.
