### PR TITLE
Depend on upstream ed215519-zebra

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -204,6 +204,6 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
     "https://github.com/djc/quinn",
-    "https://github.com/kim/ed25519-zebra",
+    "https://github.com/ZcashFoundation/ed25519-zebra",
     "https://github.com/meilisearch/madness",
 ]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -53,9 +53,8 @@ default-features = false
 features = ["managed"]
 
 [dependencies.ed25519-zebra]
-git = "https://github.com/kim/ed25519-zebra"
-branch = "zeroize"
-features = ["zeroize"]
+git = "https://github.com/ZcashFoundation/ed25519-zebra"
+rev = "0e7a96a267a756e642e102a28a44dd79b9c7df69"
 
 [dependencies.either]
 version = ">= 1.3, 1"


### PR DESCRIPTION
The patch was accepted, but no recent crates version has been released
yet.