### PR TITLE
net: mDNS-SD

### DIFF
--- a/ci/build-test
+++ b/ci/build-test
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 echo '--- Build'
-cargo build --verbose --workspace
+cargo build --verbose --workspace --all-features
 
 echo '--- Test'
-GIT_TRACE2=1 RUST_LOG=librad=trace cargo test --workspace
+GIT_TRACE2=1 RUST_LOG=librad=trace cargo test --workspace --all-features

--- a/ci/docs
+++ b/ci/docs
@@ -2,4 +2,4 @@
 set -eou pipefail
 
 echo "--- Docs"
-cargo doc --no-deps --workspace --document-private-items
+cargo doc --no-deps --workspace --document-private-items --all-features

--- a/deny.toml
+++ b/deny.toml
@@ -204,6 +204,6 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
     "https://github.com/djc/quinn",
-    "https://github.com/radicle-dev/radicle-keystore",
     "https://github.com/kim/ed25519-zebra",
+    "https://github.com/meilisearch/madness",
 ]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["The Radicle Team <dev@radicle.xyz>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
 
+[features]
+default = []
+disco-mdns = ["mdns", "madness"]
+
 [dependencies]
 async-trait = "0.1"
 bit-vec = "0.6"
@@ -17,6 +21,7 @@ globset = "0.4"
 governor = "0.3"
 lazy_static = "1"
 libc = "0.2"
+mdns = { version = "1", optional = true }
 multibase = "0.9"
 multihash = "0.11"
 nom = "5"
@@ -26,6 +31,7 @@ percent-encoding = "2"
 picky-asn1 = "0.3"
 picky-asn1-der = "0.2"
 picky-asn1-x509 = "0.4"
+pnet_datalink = "0.27"
 radicle-keystore = "0"
 rand = "0.7"
 rand_pcg = "0.2"
@@ -73,6 +79,11 @@ version = "0.12"
 default-features = false
 features = []
 
+[dependencies.madness]
+git = "https://github.com/meilisearch/madness"
+rev = "cb12159a06f3698d0ba4ea078e95f8a915a9a9d3"
+optional = true
+
 [dependencies.minicbor]
 version = ">= 0.5, 0"
 features = ["std", "derive"]
@@ -116,6 +127,7 @@ features = ["serde"]
 [dependencies.zeroize]
 version = "1.1"
 features = ["zeroize_derive"]
+
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1"

--- a/librad/src/net/discovery/mdns.rs
+++ b/librad/src/net/discovery/mdns.rs
@@ -1,0 +1,230 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{channel::mpsc, stream::StreamExt as _, SinkExt as _};
+use madness::{
+    dns::{PacketBuilder, RData, ResourceRecord},
+    service::{Query, ServiceDiscovery},
+    MdnsService,
+    Packet,
+};
+
+use super::Discovery;
+use crate::peer::PeerId;
+
+const SERVICE_NAME: &str = "_radicle-link._udp.local";
+
+pub struct Mdns {
+    _query: ServiceDiscovery,
+    chan: mpsc::Receiver<(PeerId, Vec<SocketAddr>)>,
+}
+
+impl Mdns {
+    pub fn new(
+        local_peer: PeerId,
+        listen_addrs: Vec<SocketAddr>,
+        query_interval: Duration,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut srv = MdnsService::new(true)?;
+        srv.register(SERVICE_NAME);
+        let query = srv.discover(SERVICE_NAME, query_interval);
+
+        let ptr = format!("{}.{}", local_peer, SERVICE_NAME);
+        let cname = format!("{}.radicle.local", local_peer);
+
+        let (mut tx, rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            tracing::info!("starting mDNS service discovery");
+            loop {
+                let packet = srv.next().await;
+                match packet {
+                    Packet::Query(queries) => {
+                        for query in queries {
+                            respond(&ptr, &cname, &listen_addrs, &mut srv, query)
+                        }
+                    },
+                    Packet::Response(resp) => {
+                        for info in discover(&cname, resp) {
+                            if tx.send(info).await.is_err() {
+                                tracing::info!("stopping the madness");
+                                return;
+                            }
+                        }
+                    },
+                }
+            }
+        });
+
+        Ok(Self {
+            _query: query,
+            chan: rx,
+        })
+    }
+}
+
+impl futures::stream::Stream for Mdns {
+    type Item = (PeerId, Vec<SocketAddr>);
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        self.chan.poll_next_unpin(cx)
+    }
+}
+
+impl Discovery for Mdns {
+    type Addr = SocketAddr;
+    type Stream = Self;
+
+    fn discover(self) -> Self::Stream {
+        self
+    }
+}
+
+fn respond(
+    ptr: &str,
+    cname: &str,
+    listen_addrs: &[SocketAddr],
+    srv: &mut MdnsService,
+    query: Query,
+) {
+    use std::net::SocketAddr::*;
+
+    if query.is_meta_service_query() {
+        let mut packet = PacketBuilder::new();
+        packet.header_mut().set_id(rand::random()).set_query(false);
+        packet.add_answer(ResourceRecord::IN(
+            madness::META_QUERY_SERVICE,
+            RData::ptr(SERVICE_NAME),
+        ));
+        let packet = packet.build();
+        srv.enqueue_response(packet);
+    } else if query.name.as_str() == SERVICE_NAME {
+        let mut packet = PacketBuilder::new();
+        packet.add_answer(ResourceRecord::IN(SERVICE_NAME, RData::ptr(&ptr)));
+
+        for addr in listen_addrs {
+            packet.add_answer(ResourceRecord::IN(
+                &ptr,
+                RData::srv(addr.port(), 0, 0, &cname),
+            ));
+            match addr {
+                V4(ip4) => {
+                    packet.add_answer(
+                        ResourceRecord::IN(&cname, RData::a(*ip4.ip()))
+                            .set_ttl(Duration::from_secs(300)),
+                    );
+                },
+                V6(ip6) => {
+                    packet.add_answer(
+                        ResourceRecord::IN(&cname, RData::aaaa(*ip6.ip()))
+                            .set_ttl(Duration::from_secs(300)),
+                    );
+                },
+            }
+        }
+        packet.header_mut().set_id(rand::random()).set_query(false);
+        let packet = packet.build();
+        srv.enqueue_response(packet);
+    }
+}
+
+fn discover(cname: &str, resp: mdns::Response) -> impl Iterator<Item = (PeerId, Vec<SocketAddr>)> {
+    use mdns::{Record, RecordKind::*};
+
+    let mut ports = BTreeMap::<PeerId, BTreeSet<u16>>::new();
+    let mut addrs = BTreeMap::<PeerId, BTreeSet<IpAddr>>::new();
+    let mut add_addr = |peer, addr| {
+        addrs
+            .entry(peer)
+            .and_modify(|addrs| {
+                addrs.insert(addr);
+            })
+            .or_insert_with(|| vec![addr].into_iter().collect());
+    };
+
+    fn peer_from_domain(dom: &str) -> Option<PeerId> {
+        dom.split('.').next().and_then(|first| first.parse().ok())
+    }
+
+    for Record { name, kind, .. } in resp.records() {
+        match kind {
+            SRV { target, port, .. } if target != cname && name.ends_with(SERVICE_NAME) => {
+                if let Some(peer) = peer_from_domain(target) {
+                    ports
+                        .entry(peer)
+                        .and_modify(|ports| {
+                            ports.insert(*port);
+                        })
+                        .or_insert_with(|| vec![*port].into_iter().collect());
+                }
+            },
+            A(ip4) if name != cname => {
+                if let Some(peer) = peer_from_domain(name) {
+                    add_addr(peer, IpAddr::from(*ip4));
+                }
+            },
+            AAAA(ip6) if name != cname => {
+                if let Some(peer) = peer_from_domain(name) {
+                    add_addr(peer, IpAddr::from(*ip6));
+                }
+            },
+
+            _ => (),
+        }
+    }
+
+    addrs.into_iter().filter_map(move |(peer, addrs)| {
+        ports.get(&peer).map(|ports| {
+            let addrs = addrs
+                .iter()
+                .flat_map(|addr| ports.iter().map(move |port| SocketAddr::new(*addr, *port)))
+                .collect();
+            (peer, addrs)
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use std::net::Ipv4Addr;
+
+    use crate::{keys::SecretKey, peer::PeerId};
+
+    // `madness` uses tokio, so no choice here -- MADNESS!
+    #[tokio::test]
+    // CI doesn't support multicast UDP
+    #[ignore]
+    async fn ohai() {
+        let lolek_id = PeerId::from(SecretKey::new());
+        let lolek_addrs = vec![SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            666,
+        )];
+        let bolek_id = PeerId::from(SecretKey::new());
+        let bolek_addrs = vec![SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            777,
+        )];
+
+        let interval = Duration::from_secs(10);
+
+        let mut lolek = Mdns::new(lolek_id, lolek_addrs.clone(), interval).unwrap();
+        let mut bolek = Mdns::new(bolek_id, bolek_addrs.clone(), interval).unwrap();
+
+        let (lolek_disco, bolek_disco) = futures::join!(lolek.next(), bolek.next());
+        assert_eq!(lolek_disco, Some((bolek_id, bolek_addrs)));
+        assert_eq!(bolek_disco, Some((lolek_id, lolek_addrs)));
+    }
+}

--- a/librad/tests/propagation_basic.rs
+++ b/librad/tests/propagation_basic.rs
@@ -104,7 +104,7 @@ async fn can_clone_disconnected() {
                     None,
                     urn.clone(),
                     peer1.peer_id(),
-                    Some(peer1.listen_addr()),
+                    peer1.listen_addrs(),
                 )
                 .unwrap();
 
@@ -438,7 +438,7 @@ async fn menage_a_troi() {
             .with_storage({
                 let remote_peer = peer1.peer_id();
                 let urn = expected_urn.clone();
-                let addrs = Some(peer1.listen_addr());
+                let addrs = peer1.listen_addrs().collect::<Vec<_>>();
                 move |storage| -> Result<bool, anyhow::Error> {
                     replication::replicate(&storage, None, urn.clone(), remote_peer, addrs)?;
                     Ok(storage.has_commit(&urn, Box::new(commit_id))?)
@@ -451,7 +451,7 @@ async fn menage_a_troi() {
             .with_storage({
                 let remote_peer = peer2.peer_id();
                 let urn = expected_urn.clone();
-                let addrs = Some(peer2.listen_addr());
+                let addrs = peer2.listen_addrs().collect::<Vec<_>>();
                 move |storage| -> Result<bool, anyhow::Error> {
                     replication::replicate(&storage, None, urn.clone(), remote_peer, addrs)?;
                     Ok(storage.has_commit(&urn, Box::new(commit_id))?)


### PR DESCRIPTION
Adds mDNS discovery behind a feature flag.

Collaterals:

* When configured to listen on `0.0.0.0`, resolve the machine's network
  interfaces
* Instead of a single `SocketAddr`, return all addresses the peer is
  bound to (`Peer::listen_addrs`)
* Instead of specifiying the discovery in `PeerConfig`, supply it later
  to `Peer::bootstrap` (which is now public). This is necessary for
  mDNS, because it needs to know the bound addresses.
* Monomorphise `Static` disco, and define standard impls