### PR TITLE
git: set libgit2 mwindow file limit

### DIFF
--- a/librad/src/git.rs
+++ b/librad/src/git.rs
@@ -30,3 +30,27 @@ pub mod types;
 mod sealed;
 
 pub use crate::identities::git::Urn;
+
+/// Initialise the git backend.
+///
+/// **SHOULD** be called before all accesses to git functionality.
+pub fn init() {
+    use libc::c_int;
+    use libgit2_sys as raw_git;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    unsafe {
+        INIT.call_once(|| {
+            let ret =
+                raw_git::git_libgit2_opts(raw_git::GIT_OPT_SET_MWINDOW_FILE_LIMIT as c_int, 256);
+            if ret < 0 {
+                panic!(
+                    "error setting libgit2 option: {}",
+                    git2::Error::last_error(ret).unwrap()
+                )
+            }
+        })
+    }
+}

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -72,6 +72,8 @@ impl Storage {
         S: Signer + Clone,
         S::Error: std::error::Error + Send + Sync + 'static,
     {
+        crate::git::init();
+
         let backend = git2::Repository::open_bare(paths.git_dir())?;
         let peer_id = Config::try_from(&backend)?.peer_id()?;
 
@@ -91,6 +93,8 @@ impl Storage {
         S: Signer + Clone,
         S::Error: std::error::Error + Send + Sync + 'static,
     {
+        crate::git::init();
+
         let mut backend = git2::Repository::init_opts(
             paths.git_dir(),
             git2::RepositoryInitOptions::new()


### PR DESCRIPTION
Should help prevent exhausting fd limits, as libgit2 is accumulating fds to packfiles.
