### PR TITLE
Remove feature flag for zebra fork

### DIFF
--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -55,7 +55,6 @@ features = ["managed"]
 [dependencies.ed25519-zebra]
 git = "https://github.com/kim/ed25519-zebra"
 branch = "zeroize"
-features = ["zeroize"]
 
 [dependencies.either]
 version = ">= 1.3, 1"


### PR DESCRIPTION
The feature is not optional anymore since d216136. Currently
this breaks downstream builds as Cargo can't resolve the dependencies.