### PR TITLE
Menage a troi

### DIFF
--- a/librad-test/src/git.rs
+++ b/librad-test/src/git.rs
@@ -1,0 +1,53 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use librad::git::{local::url::LocalUrl, types::remote::Remote};
+
+pub fn initial_commit(
+    repo: &git2::Repository,
+    remote: Remote<LocalUrl>,
+    reference: &str,
+    remote_callbacks: Option<git2::RemoteCallbacks>,
+) -> Result<git2::Oid, git2::Error> {
+    let mut remote = remote.create(&repo)?;
+
+    let commit_id = {
+        let empty_tree = {
+            let mut index = repo.index()?;
+            let oid = index.write_tree()?;
+            repo.find_tree(oid).unwrap()
+        };
+        let author = git2::Signature::now("The Animal", "animal@muppets.com").unwrap();
+        repo.commit(
+            Some(reference),
+            &author,
+            &author,
+            "Initial commit",
+            &empty_tree,
+            &[],
+        )?
+    };
+
+    let mut opts = git2::PushOptions::new();
+    let opts = match remote_callbacks {
+        Some(cb) => opts.remote_callbacks(cb),
+        None => &mut opts,
+    };
+    remote.push(&[reference], Some(opts))?;
+
+    Ok(commit_id)
+}

--- a/librad-test/src/lib.rs
+++ b/librad-test/src/lib.rs
@@ -18,6 +18,7 @@
 #[macro_use]
 extern crate lazy_static;
 
+pub mod git;
 pub mod logging;
 pub mod rad;
 pub mod roundtrip;

--- a/librad/src/git/storage/fetch.rs
+++ b/librad/src/git/storage/fetch.rs
@@ -99,11 +99,12 @@ impl<'a> Fetcher<'a> {
         Ok(())
     }
 
-    /// Fetch remote heads according to the remote's signed `rad/refs` branch.
+    /// Fetch remote heads according to the remote's signed `rad/signed_refs`
+    /// branch.
     ///
     /// Proceeds in three stages:
     ///
-    /// 1. fetch the remote's view of `rad/refs`
+    /// 1. fetch the remote's view of `rad/signed_refs`
     /// 2. compare the signed refs against the advertised ones
     /// 3. fetch advertised refs ⋂ signed refs
     pub fn fetch<F, G, E>(
@@ -122,7 +123,7 @@ impl<'a> Fetcher<'a> {
 
         let mut fetch_opts = self.fetch_options();
 
-        // Fetch `rad/refs` first
+        // Fetch `rad/signed_refs` first
         {
             let refspecs = Refspec::rad_signed_refs(
                 self.url.repo.clone(),

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -213,14 +213,19 @@ impl Refspec<PeerId, PeerId> {
             // Heads
             //
             // `+refs/namespaces/<namespace>/refs[/remotes/<peer>]/heads/* \
-            // :refs/namespaces/<namespace>/refs/remotes/<peer>/refs/heads/*`
+            // :refs/namespaces/<namespace>/refs/remotes/<peer>/heads/*`
             {
                 let their_singed_rad_refs = rad_signed_refs_of(tracked_peer.clone())?;
                 for (name, target) in their_singed_rad_refs.heads {
                     let name_namespaced = format!("refs/namespaces/{}/{}", namespace, name);
                     if let Some(name) = name.strip_prefix("refs/heads/") {
+                        let name_namespaced_remote = format!(
+                            "refs/namespaces/{}/refs/remotes/{}/heads/{}",
+                            namespace, tracked_peer, name
+                        );
                         let targets_match = remote_heads
                             .get(name_namespaced.as_str())
+                            .or_else(|| remote_heads.get(name_namespaced_remote.as_str()))
                             .map(|remote_target| remote_target == &*target)
                             .unwrap_or(false);
 

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -447,7 +447,7 @@ async fn ask_and_clone() {
     .await;
 }
 
-#[tokio::test(core_threads = 3)]
+#[tokio::test(core_threads = 2)]
 async fn menage_a_troi() {
     logging::init();
 

--- a/librad/tests/working_copy.rs
+++ b/librad/tests/working_copy.rs
@@ -39,6 +39,7 @@ use librad::{
 };
 
 use librad_test::{
+    git::initial_commit,
     logging,
     rad::{
         entity::{Alice, Radicle},
@@ -206,42 +207,6 @@ async fn can_fetch() {
         assert!(repo.find_commit(commit_id).is_ok());
     })
     .await;
-}
-
-// Check out a working copy on peer1, add a commit, and push it
-fn initial_commit(
-    repo: &git2::Repository,
-    remote: Remote<LocalUrl>,
-    reference: &str,
-    remote_callbacks: Option<git2::RemoteCallbacks>,
-) -> Result<git2::Oid, git2::Error> {
-    let mut remote = remote.create(&repo)?;
-
-    let commit_id = {
-        let empty_tree = {
-            let mut index = repo.index()?;
-            let oid = index.write_tree()?;
-            repo.find_tree(oid).unwrap()
-        };
-        let author = git2::Signature::now("The Animal", "animal@muppets.com").unwrap();
-        repo.commit(
-            Some(reference),
-            &author,
-            &author,
-            "Initial commit",
-            &empty_tree,
-            &[],
-        )?
-    };
-
-    let mut opts = git2::PushOptions::new();
-    let opts = match remote_callbacks {
-        Some(cb) => opts.remote_callbacks(cb),
-        None => &mut opts,
-    };
-    remote.push(&[reference], Some(opts))?;
-
-    Ok(commit_id)
 }
 
 // Wait for peer2 to receive the gossip announcement


### PR DESCRIPTION
We add a test that does the following:
* Peer 1 creates a project
* Peer 1 makes a commit to their default branch
* Peer 2 clones from Peer 1
* Peer 3 clones from Peer 2

The expectation is that Peer 2 has Peer 1's `heads/*`, which it does.
It is also expected that Peer 3 has Peer 1's `heads/*`, which it doesn't.