### PR TITLE
Use BTreeSet instead of HashSet

### DIFF
--- a/librad/src/git/fetch.rs
+++ b/librad/src/git/fetch.rs
@@ -557,7 +557,6 @@ mod tests {
     #[test]
     fn replicate_looks_legit() {
         use crate::git::refs::{Refs, Remotes};
-        use std::collections::HashMap;
 
         lazy_static! {
             static ref ZERO: ext::Oid = ext::Oid::from(git2::Oid::zero());
@@ -577,7 +576,7 @@ mod tests {
                         .iter()
                         .cloned()
                         .collect(),
-                    remotes: Remotes::from_map(HashMap::new()),
+                    remotes: Remotes::from_map(BTreeMap::new()),
                 },
             ),
             (
@@ -590,7 +589,7 @@ mod tests {
                     .iter()
                     .cloned()
                     .collect(),
-                    remotes: Remotes::from_map(HashMap::new()),
+                    remotes: Remotes::from_map(BTreeMap::new()),
                 },
             ),
         ]

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::BTreeMap,
     convert::TryFrom,
     fmt::Debug,
     hash::Hash,
@@ -46,19 +46,19 @@ pub use git_ext::Oid;
 
 /// The transitive tracking graph, up to 3 degrees
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Remotes<A: PartialEq + Eq + Ord + Hash>(HashMap<A, HashMap<A, BTreeSet<A>>>);
+pub struct Remotes<A: PartialEq + Eq + Ord>(BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>);
 
 impl<A> Remotes<A>
 where
     A: PartialEq + Eq + Ord + Hash,
 {
-    pub fn cutoff(self) -> HashMap<A, BTreeSet<A>>
+    pub fn cutoff(self) -> BTreeMap<A, BTreeMap<A, ()>>
     where
         A: Clone,
     {
         self.0
             .into_iter()
-            .map(|(k, v)| (k, v.keys().cloned().collect()))
+            .map(|(k, v)| (k, v.keys().map(|x| (x.clone(), ())).collect()))
             .collect()
     }
 
@@ -66,12 +66,12 @@ where
         self.0.iter().flat_map(|(k, v)| {
             iter::once(k).chain(
                 v.iter()
-                    .flat_map(|(k1, v1)| iter::once(k1).chain(v1.iter())),
+                    .flat_map(|(k1, v1)| iter::once(k1).chain(v1.keys())),
             )
         })
     }
 
-    pub fn from_map(map: HashMap<A, HashMap<A, BTreeSet<A>>>) -> Self {
+    pub fn from_map(map: BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>) -> Self {
         Self(map)
     }
 
@@ -84,7 +84,7 @@ impl<A> Deref for Remotes<A>
 where
     A: PartialEq + Eq + Ord + Hash,
 {
-    type Target = HashMap<A, HashMap<A, BTreeSet<A>>>;
+    type Target = BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -100,11 +100,11 @@ where
     }
 }
 
-impl<A> From<HashMap<A, HashMap<A, BTreeSet<A>>>> for Remotes<A>
+impl<A> From<BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>> for Remotes<A>
 where
     A: PartialEq + Eq + Ord + Hash,
 {
-    fn from(map: HashMap<A, HashMap<A, BTreeSet<A>>>) -> Self {
+    fn from(map: BTreeMap<A, BTreeMap<A, BTreeMap<A, ()>>>) -> Self {
         Self::from_map(map)
     }
 }
@@ -195,8 +195,8 @@ impl Refs {
             })?;
 
         let mut remotes = tracking::tracked(storage, urn)?
-            .map(|peer| (peer, HashMap::new()))
-            .collect::<HashMap<PeerId, HashMap<PeerId, BTreeSet<PeerId>>>>();
+            .map(|peer| (peer, BTreeMap::new()))
+            .collect::<BTreeMap<PeerId, BTreeMap<PeerId, BTreeMap<PeerId, ()>>>>();
 
         for (peer, tracked) in remotes.iter_mut() {
             if let Some(refs) = Self::load(storage, urn, *peer)? {

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     convert::TryFrom,
     fmt::Debug,
     hash::Hash,
@@ -46,13 +46,13 @@ pub use git_ext::Oid;
 
 /// The transitive tracking graph, up to 3 degrees
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Remotes<A: PartialEq + Eq + Hash>(HashMap<A, HashMap<A, HashSet<A>>>);
+pub struct Remotes<A: PartialEq + Eq + Ord + Hash>(HashMap<A, HashMap<A, BTreeSet<A>>>);
 
 impl<A> Remotes<A>
 where
-    A: PartialEq + Eq + Hash,
+    A: PartialEq + Eq + Ord + Hash,
 {
-    pub fn cutoff(self) -> HashMap<A, HashSet<A>>
+    pub fn cutoff(self) -> HashMap<A, BTreeSet<A>>
     where
         A: Clone,
     {
@@ -71,7 +71,7 @@ where
         })
     }
 
-    pub fn from_map(map: HashMap<A, HashMap<A, HashSet<A>>>) -> Self {
+    pub fn from_map(map: HashMap<A, HashMap<A, BTreeSet<A>>>) -> Self {
         Self(map)
     }
 
@@ -82,9 +82,9 @@ where
 
 impl<A> Deref for Remotes<A>
 where
-    A: PartialEq + Eq + Hash,
+    A: PartialEq + Eq + Ord + Hash,
 {
-    type Target = HashMap<A, HashMap<A, HashSet<A>>>;
+    type Target = HashMap<A, HashMap<A, BTreeSet<A>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -93,18 +93,18 @@ where
 
 impl<A> DerefMut for Remotes<A>
 where
-    A: PartialEq + Eq + Hash,
+    A: PartialEq + Eq + Ord + Hash,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<A> From<HashMap<A, HashMap<A, HashSet<A>>>> for Remotes<A>
+impl<A> From<HashMap<A, HashMap<A, BTreeSet<A>>>> for Remotes<A>
 where
-    A: PartialEq + Eq + Hash,
+    A: PartialEq + Eq + Ord + Hash,
 {
-    fn from(map: HashMap<A, HashMap<A, HashSet<A>>>) -> Self {
+    fn from(map: HashMap<A, HashMap<A, BTreeSet<A>>>) -> Self {
         Self::from_map(map)
     }
 }
@@ -196,7 +196,7 @@ impl Refs {
 
         let mut remotes = tracking::tracked(storage, urn)?
             .map(|peer| (peer, HashMap::new()))
-            .collect::<HashMap<PeerId, HashMap<PeerId, HashSet<PeerId>>>>();
+            .collect::<HashMap<PeerId, HashMap<PeerId, BTreeSet<PeerId>>>>();
 
         for (peer, tracked) in remotes.iter_mut() {
             if let Some(refs) = Self::load(storage, urn, *peer)? {


### PR DESCRIPTION
A forward patch of https://github.com/radicle-dev/radicle-link/pull/406

Using a HashSet the iter method will return items in an arbitrary order.
Since this is what serde uses under the hood to turn HashSet into an
array, it destabilises the signing and verification of refs.

Using a BTreeSet gives us a guaranteed order for the array, meaning
consistent de/serialization across peers.