### PR TITLE
Various guards against dancing with oneself

### DIFF
--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -503,16 +503,13 @@ where
     {
         let remote_id = conn.remote_peer_id();
         tracing::info!(remote.id = %remote_id, "New incoming connection");
-
         {
             self.connections.lock().await.insert(remote_id, conn);
             self.subscribers
                 .emit(ProtocolEvent::Connected(remote_id))
                 .await;
         }
-
         let res = self.handle_incoming_streams(incoming).await;
-
         self.handle_disconnect(remote_id).await;
 
         res


### PR DESCRIPTION
- replication: do not track self
- replication: deny replicating from self
- net: deny ingress + egress connections to local peer id

Does NOT fix #410, but can't hurt either.
