### PR TITLE
protocol: filter out unroutable IP addresses for connect

### DIFF
--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -20,6 +20,7 @@
 #![feature(bool_to_option)]
 #![feature(btree_drain_filter)]
 #![feature(core_intrinsics)]
+#![feature(ip)]
 #![feature(never_type)]
 
 #[macro_use]

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -706,7 +706,13 @@ async fn connect<Addrs>(
 where
     Addrs: IntoIterator<Item = SocketAddr>,
 {
+    fn routable(addr: &SocketAddr) -> bool {
+        let ip = addr.ip();
+        !(ip.is_unspecified() || ip.is_documentation() || ip.is_multicast())
+    }
+
     futures::stream::iter(addrs)
+        .filter(|addr| future::ready(routable(addr)))
         .filter_map(|addr| {
             let mut endpoint = endpoint.clone();
             tracing::info!(remote.id = %peer_id, "Establishing connection");


### PR DESCRIPTION
The advertised address might be `0.0.0.0`. This is a quick fix, we may want to catch this earlier in the future.
