### PR TITLE
Restrict the types which can be used as a remote for `Reference`

### DIFF
--- a/librad/src/git/sealed.rs
+++ b/librad/src/git/sealed.rs
@@ -15,7 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::peer::PeerId;
+
 /// Constraint for [sealed traits] under the `git` module hierarchy.
 ///
 /// [sealed traits]: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
 pub trait Sealed {}
+
+impl Sealed for PeerId {}
+impl Sealed for &PeerId {}

--- a/librad/src/git/types.rs
+++ b/librad/src/git/types.rs
@@ -34,7 +34,7 @@ pub mod namespace;
 pub mod reference;
 pub mod remote;
 
-pub use reference::{Many, Multiple, One, Reference, RefsCategory, Single};
+pub use reference::{AsRemote, Many, Multiple, One, Reference, RefsCategory, Single};
 
 /// A representation of git reference that is either under:
 ///   * `refs/heads`
@@ -43,7 +43,7 @@ pub type FlatRef<R, C> = Reference<PhantomData<!>, R, C>;
 
 impl<R> Display for FlatRef<R, One>
 where
-    for<'a> &'a R: Into<ext::RefLike>,
+    for<'a> &'a R: AsRemote,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(Into::<ext::RefLike>::into(self).as_str())
@@ -52,7 +52,7 @@ where
 
 impl<'a, R> From<&'a FlatRef<R, One>> for ext::RefLike
 where
-    &'a R: Into<ext::RefLike>,
+    &'a R: AsRemote,
 {
     fn from(r: &'a FlatRef<R, One>) -> Self {
         let mut path = PathBuf::new();
@@ -71,7 +71,7 @@ where
 
 impl<'a, R> From<&'a FlatRef<R, One>> for ext::RefspecPattern
 where
-    &'a R: Into<ext::RefLike>,
+    &'a R: AsRemote,
 {
     fn from(r: &'a FlatRef<R, One>) -> Self {
         Into::<ext::RefLike>::into(r).into()
@@ -80,7 +80,7 @@ where
 
 impl<R> Display for FlatRef<R, Many>
 where
-    for<'a> &'a R: Into<ext::RefLike>,
+    for<'a> &'a R: AsRemote,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(Into::<ext::RefspecPattern>::into(self).as_str())
@@ -89,7 +89,7 @@ where
 
 impl<'a, R> From<&'a FlatRef<R, Many>> for ext::RefspecPattern
 where
-    &'a R: Into<ext::RefLike>,
+    &'a R: AsRemote,
 {
     fn from(r: &'a FlatRef<R, Many>) -> Self {
         let mut path = PathBuf::new();

--- a/librad/src/git/types/reference.rs
+++ b/librad/src/git/types/reference.rs
@@ -21,9 +21,9 @@ use std::{
     path::PathBuf,
 };
 
-use crate::{git::ext, uri::RadUrn};
+use crate::{git::ext, peer::PeerId, uri::RadUrn};
 
-use super::{namespace::AsNamespace, Force, Refspec, SymbolicRef};
+use super::{namespace::AsNamespace, sealed, Force, Refspec, SymbolicRef};
 
 /// Type witness for a [`Reference`] that should point to a single reference.
 pub type One = ext::RefLike;
@@ -57,6 +57,24 @@ impl From<RefsCategory> for ext::RefLike {
         ext::RefLike::try_from(cat.to_string()).unwrap()
     }
 }
+
+/// Ad-hoc trait to prevent the typechecker from recursing.
+///
+/// Morally, we can convert `Reference<N, R, C>` into `ext::RefLike` for any `R:
+/// Into<ext::RefLike>`. However, the typechecker may then attempt to unify `R`
+/// with `Reference<_, Reference<_, ...` recursively, leading to
+/// non-termination. Hence, we restrict the types which can be used as
+/// `Reference::remote` artificially.
+pub trait AsRemote: Into<ext::RefLike> + sealed::Sealed {}
+
+impl AsRemote for PeerId {}
+impl AsRemote for &PeerId {}
+
+impl AsRemote for ext::RefLike {}
+impl AsRemote for &ext::RefLike {}
+
+impl sealed::Sealed for ext::RefLike {}
+impl sealed::Sealed for &ext::RefLike {}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Reference<Namespace, Remote, Cardinality> {
@@ -289,7 +307,7 @@ impl<N, R> Reference<N, R, One> {
 impl<N, R> Display for Reference<N, R, One>
 where
     N: AsNamespace,
-    for<'a> &'a R: Into<ext::RefLike>,
+    for<'a> &'a R: AsRemote,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(Into::<ext::RefLike>::into(self).as_str())
@@ -299,7 +317,7 @@ where
 impl<'a, N, R> From<&'a Reference<N, R, One>> for ext::RefLike
 where
     N: AsNamespace,
-    &'a R: Into<ext::RefLike>,
+    &'a R: AsRemote,
 {
     fn from(r: &'a Reference<N, R, One>) -> Self {
         let mut path = PathBuf::new();
@@ -320,7 +338,7 @@ where
 impl<'a, N, R> From<&'a Reference<N, R, One>> for ext::RefspecPattern
 where
     N: AsNamespace,
-    &'a R: Into<ext::RefLike>,
+    &'a R: AsRemote,
 {
     fn from(r: &'a Reference<N, R, One>) -> Self {
         Into::<ext::RefLike>::into(r).into()
@@ -366,7 +384,7 @@ impl<N, R> Reference<N, R, Many> {
 impl<N, R> Display for Reference<N, R, Many>
 where
     N: AsNamespace,
-    for<'a> &'a R: Into<ext::RefLike>,
+    for<'a> &'a R: AsRemote,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(Into::<ext::RefspecPattern>::into(self).as_str())
@@ -376,7 +394,7 @@ where
 impl<'a, N, R> From<&'a Reference<N, R, Many>> for ext::RefspecPattern
 where
     N: AsNamespace,
-    &'a R: Into<ext::RefLike>,
+    &'a R: AsRemote,
 {
     fn from(r: &'a Reference<N, R, Many>) -> Self {
         let mut path = PathBuf::new();


### PR DESCRIPTION
This should prevent the typechecker from recursing, at the expense of a loss of generality.
