### PR TITLE
Macros: transmute into target type

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -43,7 +43,11 @@ pub fn reflike(input: TokenStream) -> TokenStream {
         Ok(safe) => {
             let safe_str = safe.as_str();
             let expand = quote! {
-                ::std::convert::TryInto::<::radicle_git_ext::RefLike>::try_into(#safe_str).unwrap()
+                unsafe {
+                    ::std::mem::transmute::<::std::path::PathBuf, ::radicle_git_ext::RefLike>(
+                        ::std::convert::From::from(#safe_str)
+                    )
+                }
             };
 
             TokenStream::from(expand)
@@ -78,7 +82,11 @@ pub fn refspec_pattern(input: TokenStream) -> TokenStream {
         Ok(safe) => {
             let safe_str = safe.as_str();
             let expand = quote! {
-                ::std::convert::TryInto::<::radicle_git_ext::RefspecPattern>::try_into(#safe_str).unwrap()
+                unsafe {
+                    ::std::mem::transmute::<::std::path::PathBuf, ::radicle_git_ext::RefspecPattern>(
+                        ::std::convert::From::from(#safe_str)
+                    )
+                }
             };
 
             TokenStream::from(expand)


### PR DESCRIPTION
Turns out we can actually avoid the runtime conversion (and allocation).
The only potential drawback is that we emit `unsafe` code, which linters
may dislike.