### PR TITLE
Forward patch: Include fixes

### DIFF
--- a/librad/src/git/include.rs
+++ b/librad/src/git/include.rs
@@ -176,8 +176,8 @@ impl<Path> Include<Path> {
 
     fn build_remote(url: LocalUrl, peer: PeerId, handle: &str) -> Result<Remote<LocalUrl>, Error> {
         let name = format!("{}@{}", handle, peer);
-        let heads: FlatRef<PeerId, _> = FlatRef::heads(PhantomData, peer);
-        let heads = heads.with_name(ext::RefspecPattern::try_from("heads/*").unwrap());
+        let heads: FlatRef<PeerId, _> =
+            FlatRef::heads(PhantomData, peer).with_name(refspec_pattern!("heads/*"));
         let remotes = FlatRef::heads(PhantomData, ext::RefLike::try_from(handle)?);
         Ok(Remote::new(url, name).with_refspec(remotes.refspec(heads, Force::True).boxed()))
     }

--- a/librad/src/git/types/remote.rs
+++ b/librad/src/git/types/remote.rs
@@ -124,6 +124,11 @@ impl<Url> Remote<Url> {
         }
     }
 
+    pub fn with_refspec(mut self, refspec: Box<dyn AsRefspec>) -> Self {
+        self.fetch_spec = Some(refspec);
+        self
+    }
+
     /// Add a series of push specs to the remote.
     pub fn add_pushes<I>(&mut self, specs: I)
     where

--- a/librad/tests/working_copy.rs
+++ b/librad/tests/working_copy.rs
@@ -231,7 +231,7 @@ where
             local_peer_id: peer.peer_id(),
         },
         tracked_users,
-    );
+    )?;
     let inc_path = inc.file_path();
     inc.save()?;
 


### PR DESCRIPTION
maint patch: https://github.com/radicle-dev/radicle-link/pull/412

If no fetch refspec was provided we would incorrectly use our own PeerId
in the refspec. This is essentially useless because we shouldn't have
our own PeerId under our remotes.

Instead, we change the interface so that remotes are added by providing
the PeerId and handle, then building the Remote with the fetch refspec
internally.