### PR TITLE
Local transport: side-channel for blocking on local transport results

### DIFF
--- a/librad/tests/working_copy.rs
+++ b/librad/tests/working_copy.rs
@@ -19,6 +19,7 @@
 
 use std::{marker::PhantomData, time::Duration};
 
+use assert_matches::assert_matches;
 use futures::{
     future,
     stream::{Stream, StreamExt},
@@ -71,17 +72,17 @@ async fn can_fetch() {
         let (peer2, peer2_key) = apis.pop().unwrap();
         let peer2_events = peer2.subscribe().await;
 
-        let global_settings = transport::Settings {
-            paths: peer1.paths().clone(),
-            signer: SomeSigner { signer: peer1_key }.into(),
-        };
-        librad::git::local::transport::register(global_settings);
-
-        let global_settings = transport::Settings {
-            paths: peer2.paths().clone(),
-            signer: SomeSigner { signer: peer2_key }.into(),
-        };
-        librad::git::local::transport::register(global_settings);
+        librad::git::local::transport::register();
+        let local_transport_results_peer1 =
+            transport::LocalTransportFactory::configure(transport::Settings {
+                paths: peer1.paths().clone(),
+                signer: SomeSigner { signer: peer1_key }.into(),
+            });
+        let local_transport_results_peer2 =
+            transport::LocalTransportFactory::configure(transport::Settings {
+                paths: peer2.paths().clone(),
+                signer: SomeSigner { signer: peer2_key }.into(),
+            });
 
         let mut alice = Alice::new(peer1_key.public());
         let mut radicle = Radicle::new(&alice);
@@ -173,6 +174,9 @@ async fn can_fetch() {
         // Push a change and wait for peer2 to receive it in their monorepo
         let commit_id =
             initial_commit(&repo, remote, "refs/heads/master", Some(remote_callbacks)).unwrap();
+        assert!(local_transport_results_peer1
+            .wait(Duration::from_secs(3))
+            .is_some());
         wait_for_event(peer2_events, peer1.peer_id()).await;
 
         // Create working copy of project
@@ -204,6 +208,13 @@ async fn can_fetch() {
                 remote.fetch(&[&name], None, None).unwrap();
             }
         }
+        for res in local_transport_results_peer2
+            .wait(Duration::from_secs(5))
+            .unwrap()
+        {
+            assert_matches!(res, Ok(_), "fetch error");
+        }
+
         assert!(repo.find_commit(commit_id).is_ok());
     })
     .await;


### PR DESCRIPTION
`libgit2` may drop all references to the local transport before the
child process exited. We must, however, `wait(2)` on the children on a
(non-cancellable) thread, which leads to the dilemma of either risking
to block the parent process (by joining on this thread), or exiting it
prematurely.

We thus establish a side-band channel which allows non-longrunning
processes to fully await completion of their local transport operations
(e.g. in a `Drop` finaliser).

---

Supersedes #375

Note: one might think that it would be possible to simply use a `std::sync::mpsc`
channel for this, but that is not the case due to caught panics not being `Sync`.
