### PR TITLE
Make PublicKey & PeerId Copy

### DIFF
--- a/docs/spec/identities.md
+++ b/docs/spec/identities.md
@@ -143,8 +143,8 @@ be removed.
 
 ### Doc Payload
 
-The `Doc` payload MUST include the following structures for interpretation by
-the protocol:
+The `Doc` payload MUST include one of the following structures (but not both)
+for interpretation by the protocol:
 
 ```rust
 struct User {

--- a/docs/spec/identities.md
+++ b/docs/spec/identities.md
@@ -88,7 +88,58 @@ sections.
 
 The `root` of a verified `Identity` is the stable identifier of the repository.
 
-> **TODO** Insert specification of URNs here
+### Radicle URNs
+
+Identities are addressable within the Radicle Network by their stable identifier,
+encoded as a URN. Radicle URNs are syntactically and functionally equivalent to
+URNs as per [@rfc8141], although we have no intention of registering our
+namespace with the IANA. r-, q-, and f-components are not currently honoured by
+the protocol, and MAY be discarded by recipients.
+
+The syntax of a Radicle URN is defined as follows:
+
+    "rad" ":" protocol ":" root [ "/" path ]
+
+where:
+
+    protocol = "git"
+    root     = MULTIBASE(MULTIHASH(id))
+    path     = pct-encoded
+    id       = BYTES
+
+The `id` is the `root` field of a verified `Identity`, as specified previously.
+The `MULTIBASE` and `MULTIHASH` encodings are specified in [@multibase] and
+[@multihash], respectively. The preferred alphabet for the multibase encoding is
+[@z-base32]. `pct-encoded` is defined in [@rfc3986], and the equivalence rules
+as per [@rfc8141] apply.
+
+Within the "git" `protocol` context, the `path` component is interpreted as a
+`git` reference (ref), and MUST thus conform to the refname rules as described
+in [git-check-ref-format], as if no arguments were given. The prefix "refs/" MAY
+be omitted, but not the refs category (i.e. "heads/master" is permitted, but
+"master" is not). Valid ref categories are:
+
+    * heads
+    * tags
+    * remotes
+    * rad
+
+An invalid ref category is treated as non-existent.
+
+Without a `path`, a URN is to be treated as if the default value "rad/id" was
+given.
+
+Before resolving a `path` to a ref in local storage, the percent-encoding SHALL
+be removed.
+
+#### Examples
+
+    rad:git:hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try
+    rad:git:hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try/refs/heads/next
+    rad:git:hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try/heads/next
+    rad:git:hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try/tags/v0.0.1
+    rad:git:hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try/remotes/hwd1yreb5ugudg6xewxiwotj97iaj31phjdphdiej44x1acer3i45uqnwxw/heads/pu
+    rad:git:hwd1yreb5ugudg6xewxiwotj97iaj31phjdphdiej44x1acer3i45uqnwxw/rad/id
 
 ### Doc Payload
 
@@ -554,6 +605,7 @@ tree notes to reflect the new state.
 
 [git-interpret-trailers]: https://git-scm.com/docs/git-interpret-trailers
 [git-notes]: https://git-scm.com/docs/git-notes
+[git-check-ref-format]: https://git-scm.com/docs/git-check-ref-format
 [radicle-registry]: https://github.com/radicle-dev/radicle-registry
 [subtree]: https://git-scm.com/docs/git-merge#Documentation/git-merge.txt-subtree
 [canonical JSON]: http://wiki.laptop.org/go/Canonical_JSON

--- a/git-helpers/tests/remote.rs
+++ b/git-helpers/tests/remote.rs
@@ -57,7 +57,7 @@ fn smoke() {
     // Push something to `urn`
     {
         let repo_dir = tempdir().unwrap();
-        setup_repo(repo_dir.path(), &urn, peer_id.clone()).unwrap();
+        setup_repo(repo_dir.path(), &urn, peer_id).unwrap();
 
         let mut child = Command::new("git")
             .args(&["push", "origin", "master"])

--- a/librad-test/src/git.rs
+++ b/librad-test/src/git.rs
@@ -1,0 +1,53 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use librad::git::{local::url::LocalUrl, types::remote::Remote};
+
+pub fn initial_commit(
+    repo: &git2::Repository,
+    remote: Remote<LocalUrl>,
+    reference: &str,
+    remote_callbacks: Option<git2::RemoteCallbacks>,
+) -> Result<git2::Oid, git2::Error> {
+    let mut remote = remote.create(&repo)?;
+
+    let commit_id = {
+        let empty_tree = {
+            let mut index = repo.index()?;
+            let oid = index.write_tree()?;
+            repo.find_tree(oid).unwrap()
+        };
+        let author = git2::Signature::now("The Animal", "animal@muppets.com").unwrap();
+        repo.commit(
+            Some(reference),
+            &author,
+            &author,
+            "Initial commit",
+            &empty_tree,
+            &[],
+        )?
+    };
+
+    let mut opts = git2::PushOptions::new();
+    let opts = match remote_callbacks {
+        Some(cb) => opts.remote_callbacks(cb),
+        None => &mut opts,
+    };
+    remote.push(&[reference], Some(opts))?;
+
+    Ok(commit_id)
+}

--- a/librad-test/src/lib.rs
+++ b/librad-test/src/lib.rs
@@ -18,6 +18,7 @@
 #[macro_use]
 extern crate lazy_static;
 
+pub mod git;
 pub mod logging;
 pub mod rad;
 pub mod roundtrip;

--- a/librad-test/src/rad/testnet.rs
+++ b/librad-test/src/rad/testnet.rs
@@ -107,7 +107,7 @@ pub async fn setup(num_peers: usize) -> anyhow::Result<Vec<TestPeer>> {
     let mut seed_addrs = None;
     for _ in 0..num_peers {
         let peer = boot(seed_addrs.take().into_iter().collect()).await?;
-        seed_addrs = Some((peer.peer_id().clone(), peer.listen_addr()));
+        seed_addrs = Some((peer.peer_id(), peer.listen_addr()));
         peers.push(peer)
     }
 

--- a/librad/src/git/include.rs
+++ b/librad/src/git/include.rs
@@ -165,8 +165,8 @@ fn fetch_entry(remote: &Remote<LocalUrl>) -> (String, String) {
         match &remote.fetch_spec {
             Some(spec) => spec.as_refspec(),
             None => {
-                let peer_id = &remote.url.local_peer_id;
-                let heads: FlatRef<PeerId, _> = FlatRef::heads(PhantomData, Some(peer_id.clone()));
+                let heads: FlatRef<PeerId, _> =
+                    FlatRef::heads(PhantomData, Some(remote.url.local_peer_id));
                 let heads = heads.with_name("heads/*");
                 let remotes: FlatRef<String, _> =
                     FlatRef::heads(PhantomData, Some(remote.name.clone()));
@@ -213,7 +213,7 @@ mod test {
         let repo = Hash::hash(b"meow-meow");
         let url = LocalUrl {
             repo,
-            local_peer_id: (*LOCAL_PEER_ID).clone(),
+            local_peer_id: *LOCAL_PEER_ID,
         };
 
         // Start with an empty config to catch corner-cases where git2::Config does not

--- a/librad/src/git/p2p/transport.rs
+++ b/librad/src/git/p2p/transport.rs
@@ -84,7 +84,7 @@ pub trait GitStream: AsyncRead + AsyncWrite + Unpin + Send {}
 pub trait GitStreamFactory: Sync + Send {
     async fn open_stream(
         &self,
-        to: &PeerId,
+        to: PeerId,
         addr_hints: &[SocketAddr],
     ) -> Option<Box<dyn GitStream>>;
 }
@@ -130,18 +130,18 @@ impl RadTransport {
     /// on behalf of `peer_id`.
     ///
     /// See the module documentation for why we key stream factories by sender.
-    pub fn register_stream_factory(&self, peer_id: &PeerId, fac: Weak<Box<dyn GitStreamFactory>>) {
-        self.fac.write().unwrap().insert(peer_id.clone(), fac);
+    pub fn register_stream_factory(&self, peer_id: PeerId, fac: Weak<Box<dyn GitStreamFactory>>) {
+        self.fac.write().unwrap().insert(peer_id, fac);
     }
 
     fn open_stream(
         &self,
-        from: &PeerId,
-        to: &PeerId,
+        from: PeerId,
+        to: PeerId,
         addr_hints: &[SocketAddr],
     ) -> Option<Box<dyn GitStream>> {
         let fac = self.fac.read().unwrap();
-        match fac.get(from) {
+        match fac.get(&from) {
             None => None,
             Some(weak) => match weak.upgrade() {
                 None => {
@@ -151,7 +151,7 @@ impl RadTransport {
                     );
                     drop(fac);
                     let mut fac = self.fac.write().unwrap();
-                    fac.remove(from);
+                    fac.remove(&from);
                     None
                 },
                 Some(fac) => block_on(fac.open_stream(to, addr_hints)),
@@ -168,7 +168,7 @@ impl SmartSubtransport for RadTransport {
     ) -> Result<Box<dyn SmartSubtransportStream>, git2::Error> {
         let url: GitUrl = url.parse().map_err(into_git_err)?;
         let stream = self
-            .open_stream(&url.local_peer, &url.remote_peer, &url.addr_hints)
+            .open_stream(url.local_peer, url.remote_peer, &url.addr_hints)
             .ok_or_else(|| into_git_err(format!("No connection to {}", url.remote_peer)))?;
 
         Ok(Box::new(RadSubTransport {
@@ -202,7 +202,7 @@ impl RadSubTransport {
                     uri::Protocol::Git,
                     uri::Path::empty(),
                 ),
-                self.url.remote_peer.clone(),
+                self.url.remote_peer,
             );
             self.stream.write_all(header.to_string().as_bytes()).await
         } else {

--- a/librad/src/git/p2p/url.rs
+++ b/librad/src/git/p2p/url.rs
@@ -191,7 +191,7 @@ impl<'a> GitUrlRef<'a> {
     where
         Addrs: AsRef<[SocketAddr]>,
     {
-        Self::from_rad_urn(url.urn, local_peer, url.authority, addr_hints)
+        Self::from_rad_urn(url.urn, local_peer, &url.authority, addr_hints)
     }
 
     pub fn from_rad_urn<Addrs>(
@@ -213,8 +213,8 @@ impl<'a> GitUrlRef<'a> {
 
     pub fn to_owned(&self) -> GitUrl {
         GitUrl {
-            local_peer: self.local_peer.clone(),
-            remote_peer: self.remote_peer.clone(),
+            local_peer: *self.local_peer,
+            remote_peer: *self.remote_peer,
             addr_hints: self.addr_hints.to_vec(),
             repo: self.repo.clone(),
         }

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -169,7 +169,7 @@ pub struct Signed {
 }
 
 impl Signed {
-    pub fn from_json(data: &[u8], signer: &PeerId) -> Result<Self, signed::Error> {
+    pub fn from_json(data: &[u8], signer: PeerId) -> Result<Self, signed::Error> {
         let this: Self = serde_json::from_slice(data)?;
         let canonical = this.refs.canonical_form()?;
         if this.signature.verify(&canonical, &*signer) {

--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -60,7 +60,7 @@ impl<S: Clone> Repo<'_, S> {
     /// Stop tracking [`PeerId`]s view of this repo
     ///
     /// Equivalent to `git remote rm`.
-    pub fn untrack(&self, peer: &PeerId) -> Result<(), Error> {
+    pub fn untrack(&self, peer: PeerId) -> Result<(), Error> {
         self.storage.untrack(&self.urn, peer).map_err(Error::from)
     }
 
@@ -113,14 +113,14 @@ where
     /// `addr_hints` may be supplied for the networking layer to establish a new
     /// connection to the peer specified in the `url` if none is currently
     /// active.
-    pub fn fetch<Addrs>(&self, from: &PeerId, addr_hints: Addrs) -> Result<(), Error>
+    pub fn fetch<Addrs>(&self, from: PeerId, addr_hints: Addrs) -> Result<(), Error>
     where
         Addrs: IntoIterator<Item = SocketAddr>,
     {
         self.storage
             .fetch_repo(
                 RadUrl {
-                    authority: from.clone(),
+                    authority: from,
                     urn: self.urn.clone(),
                 },
                 addr_hints,
@@ -131,7 +131,7 @@ where
     /// Track [`PeerId`]s view of this repo
     ///
     /// Equivalent to `git remote add`.
-    pub fn track(&self, peer: &PeerId) -> Result<(), Error> {
+    pub fn track(&self, peer: PeerId) -> Result<(), Error> {
         self.storage.track(&self.urn, peer).map_err(Error::from)
     }
 

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -160,8 +160,8 @@ pub struct Storage<S> {
 }
 
 impl<S: Clone> Storage<S> {
-    pub fn peer_id(&self) -> &PeerId {
-        &self.peer_id
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
     }
 
     pub fn open_repo(&self, urn: RadUrn) -> Result<Repo<S>, Error> {
@@ -257,7 +257,7 @@ impl<S: Clone> Storage<S> {
         self.metadata_from_reference(NamespacedRef::rad_self(urn.id.clone(), peer).borrow())
     }
 
-    pub fn certifiers_of(&self, urn: &RadUrn, peer: &PeerId) -> Result<HashSet<RadUrn>, Error> {
+    pub fn certifiers_of(&self, urn: &RadUrn, peer: PeerId) -> Result<HashSet<RadUrn>, Error> {
         let mut refs = References::from_globs(
             &self.backend,
             &[format!(
@@ -321,7 +321,7 @@ impl<S: Clone> Storage<S> {
             .or_matches(is_not_found_err, || Ok(false))
     }
 
-    pub fn untrack(&self, urn: &RadUrn, peer: &PeerId) -> Result<(), Error> {
+    pub fn untrack(&self, urn: &RadUrn, peer: PeerId) -> Result<(), Error> {
         let remote_name = tracking_remote_name(urn, peer);
         // TODO: This removes all remote tracking branches matching the
         // fetchspec (I suppose). Not sure this is what we want.
@@ -355,7 +355,7 @@ impl<S: Clone> Storage<S> {
         // verify the signature, and add their [`Remotes`] to ours (minus the 3rd
         // degree)
         for (peer, tracked) in remotes.iter_mut() {
-            match self.rad_signed_refs_of(urn, peer.clone()) {
+            match self.rad_signed_refs_of(urn, *peer) {
                 Ok(refs) => *tracked = refs.remotes.cutoff(),
                 Err(Error::Blob(blob::Error::NotFound(_))) => {},
                 Err(e) => return Err(e),
@@ -372,13 +372,13 @@ impl<S: Clone> Storage<S> {
 
     pub fn rad_signed_refs_of(&self, urn: &RadUrn, peer: PeerId) -> Result<Refs, Error> {
         let signed = {
-            let refs = NamespacedRef::rad_signed_refs(urn.id.clone(), peer.clone());
+            let refs = NamespacedRef::rad_signed_refs(urn.id.clone(), peer);
             let blob = Blob::Tip {
                 branch: refs.borrow().into(),
                 path: Path::new("refs"),
             }
             .get(&self.backend)?;
-            refs::Signed::from_json(blob.content(), &peer)
+            refs::Signed::from_json(blob.content(), peer)
         }?;
 
         Ok(Refs::from(signed))
@@ -642,7 +642,7 @@ where
         let span = tracing::info_span!("Storage::clone_repo", local.id = %self.peer_id, url = %url);
         let _guard = span.enter();
 
-        let remote_peer = url.authority.clone();
+        let remote_peer = url.authority;
 
         let urn = RadUrn {
             path: uri::Path::empty(),
@@ -654,11 +654,11 @@ where
         }
 
         // Fetch the identity first
-        let git_url = GitUrl::from_rad_url(url, self.peer_id.clone(), addr_hints);
+        let git_url = GitUrl::from_rad_url(url, self.peer_id, addr_hints);
         let mut fetcher = Fetcher::new(&self.backend, git_url)?;
         fetcher.prefetch()?;
 
-        let meta = self.some_metadata_of(&urn, remote_peer.clone())?;
+        let meta = self.some_metadata_of(&urn, remote_peer)?;
 
         // TODO: properly verify
         let valid: Result<(), Error> = {
@@ -729,7 +729,7 @@ where
         let span = tracing::info_span!("Storage::fetch", local.id = %self.peer_id, url = %url);
         let _guard = span.enter();
 
-        let git_url = GitUrl::from_rad_url(url, self.peer_id.clone(), addr_hints);
+        let git_url = GitUrl::from_rad_url(url, self.peer_id, addr_hints);
         let fetcher = Fetcher::new(&self.backend, git_url)?;
         self.fetch_internal(fetcher)
     }
@@ -738,13 +738,14 @@ where
         let url = fetcher.url();
         let urn = url.clone().into_rad_url().urn;
 
-        let remote_peer = url.remote_peer.clone();
+        let remote_peer = url.remote_peer;
 
         let rad_signed_refs = self.rad_signed_refs(&urn)?;
         let transitively_tracked = rad_signed_refs
             .remotes
             .flatten()
-            .collect::<HashSet<&PeerId>>();
+            .copied()
+            .collect::<HashSet<PeerId>>();
 
         fetcher.fetch(
             transitively_tracked,
@@ -856,13 +857,13 @@ where
         }
     }
 
-    pub fn track(&self, urn: &RadUrn, peer: &PeerId) -> Result<(), Error> {
-        if peer == &self.peer_id {
+    pub fn track(&self, urn: &RadUrn, peer: PeerId) -> Result<(), Error> {
+        if peer == self.peer_id {
             return Err(Error::SelfReferential);
         }
 
         let remote_name = tracking_remote_name(urn, peer);
-        let url = GitUrlRef::from_rad_urn(&urn, &self.peer_id, peer, &[]).to_string();
+        let url = GitUrlRef::from_rad_urn(&urn, &self.peer_id, &peer, &[]).to_string();
 
         tracing::debug!(
             urn = %urn,
@@ -930,13 +931,13 @@ where
         meta.signatures()
             .iter()
             .map(|(pk, sig)| {
-                let peer_id = PeerId::from(pk.clone());
+                let peer_id = PeerId::from(*pk);
                 match &sig.by {
                     Signatory::User(urn) => (peer_id, Some(urn)),
                     Signatory::OwnedKey => (peer_id, None),
                 }
             })
-            .filter(|(peer, _)| peer != self.peer_id())
+            .filter(|(peer, _)| peer != &self.peer_id())
             .try_for_each(|(peer, urn)| {
                 tracing::debug!(
                     tracked.peer = %peer,
@@ -947,11 +948,11 @@ where
                 );
 
                 // Track the signer's version of this repo (if any)
-                self.track(&meta_urn, &peer)?;
+                self.track(&meta_urn, peer)?;
                 // Track the signer's version of the identity she used for
                 // signing (if any)
                 if let Some(urn) = urn {
-                    self.track(urn, &peer)?;
+                    self.track(urn, peer)?;
                 }
 
                 Ok(())
@@ -1008,7 +1009,7 @@ where
     /// Fails when attempting to find the pair fails, except when the
     /// encountered error checks [`is_not_found_err`], in which case
     /// `Ok(false)` is returned.
-    pub fn is_tracked(&self, urn: &RadUrn, peer: &PeerId) -> Result<bool, Error> {
+    pub fn is_tracked(&self, urn: &RadUrn, peer: PeerId) -> Result<bool, Error> {
         match self.backend.find_remote(&tracking_remote_name(urn, peer)) {
             Ok(_) => Ok(true),
             Err(e) if is_not_found_err(&e) => Ok(false),
@@ -1061,7 +1062,7 @@ impl Iterator for Tracked {
     }
 }
 
-fn tracking_remote_name(urn: &RadUrn, peer: &PeerId) -> String {
+fn tracking_remote_name(urn: &RadUrn, peer: PeerId) -> String {
     format!("{}/{}", urn.id, peer)
 }
 

--- a/librad/src/git/storage/fetch.rs
+++ b/librad/src/git/storage/fetch.rs
@@ -99,11 +99,12 @@ impl<'a> Fetcher<'a> {
         Ok(())
     }
 
-    /// Fetch remote heads according to the remote's signed `rad/refs` branch.
+    /// Fetch remote heads according to the remote's signed `rad/signed_refs`
+    /// branch.
     ///
     /// Proceeds in three stages:
     ///
-    /// 1. fetch the remote's view of `rad/refs`
+    /// 1. fetch the remote's view of `rad/signed_refs`
     /// 2. compare the signed refs against the advertised ones
     /// 3. fetch advertised refs ⋂ signed refs
     pub fn fetch<F, G, E>(
@@ -122,7 +123,7 @@ impl<'a> Fetcher<'a> {
 
         let mut fetch_opts = self.fetch_options();
 
-        // Fetch `rad/refs` first
+        // Fetch `rad/signed_refs` first
         {
             let refspecs = Refspec::rad_signed_refs(
                 self.url.repo.clone(),

--- a/librad/src/git/storage/test.rs
+++ b/librad/src/git/storage/test.rs
@@ -62,8 +62,8 @@ fn test_tracking_read_after_write() {
     };
     let peer = PeerId::from(SecretKey::new());
 
-    store.track(&urn, &peer).unwrap();
-    assert!(store.is_tracked(&urn, &peer).unwrap());
+    store.track(&urn, peer).unwrap();
+    assert!(store.is_tracked(&urn, peer).unwrap());
 }
 
 #[test]
@@ -76,11 +76,11 @@ fn test_idempotent_tracking() {
     };
     let peer = PeerId::from(SecretKey::new());
 
-    store.track(&urn, &peer).unwrap();
+    store.track(&urn, peer).unwrap();
 
     // Attempting to track again does not fail
-    store.track(&urn, &peer).unwrap();
-    assert!(store.is_tracked(&urn, &peer).unwrap());
+    store.track(&urn, peer).unwrap();
+    assert!(store.is_tracked(&urn, peer).unwrap());
 }
 
 #[test]
@@ -93,10 +93,10 @@ fn test_untrack() {
     };
     let peer = PeerId::from(SecretKey::new());
 
-    store.track(&urn, &peer).unwrap();
-    store.untrack(&urn, &peer).unwrap();
+    store.track(&urn, peer).unwrap();
+    store.untrack(&urn, peer).unwrap();
 
-    assert!(!store.is_tracked(&urn, &peer).unwrap())
+    assert!(!store.is_tracked(&urn, peer).unwrap())
 }
 
 #[test]

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -213,14 +213,19 @@ impl Refspec<PeerId, PeerId> {
             // Heads
             //
             // `+refs/namespaces/<namespace>/refs[/remotes/<peer>]/heads/* \
-            // :refs/namespaces/<namespace>/refs/remotes/<peer>/refs/heads/*`
+            // :refs/namespaces/<namespace>/refs/remotes/<peer>/heads/*`
             {
                 let their_singed_rad_refs = rad_signed_refs_of(tracked_peer.clone())?;
                 for (name, target) in their_singed_rad_refs.heads {
                     let name_namespaced = format!("refs/namespaces/{}/{}", namespace, name);
                     if let Some(name) = name.strip_prefix("refs/heads/") {
+                        let name_namespaced_remote = format!(
+                            "refs/namespaces/{}/refs/remotes/{}/heads/{}",
+                            namespace, tracked_peer, name
+                        );
                         let targets_match = remote_heads
                             .get(name_namespaced.as_str())
+                            .or_else(|| remote_heads.get(name_namespaced_remote.as_str()))
                             .map(|remote_target| remote_target == &*target)
                             .unwrap_or(false);
 

--- a/librad/src/git/types/remote.rs
+++ b/librad/src/git/types/remote.rs
@@ -192,10 +192,10 @@ mod tests {
         let namespace = Hash::hash(b"meow-meow");
         let url = LocalUrl {
             repo: namespace,
-            local_peer_id: peer_id.clone(),
+            local_peer_id: peer_id,
         };
         let name = format!("lyla@{}", peer_id);
-        let heads: FlatRef<PeerId, _> = FlatRef::heads(PhantomData, Some(peer_id.clone()));
+        let heads: FlatRef<PeerId, _> = FlatRef::heads(PhantomData, Some(peer_id));
         let heads = heads.with_name("heads/*");
         let remotes: FlatRef<String, _> = FlatRef::heads(PhantomData, Some(name.clone()));
         let remote = Remote {

--- a/librad/src/identities/delegation/indirect.rs
+++ b/librad/src/identities/delegation/indirect.rs
@@ -122,7 +122,7 @@ impl<T, R, C> Indirect<T, R, C> {
                 entry.insert(pos);
                 Ok(())
             },
-            Entry::Occupied(entry) => Err(DuplicateKey(entry.key().clone())),
+            Entry::Occupied(entry) => Err(DuplicateKey(*entry.key())),
         };
 
         for d in iter {
@@ -137,7 +137,7 @@ impl<T, R, C> Indirect<T, R, C> {
                     let pos = ids.len() - 1;
 
                     for key in &ids[pos].doc.delegations {
-                        insert(key.clone(), Some(pos))?
+                        insert(*key, Some(pos))?
                     }
                 },
             }

--- a/librad/src/identities/generic/gen.rs
+++ b/librad/src/identities/generic/gen.rs
@@ -263,7 +263,7 @@ pub fn gen_history(
                             .iter()
                             .map(|(pk, _)| {
                                 let sk = keys.get(pk).unwrap();
-                                (pk.clone(), sk.sign(revision.as_ref()))
+                                (*pk, sk.sign(revision.as_ref()))
                             })
                             .collect::<BTreeMap<_, _>>()
                             .into();
@@ -300,7 +300,7 @@ fn mk_direct(
 
     let delegations: delegation::Direct = signatures
         .iter()
-        .map(|(pk, _)| pk.clone())
+        .map(|(pk, _)| *pk)
         .collect::<BTreeSet<_>>()
         .into();
 
@@ -332,7 +332,7 @@ where
         let sig = signatures
             .iter()
             .next()
-            .map(|(k, s)| (k.clone(), s.clone()))
+            .map(|(k, s)| (*k, s.clone()))
             .unwrap();
         let inner = Identity {
             content_id: Boring,

--- a/librad/src/identities/payload.rs
+++ b/librad/src/identities/payload.rs
@@ -769,7 +769,7 @@ nom is a parser combinators library written in Rust.";
         T: serde::Serialize + serde::de::DeserializeOwned,
     {
         let k = SecretKey::new().public();
-        let d = vec![k.clone(), k];
+        let d = vec![k, k];
 
         let ser = serde_json::to_string(&d).unwrap();
         assert!(matches!(

--- a/librad/src/keys.rs
+++ b/librad/src/keys.rs
@@ -54,7 +54,7 @@ impl<T: error::Error + Send + Sync + 'static> SignError for T {}
 pub struct SecretKey(ed25519::SigningKey);
 
 /// The public part of a `Key``
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct PublicKey(ed25519::VerificationKeyBytes);
 
 impl From<sign::PublicKey> for PublicKey {

--- a/librad/src/net/connection.rs
+++ b/librad/src/net/connection.rs
@@ -26,14 +26,14 @@ use futures::io::{AsyncRead, AsyncWrite};
 pub trait LocalInfo {
     type Addr;
 
-    fn local_peer_id(&self) -> &PeerId;
+    fn local_peer_id(&self) -> PeerId;
     fn local_addr(&self) -> io::Result<Self::Addr>;
 }
 
 pub trait RemoteInfo {
     type Addr;
 
-    fn remote_peer_id(&self) -> &PeerId;
+    fn remote_peer_id(&self) -> PeerId;
     fn remote_addr(&self) -> Self::Addr;
 }
 
@@ -108,12 +108,12 @@ pub(crate) mod mock {
     impl RemoteInfo for MockStream {
         type Addr = PeerId;
 
-        fn remote_peer_id(&self) -> &PeerId {
-            &self.id
+        fn remote_peer_id(&self) -> PeerId {
+            self.id
         }
 
         fn remote_addr(&self) -> Self::Addr {
-            self.id.clone()
+            self.id
         }
     }
 

--- a/librad/src/net/connection.rs
+++ b/librad/src/net/connection.rs
@@ -62,6 +62,7 @@ pub enum CloseReason {
     ConnectionError = 3,
     InternalError = 4,
     ServerShutdown = 5,
+    InvalidUpgrade = 6,
 }
 
 impl CloseReason {
@@ -72,6 +73,7 @@ impl CloseReason {
             Self::ConnectionError => b"connection error",
             Self::InternalError => b"internal server error",
             Self::ServerShutdown => b"server shutdown",
+            Self::InvalidUpgrade => b"invalid or unsupported protocol upgrade",
         }
     }
 }

--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -776,7 +776,11 @@ where
     }
 
     async fn add_known<I: IntoIterator<Item = PeerInfo<Addr>>>(&self, peers: I) {
-        self.known_peers.lock().await.insert(peers)
+        self.known_peers.lock().await.insert(
+            peers
+                .into_iter()
+                .filter(|info| &info.peer_id != self.peer_id()),
+        )
     }
 
     async fn sample_known(&self) -> Vec<PeerInfo<Addr>> {

--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -622,7 +622,7 @@ where
                 // the end of the random walk. Do it anyway for now.
                 self.add_known(peers.clone()).await;
 
-                if ttl > 0 {
+                if ttl == 0 {
                     let sample = self.sample_known().await;
                     self.send_adhoc(&origin, ShuffleReply { peers: sample })
                         .await

--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -182,26 +182,24 @@ where
         if !self.peers.contains_key(&peer_id) && self.peers.len() + 1 > self.max_peers {
             self.peers.insert(peer_id, sink);
 
-            let eject = self
-                .peers
-                .keys()
-                .choose(&mut self.rng)
-                .expect("Iterator must contain at least 1 element, as per the if condition. qed")
-                .clone();
-            self.remove(&eject)
+            let (eject, _) = self
+                .random()
+                .expect("Iterator must contain at least 1 element, as per the if condition. qed");
+            self.remove(eject)
         } else {
-            self.peers
-                .insert(peer_id.clone(), sink)
-                .map(|s| (peer_id, s))
+            self.peers.insert(peer_id, sink).map(|s| (peer_id, s))
         }
     }
 
-    fn remove(&mut self, peer_id: &PeerId) -> Option<(PeerId, S)> {
-        self.peers.remove(peer_id).map(|s| (peer_id.to_owned(), s))
+    fn remove(&mut self, peer_id: PeerId) -> Option<(PeerId, S)> {
+        self.peers.remove(&peer_id).map(|s| (peer_id, s))
     }
 
-    fn random(&mut self) -> Option<(&PeerId, &mut S)> {
-        self.peers.iter_mut().choose(&mut self.rng)
+    fn random(&mut self) -> Option<(PeerId, &mut S)> {
+        self.peers
+            .iter_mut()
+            .choose(&mut self.rng)
+            .map(|(k, s)| (*k, s))
     }
 
     fn contains(&self, peer_id: &PeerId) -> bool {
@@ -253,7 +251,7 @@ where
         for info in peers {
             let entry = self
                 .peers
-                .entry(info.peer_id.clone())
+                .entry(info.peer_id)
                 .or_insert_with(|| info.clone());
             entry.seen_addrs = entry.seen_addrs.union(&info.seen_addrs).cloned().collect();
         }
@@ -322,7 +320,7 @@ where
         }
 
         Self {
-            local_id: self.local_id.clone(),
+            local_id: self.local_id,
             local_ad: self.local_ad.clone(),
             mparams: self.mparams.clone(),
             storage: self.storage.clone(),
@@ -351,7 +349,7 @@ where
     <W as RemoteInfo>::Addr: AsAddr<Addr>,
 {
     pub fn new(
-        local_id: &PeerId,
+        local_id: PeerId,
         local_ad: PeerAdvertisement<Addr>,
         mparams: MembershipParams,
         storage: Storage,
@@ -371,7 +369,7 @@ where
         })));
 
         let this = Self {
-            local_id: local_id.clone(),
+            local_id,
             local_ad,
 
             mparams,
@@ -422,8 +420,8 @@ where
         this
     }
 
-    pub fn peer_id(&self) -> &PeerId {
-        &self.local_id
+    pub fn peer_id(&self) -> PeerId {
+        self.local_id
     }
 
     pub async fn is_connected(&self) -> bool {
@@ -502,7 +500,7 @@ where
             let mut recv = FramedRead::new(recv, Codec::new());
             let send = FramedWrite::new(send, Codec::new());
 
-            let remote_id = recv.remote_peer_id().clone();
+            let remote_id = recv.remote_peer_id();
             // This should not be possible, as we prevent it in the TLS handshake.
             // Leaving it here regardless as a sanity check.
             if remote_id == self.local_id {
@@ -510,7 +508,7 @@ where
             }
 
             if let Some((ejected_peer, mut ejected_send)) =
-                self.add_connected(remote_id.clone(), send).await
+                self.add_connected(remote_id, send).await
             {
                 tracing::trace!(
                     msg = "Ejecting connected peer",
@@ -530,11 +528,11 @@ where
                 match recvd {
                     Ok(rpc) => match rpc {
                         Rpc::Membership(msg) => {
-                            self.handle_membership(&remote_id, recv.remote_addr().as_addr(), msg)
+                            self.handle_membership(remote_id, recv.remote_addr().as_addr(), msg)
                                 .await?
                         },
 
-                        Rpc::Gossip(msg) => self.handle_gossip(&remote_id, msg).await?,
+                        Rpc::Gossip(msg) => self.handle_gossip(remote_id, msg).await?,
                     },
 
                     Err(e) => {
@@ -545,7 +543,7 @@ where
             }
 
             tracing::trace!(msg = "Recv stream is done, disconnecting");
-            self.remove_connected(&remote_id).await;
+            self.remove_connected(remote_id).await;
 
             Ok(())
         }
@@ -555,14 +553,14 @@ where
 
     async fn handle_membership(
         &self,
-        remote_id: &PeerId,
+        remote_id: PeerId,
         remote_addr: Addr,
         msg: Membership<Addr>,
     ) -> Result<(), Error> {
         use Membership::*;
 
         let make_peer_info = |ad: PeerAdvertisement<Addr>| PeerInfo {
-            peer_id: remote_id.clone(),
+            peer_id: remote_id,
             advertised_info: ad,
             seen_addrs: vec![remote_addr].into_iter().collect(),
         };
@@ -627,7 +625,7 @@ where
                     self.send_adhoc(&origin, ShuffleReply { peers: sample })
                         .await
                 } else {
-                    let origin = if &origin.peer_id == remote_id {
+                    let origin = if origin.peer_id == remote_id {
                         make_peer_info(origin.advertised_info)
                     } else {
                         origin
@@ -656,7 +654,7 @@ where
 
     async fn handle_gossip(
         &self,
-        remote_id: &PeerId,
+        remote_id: PeerId,
         msg: Gossip<Addr, Broadcast>,
     ) -> Result<(), Error> {
         use Gossip::*;
@@ -675,7 +673,7 @@ where
                         })))
                         .await;
 
-                    match self.storage.put(&remote_id, val.clone()).await {
+                    match self.storage.put(remote_id, val.clone()).await {
                         // `val` was new, and is now fetched to local storage.
                         // Let connected peers know they can now fetch it from
                         // us.
@@ -742,7 +740,7 @@ where
                     let have = self.storage.ask(val.clone()).await;
                     if have {
                         self.reply(
-                            &remote_id.clone(),
+                            remote_id,
                             Have {
                                 origin: self.local_peer_info(),
                                 val,
@@ -769,7 +767,7 @@ where
         self.connected_peers.lock().await.insert(peer_id, out)
     }
 
-    async fn remove_connected(&self, peer_id: &PeerId) {
+    async fn remove_connected(&self, peer_id: PeerId) {
         if let Some((_, mut stream)) = self.connected_peers.lock().await.remove(peer_id) {
             let _ = stream.close().await;
         }
@@ -779,7 +777,7 @@ where
         self.known_peers.lock().await.insert(
             peers
                 .into_iter()
-                .filter(|info| &info.peer_id != self.peer_id()),
+                .filter(|info| info.peer_id != self.peer_id()),
         )
     }
 
@@ -848,7 +846,7 @@ where
     async fn broadcast<'a, M, X>(&self, rpc: M, excluding: X)
     where
         M: Into<Rpc<Addr, Broadcast>>,
-        X: Into<Option<&'a PeerId>>,
+        X: Into<Option<PeerId>>,
     {
         let rpc = rpc.into();
         let excluding = excluding.into();
@@ -857,7 +855,7 @@ where
         futures::stream::iter(
             connected_peers
                 .iter_mut()
-                .filter(|(peer_id, _)| Some(*peer_id) != excluding),
+                .filter(|(peer_id, _)| Some(*peer_id) != excluding.as_ref()),
         )
         .for_each_concurrent(None, |(peer, out)| {
             let rpc = rpc.clone();
@@ -880,9 +878,9 @@ where
         .await
     }
 
-    async fn reply<M: Into<Rpc<Addr, Broadcast>>>(&self, to: &PeerId, rpc: M) {
+    async fn reply<M: Into<Rpc<Addr, Broadcast>>>(&self, to: PeerId, rpc: M) {
         let rpc = rpc.into();
-        futures::stream::iter(self.connected_peers.lock().await.get_mut(to))
+        futures::stream::iter(self.connected_peers.lock().await.get_mut(&to))
             .for_each(|out| {
                 let rpc = rpc.clone();
                 async move {
@@ -916,7 +914,7 @@ where
 
     fn local_peer_info(&self) -> PeerInfo<Addr> {
         PeerInfo {
-            peer_id: self.local_id.clone(),
+            peer_id: self.local_id,
             advertised_info: self.local_ad.clone(),
             seen_addrs: HashSet::with_capacity(0),
         }

--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -466,7 +466,7 @@ where
 
     pub(super) async fn outgoing<Stream>(
         &self,
-        s: Upgraded<Stream, upgrade::Gossip>,
+        s: Upgraded<upgrade::Gossip, Stream>,
         hello: impl Into<Option<Rpc<Addr, Broadcast>>>,
     ) -> Result<(), Error>
     where
@@ -490,7 +490,7 @@ where
 
     pub(super) async fn incoming<Stream>(
         &self,
-        s: Upgraded<Stream, upgrade::Gossip>,
+        s: Upgraded<upgrade::Gossip, Stream>,
     ) -> Result<(), Error>
     where
         Stream: connection::Stream<Read = R, Write = W>,

--- a/librad/src/net/gossip/storage.rs
+++ b/librad/src/net/gossip/storage.rs
@@ -40,7 +40,7 @@ pub trait LocalStorage: Clone + Send + Sync {
     /// up-to-date, or it was not possible to fetch the actual state from
     /// the `provider`. In this case, the network is asked to retransmit
     /// [`Self::Update`], so we can eventually try again.
-    async fn put(&self, provider: &PeerId, has: Self::Update) -> PutResult;
+    async fn put(&self, provider: PeerId, has: Self::Update) -> PutResult;
 
     /// Ask the local storage if value `A` is available.
     ///

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -262,7 +262,7 @@ where
         (this, Box::pin(run_loop))
     }
 
-    pub fn peer_id(&self) -> &PeerId {
+    pub fn peer_id(&self) -> PeerId {
         self.gossip.peer_id()
     }
 
@@ -309,7 +309,7 @@ where
     /// convenience (one can pass [`None`], for example).
     pub async fn open_git<Addrs>(
         &self,
-        to: &PeerId,
+        to: PeerId,
         addr_hints: Addrs,
     ) -> Result<Upgraded<upgrade::Git, quic::Stream>, Error>
     where
@@ -323,7 +323,7 @@ where
                         let addr_hints = addr_hints.into_iter().collect::<Vec<_>>();
                         let (conn, incoming) = connect(&self.endpoint, to, addr_hints)
                             .await
-                            .ok_or_else(|| Error::NoConnection(to.clone()))?;
+                            .ok_or_else(|| Error::NoConnection(to))?;
 
                         let stream = conn.open_stream().await?;
                         upgrade(stream, upgrade::Git)
@@ -356,7 +356,7 @@ where
                 );
 
                 if !self.connections.lock().await.contains_key(&peer) {
-                    if let Some((conn, incoming)) = connect(&self.endpoint, &peer, addrs).await {
+                    if let Some((conn, incoming)) = connect(&self.endpoint, peer, addrs).await {
                         self.handle_connect(conn, incoming.boxed(), None).await;
                     }
                 }
@@ -437,16 +437,16 @@ where
         mut incoming: BoxStream<'_, quic::Result<quic::Stream>>,
         hello: impl Into<Option<gossip::Rpc<IpAddr, A>>>,
     ) {
-        let remote_id = conn.remote_peer_id().clone();
+        let remote_id = conn.remote_peer_id();
         tracing::info!(remote.id = %remote_id, "New outgoing connection");
 
         {
             self.connections
                 .lock()
                 .await
-                .insert(remote_id.clone(), conn.clone());
+                .insert(remote_id, conn.clone());
             self.subscribers
-                .emit(ProtocolEvent::Connected(remote_id.clone()))
+                .emit(ProtocolEvent::Connected(remote_id))
                 .await;
         }
 
@@ -487,16 +487,13 @@ where
     where
         Incoming: futures::Stream<Item = quic::Result<quic::Stream>> + Unpin,
     {
-        let remote_id = conn.remote_peer_id().clone();
+        let remote_id = conn.remote_peer_id();
         tracing::info!(remote.id = %remote_id, "New incoming connection");
 
         {
-            self.connections
-                .lock()
-                .await
-                .insert(remote_id.clone(), conn);
+            self.connections.lock().await.insert(remote_id, conn);
             self.subscribers
-                .emit(ProtocolEvent::Connected(remote_id.clone()))
+                .emit(ProtocolEvent::Connected(remote_id))
                 .await;
         }
 
@@ -553,13 +550,13 @@ where
         }
     }
 
-    async fn open_stream<U>(&self, to: &PeerId, up: U) -> Result<Upgraded<U, quic::Stream>, Error>
+    async fn open_stream<U>(&self, to: PeerId, up: U) -> Result<Upgraded<U, quic::Stream>, Error>
     where
         U: Into<UpgradeRequest>,
     {
-        let stream = match self.connections.lock().await.get(to) {
+        let stream = match self.connections.lock().await.get(&to) {
             Some(conn) => conn.open_stream().await.map_err(Error::from),
-            None => Err(Error::NoConnection(to.clone())),
+            None => Err(Error::NoConnection(to)),
         }?;
 
         upgrade(stream, up)
@@ -579,7 +576,7 @@ where
 {
     async fn open_stream(
         &self,
-        to: &PeerId,
+        to: PeerId,
         addr_hints: &[SocketAddr],
     ) -> Option<Box<dyn GitStream>> {
         let span = tracing::trace_span!("GitStreamFactory::open_stream", peer.id = %to);
@@ -619,12 +616,12 @@ async fn connect_peer_info(
     let addrs = iter::once(peer_info.advertised_info.listen_addr)
         .chain(peer_info.seen_addrs)
         .map(move |ip| SocketAddr::new(ip, advertised_port));
-    connect(endpoint, &peer_info.peer_id, addrs).await
+    connect(endpoint, peer_info.peer_id, addrs).await
 }
 
 async fn connect<Addrs>(
     endpoint: &quic::Endpoint,
-    peer_id: &PeerId,
+    peer_id: PeerId,
     addrs: Addrs,
 ) -> Option<(
     quic::Connection,

--- a/librad/src/net/quic.rs
+++ b/librad/src/net/quic.rs
@@ -294,6 +294,11 @@ impl Stream {
     {
         Framed::new(self, codec)
     }
+
+    pub fn close(self, reason: CloseReason) {
+        self.send.close(reason);
+        self.recv.close(reason);
+    }
 }
 
 impl RemoteInfo for Stream {
@@ -346,6 +351,12 @@ pub struct RecvStream {
     recv: quinn::RecvStream,
 }
 
+impl RecvStream {
+    pub fn close(mut self, reason: CloseReason) {
+        let _ = self.recv.stop(VarInt::from_u32(reason as u32));
+    }
+}
+
 impl RemoteInfo for RecvStream {
     type Addr = SocketAddr;
 
@@ -371,6 +382,12 @@ impl AsyncRead for RecvStream {
 pub struct SendStream {
     conn: Connection,
     send: quinn::SendStream,
+}
+
+impl SendStream {
+    pub fn close(mut self, reason: CloseReason) {
+        let _ = self.send.reset(VarInt::from_u32(reason as u32));
+    }
 }
 
 impl RemoteInfo for SendStream {

--- a/librad/src/net/upgrade.rs
+++ b/librad/src/net/upgrade.rs
@@ -315,7 +315,7 @@ mod tests {
     async fn test_upgrade(
         req: impl Into<UpgradeRequest>,
     ) -> Result<SomeUpgraded<()>, Error<MockStream>> {
-        let (initiator, receiver) = MockStream::pair(INITIATOR.clone(), RECEIVER.clone(), 512);
+        let (initiator, receiver) = MockStream::pair(*INITIATOR, *RECEIVER, 512);
         try_join!(
             async { upgrade(initiator, req).await.map_err(Error::from) },
             async {

--- a/librad/src/peer.rs
+++ b/librad/src/peer.rs
@@ -25,7 +25,7 @@ use keystore::sign;
 
 use crate::keys::{self, PublicKey, SecretKey};
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Encode, Decode)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Encode, Decode)]
 #[cbor(array)]
 pub struct PeerId(#[n(0)] PublicKey);
 

--- a/librad/src/uri.rs
+++ b/librad/src/uri.rs
@@ -316,7 +316,7 @@ impl RadUrn {
 
     pub fn as_rad_url_ref<'a>(&'a self, authority: &'a PeerId) -> RadUrlRef<'a> {
         RadUrlRef {
-            authority,
+            authority: &authority,
             urn: self,
         }
     }
@@ -592,7 +592,7 @@ pub struct RadUrlRef<'a> {
 impl<'a> RadUrlRef<'a> {
     pub fn to_owned(&self) -> RadUrl {
         RadUrl {
-            authority: self.authority.clone(),
+            authority: *self.authority,
             urn: self.urn.clone(),
         }
     }

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -84,7 +84,7 @@ async fn can_clone() {
             .with_storage(move |storage| {
                 storage
                     .clone_repo::<ProjectInfo, _>(
-                        radicle_urn.clone().into_rad_url(peer1.peer_id().clone()),
+                        radicle_urn.clone().into_rad_url(peer1.peer_id()),
                         None,
                     )
                     .unwrap();
@@ -137,7 +137,7 @@ async fn can_clone_disconnected() {
             .with_storage(move |storage| {
                 storage
                     .clone_repo::<ProjectInfo, _>(
-                        radicle_urn.clone().into_rad_url(peer1.peer_id().clone()),
+                        radicle_urn.clone().into_rad_url(peer1.peer_id()),
                         Some(peer1.listen_addr()),
                     )
                     .unwrap();
@@ -195,7 +195,7 @@ async fn fetches_on_gossip_notify() {
         }
 
         {
-            let radicle_at_peer1 = radicle.urn().into_rad_url(peer1.peer_id().clone());
+            let radicle_at_peer1 = radicle.urn().into_rad_url(peer1.peer_id());
             peer2
                 .with_storage(move |storage| {
                     storage
@@ -224,7 +224,7 @@ async fn fetches_on_gossip_notify() {
                     let rev = repo.find_reference(refname)?.target().unwrap();
 
                     futures::executor::block_on(peer1.protocol().announce(Gossip {
-                        origin: Some(peer1.peer_id().clone()),
+                        origin: Some(peer1.peer_id()),
                         urn: RadUrn {
                             path: uri::Path::parse(refname).unwrap(),
                             ..radicle.urn()
@@ -241,9 +241,9 @@ async fn fetches_on_gossip_notify() {
                 ))),
             });
 
-            let url = LocalUrl::from_urn(urn.clone(), peer1.peer_id().clone());
+            let url = LocalUrl::from_urn(urn.clone(), peer1.peer_id());
 
-            let heads = NamespacedRef::heads(urn.clone().id, Some(peer1.peer_id().clone()));
+            let heads = NamespacedRef::heads(urn.clone().id, Some(peer1.peer_id()));
             let remotes: FlatRef<String, _> = FlatRef::heads(
                 PhantomData,
                 Some(format!("{}@{}", alice_name, peer1.peer_id())),
@@ -263,7 +263,7 @@ async fn fetches_on_gossip_notify() {
                 peer2_events
                     .filter(|event| match event {
                         PeerEvent::GossipFetch(FetchInfo { provider, .. }) => {
-                            future::ready(provider == peer1_id)
+                            future::ready(*provider == peer1_id)
                         },
                     })
                     .map(|_| ())
@@ -324,8 +324,8 @@ async fn all_metadata_returns_only_local_projects() {
                 .unwrap();
         }
 
-        let radicle_at_peer1 = radicle.urn().into_rad_url(peer1.peer_id().clone());
-        let radicle_at_peer2 = radicle.urn().into_rad_url(peer2.peer_id().clone());
+        let radicle_at_peer1 = radicle.urn().into_rad_url(peer1.peer_id());
+        let radicle_at_peer2 = radicle.urn().into_rad_url(peer2.peer_id());
 
         peer1
             .with_storage(move |storage| {
@@ -456,11 +456,11 @@ async fn menage_a_troi() {
     let peers = testnet::setup(NUM_PEERS).await.unwrap();
     testnet::run_on_testnet(peers, NUM_PEERS, async move |mut apis| {
         let (peer1, peer1_key) = apis.pop().unwrap();
-        let peer1_id = peer1.peer_id().clone();
+        let peer1_id = peer1.peer_id();
         let peer1_addr = peer1.listen_addr();
 
         let (peer2, _) = apis.pop().unwrap();
-        let peer2_id = peer2.peer_id().clone();
+        let peer2_id = peer2.peer_id();
         let peer2_addr = peer2.listen_addr();
 
         let (peer3, _) = apis.pop().unwrap();
@@ -503,9 +503,9 @@ async fn menage_a_troi() {
             librad::git::local::transport::register(settings);
             // Perform commit and push to working copy on peer1
             let repo = git2::Repository::init(tmp.path().join("peer1")).unwrap();
-            let url = LocalUrl::from_urn(urn.clone(), peer1_id.clone());
+            let url = LocalUrl::from_urn(urn.clone(), peer1_id);
 
-            let heads = NamespacedRef::heads(urn.clone().id, Some(peer1_id.clone()));
+            let heads = NamespacedRef::heads(urn.clone().id, Some(peer1_id));
             let remotes: FlatRef<String, _> =
                 FlatRef::heads(PhantomData, Some(format!("{}@{}", alice_name, peer1_id)));
 
@@ -521,10 +521,10 @@ async fn menage_a_troi() {
             .unwrap();
         });
 
-        let head = NamespacedRef::head(urn.clone().id, peer1_id.clone(), &default_branch);
+        let head = NamespacedRef::head(urn.clone().id, peer1_id, &default_branch);
         let peer2_has_ref = {
             let head = head.clone();
-            let url = urn.clone().into_rad_url(peer1_id.clone());
+            let url = urn.clone().into_rad_url(peer1_id);
             peer2
                 .with_storage(move |storage| {
                     storage

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -447,7 +447,7 @@ async fn ask_and_clone() {
     .await;
 }
 
-#[tokio::test(core_threads = 3)]
+#[tokio::test(core_threads = 2)]
 async fn menage_a_troi() {
     logging::init();
 

--- a/librad/tests/working_copy.rs
+++ b/librad/tests/working_copy.rs
@@ -39,6 +39,7 @@ use librad::{
 };
 
 use librad_test::{
+    git::initial_commit,
     logging,
     rad::{
         entity::{Alice, Radicle},
@@ -206,42 +207,6 @@ async fn can_fetch() {
         assert!(repo.find_commit(commit_id).is_ok());
     })
     .await;
-}
-
-// Check out a working copy on peer1, add a commit, and push it
-fn initial_commit(
-    repo: &git2::Repository,
-    remote: Remote<LocalUrl>,
-    reference: &str,
-    remote_callbacks: Option<git2::RemoteCallbacks>,
-) -> Result<git2::Oid, git2::Error> {
-    let mut remote = remote.create(&repo)?;
-
-    let commit_id = {
-        let empty_tree = {
-            let mut index = repo.index()?;
-            let oid = index.write_tree()?;
-            repo.find_tree(oid).unwrap()
-        };
-        let author = git2::Signature::now("The Animal", "animal@muppets.com").unwrap();
-        repo.commit(
-            Some(reference),
-            &author,
-            &author,
-            "Initial commit",
-            &empty_tree,
-            &[],
-        )?
-    };
-
-    let mut opts = git2::PushOptions::new();
-    let opts = match remote_callbacks {
-        Some(cb) => opts.remote_callbacks(cb),
-        None => &mut opts,
-    };
-    remote.push(&[reference], Some(opts))?;
-
-    Ok(commit_id)
 }
 
 // Wait for peer2 to receive the gossip announcement

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -217,8 +217,8 @@ impl Node {
         urn: &RadUrn,
         peer_info: &PeerInfo<std::net::IpAddr>,
     ) -> Result<(), Error> {
-        let peer_id = &peer_info.peer_id;
-        let url = urn.clone().into_rad_url(peer_id.clone());
+        let peer_id = peer_info.peer_id;
+        let url = urn.clone().into_rad_url(peer_id);
         let port = peer_info.advertised_info.listen_port;
         let addr_hints = peer_info
             .seen_addrs
@@ -227,12 +227,11 @@ impl Node {
             .collect::<Vec<_>>();
 
         let result = {
-            let peer_id = peer_id.clone();
             let urn = urn.clone();
             api.with_storage(move |storage| {
                 storage
                     .clone_repo::<project::ProjectInfo, _>(url, addr_hints)
-                    .and_then(|_| storage.track(&urn, &peer_id))
+                    .and_then(|_| storage.track(&urn, peer_id))
             })
         }
         .await

--- a/spec/references.bib
+++ b/spec/references.bib
@@ -186,6 +186,21 @@
   abstract={JavaScript Object Notation (JSON) is a lightweight, text-based, language-independent data interchange format. It was derived from the ECMAScript Programming Language Standard. JSON defines a small set of formatting rules for the portable representation of structured data. This document removes inconsistencies with other specifications of JSON, repairs specification errors, and offers experience-based interoperability guidance.},
 }
 
+@misc{rfc8141,
+  series={Request for Comments},
+  number=8141,
+  howpublished={RFC 8141},
+  publisher={RFC Editor},
+  doi={10.17487/RFC8141},
+  url={https://rfc-editor.org/rfc/rfc8141.txt},
+  author={Peter Saint-Andre and Dr. John C. Klensin},
+  title={{Uniform Resource Names (URNs)}},
+  pagetotal=40,
+  year=2017,
+  month=apr,
+  abstract={A Uniform Resource Name (URN) is a Uniform Resource Identifier (URI) that is assigned under the "urn" URI scheme and a particular URN namespace, with the intent that the URN will be a persistent, location-independent resource identifier. With regard to URN syntax, this document defines the canonical syntax for URNs (in a way that is consistent with URI syntax), specifies methods for determining URN-equivalence, and discusses URI conformance. With regard to URN namespaces, this document specifies a method for defining a URN namespace and associating it with a namespace identifier, and it describes procedures for registering namespace identifiers with the Internet Assigned Numbers Authority (IANA). This document obsoletes both RFCs 2141 and 3406.},
+}
+
 #
 # Websites
 #


### PR DESCRIPTION
Fixes #348 

We derive Copy for PublicKey & PeerId since they're simply a slice of
bytes.
The majority of the changes are removing the clone calls on
PeerId/PublickKey and removing the ask by reference on PeerId in
function calls.