### PR TITLE
Add helper to set include directive

### DIFF
--- a/librad/src/git/include.rs
+++ b/librad/src/git/include.rs
@@ -30,6 +30,9 @@ use crate::{
     peer::PeerId,
 };
 
+/// Config key to reference generated include files in working copies.
+const GIT_CONFIG_PATH_KEY: &str = "include.path";
+
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
@@ -139,6 +142,14 @@ impl<Path> Include<Path> {
             local_url,
         }
     }
+}
+
+/// Adds an include directive to the `repo`.
+pub fn set_include_path(repo: &git2::Repository, include_path: PathBuf) -> Result<(), Error> {
+    let mut config = repo.config().unwrap();
+    config
+        .set_str(GIT_CONFIG_PATH_KEY, &format!("{}", include_path.display()))
+        .map_err(Error::from)
 }
 
 fn remote_prefix(remote: &Remote<LocalUrl>) -> String {

--- a/librad/src/git/include.rs
+++ b/librad/src/git/include.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 /// Config key to reference generated include files in working copies.
-const GIT_CONFIG_PATH_KEY: &str = "include.path";
+pub const GIT_CONFIG_PATH_KEY: &str = "include.path";
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/librad/tests/working_copy.rs
+++ b/librad/tests/working_copy.rs
@@ -28,7 +28,7 @@ use tempfile::tempdir;
 
 use librad::{
     git::{
-        include::Include,
+        include,
         local::{transport, url::LocalUrl},
         types::{remote::Remote, FlatRef, Force, NamespacedRef},
     },
@@ -169,15 +169,12 @@ async fn can_fetch() {
             repo: radicle.urn().id,
             local_peer_id: peer2.peer_id().clone(),
         };
-        let include = Include::from_tracked_users(tmp.path(), url, tracked_users.into_iter());
-        let include_file = include.file_path();
-        include.save().unwrap();
+        let inc = include::Include::from_tracked_users(tmp.path(), url, tracked_users.into_iter());
+        let inc_path = inc.file_path();
+        inc.save().unwrap();
 
         // Add the include above to include.path of the repo config
-        let mut config = repo.config().unwrap();
-        config
-            .set_str("include.path", &format!("{}", include_file.display()))
-            .unwrap();
+        include::set_include_path(&repo, inc_path).unwrap();
 
         // Fetch from the working copy and check we have the commit in the working copy
         for remote in repo.remotes().unwrap().iter() {


### PR DESCRIPTION
Commonly in tandem to the generation of the include file itself, working
copies need to be equipped with an include directive pointing to said
files. To avoid miss-spellings in the config key this change exports
a helper for that.