### PR TITLE
Fix: ignore errors if certifier symref already exists

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -790,8 +790,8 @@ where
                         certifier_id
                             .symbolic_ref(certifier_here, Force::False)
                             .create(&self.backend)
-                            .map_err(Error::from)
                             .and(Ok(()))
+                            .or_matches::<Error, _, _>(is_exists_err, || Ok(()))
                     },
                 }
             })?;


### PR DESCRIPTION
Somewhat counter-intuitively, `Force::False` will still return an error
if the symbolic reference already exists. We ignore this error, and
proceed attempting to symref the remaining certifier ids.
