### PR TITLE
git-helpers: Put credentials to git credential store when approved

### DIFF
--- a/git-helpers/src/remote_helper.rs
+++ b/git-helpers/src/remote_helper.rs
@@ -79,11 +79,13 @@ pub fn run() -> anyhow::Result<()> {
 }
 
 fn get_signer(git_dir: &Path, keys_dir: &Path, url: &LocalUrl) -> anyhow::Result<BoxedSigner> {
-    let pass = credential::Git::new(git_dir).get(url)?;
+    let mut cred = credential::Git::new(git_dir);
+    let pass = cred.get(url)?;
     let file = keys_dir.join(SECRET_KEY_FILE);
     let keystore =
-        FileStorage::<_, PublicKey, _, _>::new(&file, Pwhash::new(pass, *crypto::KDF_PARAMS_PROD));
+        FileStorage::<_, PublicKey, _, _>::new(&file, Pwhash::new(pass.clone(), *crypto::KDF_PARAMS_PROD));
     let key: SecretKey = keystore.get_key().map(|keypair| keypair.secret_key)?;
+    cred.put(url, pass)?;
 
     Ok(SomeSigner { signer: key }.into())
 }


### PR DESCRIPTION
Change `get_signer` to put back the credentials once the key store was succesfully unsealed. This solves the problem from #480 where credentials aren't automatically stored when a git credential helper (such as `git config credential.helper store`) is configured.

Signed-off-by: Wladimir J. van der Laan <laanwj@protonmail.com>