### PR TITLE
Add Info::Applied

### DIFF
--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -101,6 +101,7 @@ where
     Addr: Clone + PartialEq + Eq + Hash,
 {
     Has(Has<Addr, A>),
+    Applied(A),
 }
 
 #[derive(Clone, Debug)]
@@ -683,11 +684,15 @@ where
                             self.broadcast(
                                 Have {
                                     origin: self.local_peer_info(),
-                                    val,
+                                    val: val.clone(),
                                 },
                                 remote_id,
                             )
-                            .await
+                            .await;
+
+                            self.subscribers
+                                .emit(ProtocolEvent::Info(Info::Applied(val)))
+                                .await;
                         },
 
                         // Meh. Request retransmission.

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -251,6 +251,15 @@ impl Node {
                     }
                 }
             },
+            ProtocolEvent::Gossip(gossip::Info::Applied(peer::Gossip { urn, rev, origin })) => {
+                let peer_id = origin.map(|peer| peer.to_string());
+                tracing::info!(
+                    "Applied change for URN `{}`, rev = {:?}, peer.id = {:?}",
+                    urn,
+                    rev,
+                    peer_id
+                );
+            },
             ProtocolEvent::Connected(id) => {
                 let event = Event::peer_connected(id, &api).await?;
 


### PR DESCRIPTION
When having tracked a peer we don't immediately have their changes. We
can know that we do have the peer's changes when we have fetched their
changes or if we have applied them from a gossip message.

We need a way to surface that a result was successfully applied. In this
patch we do this by adding it to the `Info` enum and emit the protocol
message to the subscribers.