### PR TITLE
Allow untrack of non-existing remote

### DIFF
--- a/librad/src/git/repo.rs
+++ b/librad/src/git/repo.rs
@@ -60,7 +60,7 @@ impl<S: Clone> Repo<'_, S> {
     /// Stop tracking [`PeerId`]s view of this repo
     ///
     /// Equivalent to `git remote rm`.
-    pub fn untrack(&self, peer: &PeerId) -> Result<(), Error> {
+    pub fn untrack(&self, peer: &PeerId) -> Result<bool, Error> {
         self.storage.untrack(&self.urn, &peer).map_err(Error::from)
     }
 

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -321,13 +321,19 @@ impl<S: Clone> Storage<S> {
             .or_matches(is_not_found_err, || Ok(false))
     }
 
-    pub fn untrack(&self, urn: &RadUrn, peer: &PeerId) -> Result<(), Error> {
+    /// Untrack the identity under `urn` for the given `peer`.
+    ///
+    /// If the remote for this `peer` did not exists this function will return
+    /// `false`. Otherwise, if the remote did exist and was successfully
+    /// remove then this function will return `true`.
+    pub fn untrack(&self, urn: &RadUrn, peer: &PeerId) -> Result<bool, Error> {
         let remote_name = tracking_remote_name(urn, peer);
         // TODO: This removes all remote tracking branches matching the
         // fetchspec (I suppose). Not sure this is what we want.
         self.backend
             .remote_delete(&remote_name)
-            .map_err(|e| e.into())
+            .map(|()| true)
+            .or_matches(is_not_found_err, || Ok(false))
     }
 
     pub fn tracked(&self, urn: &RadUrn) -> Result<Tracked, Error> {

--- a/librad/src/git/storage/test.rs
+++ b/librad/src/git/storage/test.rs
@@ -100,6 +100,19 @@ fn test_untrack() {
 }
 
 #[test]
+fn untrack_non_existing_remote() {
+    let store = storage(SecretKey::new());
+    let urn = RadUrn {
+        id: Hash::hash(b"lala"),
+        proto: uri::Protocol::Git,
+        path: uri::Path::empty(),
+    };
+    let peer = PeerId::from(SecretKey::new());
+
+    store.untrack(&urn, &peer).unwrap();
+}
+
+#[test]
 fn test_all_metadata_heads() {
     let key = SecretKey::new();
     let store = storage(key);


### PR DESCRIPTION
If we call untrack on a non-existing remote we get an error back from
git2 saying that it doesn't exist. It would make more sense to match on
the remote not existing and return a bool whether the remote used to
exist or not.