### PR TITLE
Check certifier existence

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -787,11 +787,15 @@ where
                             self.adopt_as_ours(&remote_certifier, &certifier_id)?;
                         }
 
-                        certifier_id
-                            .symbolic_ref(certifier_here, Force::False)
-                            .create(&self.backend)
-                            .map_err(Error::from)
-                            .and(Ok(()))
+                        if !self.has_ref(&certifier_here)? {
+                            certifier_id
+                                .symbolic_ref(certifier_here, Force::False)
+                                .create(&self.backend)
+                                .map_err(Error::from)
+                                .and(Ok(()))
+                        } else {
+                            Ok(())
+                        }
                     },
                 }
             })?;


### PR DESCRIPTION
It could be the case that we already have the certifier -- for example,
we have cloned the project but now we are fetching. In this case we
should check if it exists before creating the symbolic reference,
otherwise it's a no-op.