### PR TITLE
protocol: handle disconnect when conn is done

### DIFF
--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -61,7 +61,7 @@ use crate::{
 #[derive(Clone, Debug)]
 pub enum ProtocolEvent<A> {
     Connected(PeerId),
-    Disconnected(PeerId),
+    Disconnecting(PeerId),
     Listening(SocketAddr),
     Gossip(gossip::Info<IpAddr, A>),
     Membership(gossip::MembershipInfo<IpAddr>),
@@ -487,7 +487,7 @@ where
         if let Some(conn) = self.connections.lock().await.remove(&peer) {
             tracing::info!(msg = "Disconnecting", remote.addr = %conn.remote_addr());
             self.subscribers
-                .emit(ProtocolEvent::Disconnected(peer))
+                .emit(ProtocolEvent::Disconnecting(peer))
                 .await
         }
     }

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -251,7 +251,7 @@ impl Node {
 
                 transmit.send(event).await.ok();
             },
-            ProtocolEvent::Disconnecting(id) => {
+            ProtocolEvent::Disconnected(id) => {
                 transmit.send(Event::PeerDisconnected(id)).await.ok();
             },
             ProtocolEvent::Listening(addr) => {

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -251,7 +251,7 @@ impl Node {
 
                 transmit.send(event).await.ok();
             },
-            ProtocolEvent::Disconnected(id) => {
+            ProtocolEvent::Disconnecting(id) => {
                 transmit.send(Event::PeerDisconnected(id)).await.ok();
             },
             ProtocolEvent::Listening(addr) => {


### PR DESCRIPTION
Adds explicit disconnect handling in the two places where they seemed to
lack so far. This should make it possible for a protocol user to observe
all disconnections, not only the ones initiated by the gossip layer.
Might be worthwhile at a later stage to bubble up the connect and
disconnect control events from gossip. Also aligned the variant names.