### PR TITLE
CI: Run tests verbosely

### DIFF
--- a/ci/build-test
+++ b/ci/build-test
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-echo '--- Build & Test'
-cargo test --all
+echo '--- Build'
+cargo build --verbose --workspace
+
+echo '--- Test'
+GIT_TRACE2=1 RUST_LOG=librad=trace cargo test --workspace


### PR DESCRIPTION
Strangely, `cargo` can be told to run only the unit or doc tests, but not to
only run the integration tests. Perhaps we should meditate over organising those
slow tests in a different way to work around the deficiencies of the tooling
(see also #353).
