### PR TITLE
net: guard against a panic when connecting

### DIFF
--- a/librad/src/net/gossip.rs
+++ b/librad/src/net/gossip.rs
@@ -253,7 +253,13 @@ where
                 .peers
                 .entry(info.peer_id)
                 .or_insert_with(|| info.clone());
-            entry.seen_addrs = entry.seen_addrs.union(&info.seen_addrs).cloned().collect();
+            let seen_addrs = entry
+                .seen_addrs
+                .union(&info.seen_addrs)
+                .cloned()
+                .collect::<HashSet<_>>();
+            debug_assert!(!seen_addrs.is_empty());
+            entry.seen_addrs = seen_addrs;
         }
     }
 


### PR DESCRIPTION
It is unclear if there is a condition where `seen_addrs` can be empty,
or if `quinn::Connection::remote_address` can return a non-routable
address. This is a quick fix to to prevent `future::select_ok` from
panicking when given an empty iterator.
