### PR TITLE
Use BTreeSet instead of HashSet

### DIFF
--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fmt::Debug,
     hash::Hash,
     iter,
@@ -38,13 +38,13 @@ pub use git_ext::Oid;
 
 /// The transitive tracking graph, up to 3 degrees
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Remotes<A: PartialEq + Eq + Hash>(HashMap<A, HashMap<A, HashSet<A>>>);
+pub struct Remotes<A: PartialEq + Eq + Ord + Hash>(HashMap<A, HashMap<A, BTreeSet<A>>>);
 
 impl<A> Remotes<A>
 where
-    A: PartialEq + Eq + Hash,
+    A: PartialEq + Eq + Ord + Hash,
 {
-    pub fn cutoff(self) -> HashMap<A, HashSet<A>>
+    pub fn cutoff(self) -> HashMap<A, BTreeSet<A>>
     where
         A: Clone,
     {
@@ -63,7 +63,7 @@ where
         })
     }
 
-    pub fn from_map(map: HashMap<A, HashMap<A, HashSet<A>>>) -> Self {
+    pub fn from_map(map: HashMap<A, HashMap<A, BTreeSet<A>>>) -> Self {
         Self(map)
     }
 
@@ -74,9 +74,9 @@ where
 
 impl<A> Deref for Remotes<A>
 where
-    A: PartialEq + Eq + Hash,
+    A: PartialEq + Eq + Ord + Hash,
 {
-    type Target = HashMap<A, HashMap<A, HashSet<A>>>;
+    type Target = HashMap<A, HashMap<A, BTreeSet<A>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -85,18 +85,18 @@ where
 
 impl<A> DerefMut for Remotes<A>
 where
-    A: PartialEq + Eq + Hash,
+    A: PartialEq + Eq + Ord + Hash,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<A> From<HashMap<A, HashMap<A, HashSet<A>>>> for Remotes<A>
+impl<A> From<HashMap<A, HashMap<A, BTreeSet<A>>>> for Remotes<A>
 where
-    A: PartialEq + Eq + Hash,
+    A: PartialEq + Eq + Ord + Hash,
 {
-    fn from(map: HashMap<A, HashMap<A, HashSet<A>>>) -> Self {
+    fn from(map: HashMap<A, HashMap<A, BTreeSet<A>>>) -> Self {
         Self::from_map(map)
     }
 }

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::BTreeMap,
     fmt::Debug,
     hash::Hash,
     iter,
@@ -38,19 +38,19 @@ pub use git_ext::Oid;
 
 /// The transitive tracking graph, up to 3 degrees
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Remotes<A: PartialEq + Eq + Ord + Hash>(HashMap<A, HashMap<A, BTreeSet<A>>>);
+pub struct Remotes<A: PartialEq + Eq + Ord>(BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>);
 
 impl<A> Remotes<A>
 where
     A: PartialEq + Eq + Ord + Hash,
 {
-    pub fn cutoff(self) -> HashMap<A, BTreeSet<A>>
+    pub fn cutoff(self) -> BTreeMap<A, BTreeMap<A, ()>>
     where
         A: Clone,
     {
         self.0
             .into_iter()
-            .map(|(k, v)| (k, v.keys().cloned().collect()))
+            .map(|(k, v)| (k, v.keys().map(|x| (x.clone(), ())).collect()))
             .collect()
     }
 
@@ -58,12 +58,12 @@ where
         self.0.iter().flat_map(|(k, v)| {
             iter::once(k).chain(
                 v.iter()
-                    .flat_map(|(k1, v1)| iter::once(k1).chain(v1.iter())),
+                    .flat_map(|(k1, v1)| iter::once(k1).chain(v1.keys())),
             )
         })
     }
 
-    pub fn from_map(map: HashMap<A, HashMap<A, BTreeSet<A>>>) -> Self {
+    pub fn from_map(map: BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>) -> Self {
         Self(map)
     }
 
@@ -76,7 +76,7 @@ impl<A> Deref for Remotes<A>
 where
     A: PartialEq + Eq + Ord + Hash,
 {
-    type Target = HashMap<A, HashMap<A, BTreeSet<A>>>;
+    type Target = BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -92,11 +92,11 @@ where
     }
 }
 
-impl<A> From<HashMap<A, HashMap<A, BTreeSet<A>>>> for Remotes<A>
+impl<A> From<BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>> for Remotes<A>
 where
     A: PartialEq + Eq + Ord + Hash,
 {
-    fn from(map: HashMap<A, HashMap<A, BTreeSet<A>>>) -> Self {
+    fn from(map: BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>) -> Self {
         Self::from_map(map)
     }
 }

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -17,7 +17,7 @@
 
 use std::{
     borrow::Borrow,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     convert::TryFrom,
     io,
     iter,
@@ -362,7 +362,7 @@ impl<S: Clone> Storage<S> {
 
         // Get 1st degree tracked peers from the remotes configured in .git/config
         let tracked = self.tracked(urn)?;
-        let mut remotes: HashMap<PeerId, HashMap<PeerId, HashSet<PeerId>>> =
+        let mut remotes: HashMap<PeerId, HashMap<PeerId, BTreeSet<PeerId>>> =
             tracked.map(|peer| (peer, HashMap::new())).collect();
 
         tracing::debug!(urn = %urn, remotes.bare = ?remotes);

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -17,7 +17,7 @@
 
 use std::{
     borrow::Borrow,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     convert::TryFrom,
     io,
     iter,
@@ -362,8 +362,8 @@ impl<S: Clone> Storage<S> {
 
         // Get 1st degree tracked peers from the remotes configured in .git/config
         let tracked = self.tracked(urn)?;
-        let mut remotes: HashMap<PeerId, HashMap<PeerId, BTreeSet<PeerId>>> =
-            tracked.map(|peer| (peer, HashMap::new())).collect();
+        let mut remotes: BTreeMap<PeerId, BTreeMap<PeerId, BTreeMap<PeerId, ()>>> =
+            tracked.map(|peer| (peer, BTreeMap::new())).collect();
 
         tracing::debug!(urn = %urn, remotes.bare = ?remotes);
 

--- a/librad/src/git/storage/test.rs
+++ b/librad/src/git/storage/test.rs
@@ -17,7 +17,7 @@
 
 use super::*;
 
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 
 use crate::{
     git::types::NamespacedRef,


### PR DESCRIPTION
Using a HashSet the iter method will return items in an arbitrary order.
Since this is what serde uses under the hood to turn HashSet into an
array, it destabilises the signing and verification of refs.

Using a BTreeSet gives us a guaranteed order for the array, meaning
consistent de/serialization across peers.