### PR TITLE
Gossip: Quick fix to not remember local peer as "known"

### DIFF
--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -776,7 +776,11 @@ where
     }
 
     async fn add_known<I: IntoIterator<Item = PeerInfo<Addr>>>(&self, peers: I) {
-        self.known_peers.lock().await.insert(peers)
+        self.known_peers.lock().await.insert(
+            peers
+                .into_iter()
+                .filter(|info| &info.peer_id != self.peer_id()),
+        )
     }
 
     async fn sample_known(&self) -> Vec<PeerInfo<Addr>> {


### PR DESCRIPTION
We can't connect to ourselves, so there is no point in remembering. This
invariant should probably be maintained by the `KnownPeers` datastructure,
but this will do as a quick fix.
