### PR TITLE
Fix broadcast local storage provider

### DIFF
--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -13,7 +13,7 @@ use crate::PeerId;
 #[tracing::instrument(skip(state, disco))]
 pub(super) async fn disco<S, D>(state: State<S>, disco: D)
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload> + 'static,
     D: futures::Stream<Item = (PeerId, Vec<SocketAddr>)>,
 {
     disco
@@ -27,7 +27,7 @@ where
 #[tracing::instrument(skip(state, tasks))]
 pub(super) async fn periodic<S, P>(state: State<S>, tasks: P)
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload> + 'static,
     P: futures::Stream<Item = membership::Periodic<SocketAddr>>,
 {
     tasks
@@ -76,7 +76,7 @@ where
 #[tracing::instrument(skip(state, rx))]
 pub(super) async fn ground_control<S, E>(state: State<S>, mut rx: E)
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload> + 'static,
     E: futures::Stream<Item = Result<event::Downstream, RecvError>> + Unpin,
 {
     use event::{

--- a/librad/src/net/protocol/broadcast.rs
+++ b/librad/src/net/protocol/broadcast.rs
@@ -69,9 +69,9 @@ pub(super) async fn apply<M, S, F, A, P>(
 ) -> Result<(Option<event::Gossip<A, P>>, Vec<tick::Tock<A, P>>), Error<A, P>>
 where
     M: Membership,
-    S: LocalStorage<Update = P> + ErrorRateLimited,
+    S: LocalStorage<A, Update = P> + ErrorRateLimited,
     F: Fn() -> PeerInfo<A>,
-    A: Clone + Debug + Ord,
+    A: Clone + Debug + Ord + Send + 'static,
     P: Clone + Debug,
 {
     use tick::Tock::*;
@@ -95,7 +95,7 @@ where
 
     match message {
         Have { origin, val } => {
-            let res = (*storage).put(remote_id, val.clone()).await;
+            let res = (*storage).put(origin.clone(), val.clone()).await;
             let event = event::Gossip::Put {
                 provider: origin.clone(),
                 payload: val.clone(),

--- a/librad/src/net/protocol/broadcast/storage.rs
+++ b/librad/src/net/protocol/broadcast/storage.rs
@@ -5,30 +5,53 @@
 
 use crate::peer::PeerId;
 
+/// Result of applying a broadcast update to local storage.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PutResult<Update> {
+    /// The `Update` was not previously seen, and applied successfully.
+    ///
+    /// The `Update` may be subject to transformations, e.g. to adjust origin
+    /// information. The payload of `Applied` will be used for further
+    /// broadcasting.
+    ///
+    /// Since the data is now available from the local peer, the `origin` value
+    /// of the gossip [`super::Message`] will be modified to point to the
+    /// local peer.
     Applied(Update),
+
+    /// The `Update` has already been applied previously.
+    ///
+    /// Broadcast will terminate here.
     Stale,
+
+    /// The `Update` is not interesting, typically because there is no tracking
+    /// relationship.
+    ///
+    /// The `Update` will be relayed, while the `origin` of the
+    /// [`super::Message`] stays unmodified.
     Uninteresting,
+
+    /// An (intermittent) error occurred while trying to apply the `Update`.
+    ///
+    /// The `Update` will be relayed, while the `origin` of the
+    /// [`super::Message`] stays unmodified. Additionally, the local peer
+    /// may ask for a retransmission of the `Update` at a later point.
     Error,
 }
 
 #[async_trait]
-pub trait LocalStorage: Clone + Send + Sync {
+pub trait LocalStorage<Addr>: Clone + Send + Sync {
+    /// The payload value of the broadcast message.
+    ///
+    /// Corresponds to `val` of [`super::Message`].
     type Update;
 
     /// Notify the local storage that a new value is available.
     ///
-    /// If the value was stored locally already, [`PutResult::Stale`] must be
-    /// returned. Otherwise, [`PutResult::Applied`] indicates that we _now_
-    /// have the value locally, and other peers may fetch it from us.
-    ///
-    /// [`PutResult::Error`] indicates that a storage error occurred -- either
-    /// the implementer wasn't able to determine if the local storage is
-    /// up-to-date, or it was not possible to fetch the actual state from
-    /// the `provider`. In this case, the network is asked to retransmit
-    /// [`Self::Update`], so we can eventually try again.
-    async fn put(&self, provider: PeerId, has: Self::Update) -> PutResult<Self::Update>;
+    /// The `provider` corresponds to the `origin` of [`super::Message::Have`].
+    async fn put<P>(&self, provider: P, has: Self::Update) -> PutResult<Self::Update>
+    where
+        P: Into<(PeerId, Vec<Addr>)> + Send;
 
     /// Ask the local storage if value `A` is available.
     ///

--- a/librad/src/net/protocol/gossip.rs
+++ b/librad/src/net/protocol/gossip.rs
@@ -61,7 +61,7 @@ pub struct Payload {
     /// The origin of the update.
     ///
     /// If `Some`, this refers to the `PeerId`'s view of `urn` and `rev`. That
-    /// is, it may map to `remotes/<PeerId>/<urn>`.
+    /// is, it may map to `remotes/<origin>/<urn.path@rev>`.
     #[n(2)]
     pub origin: Option<PeerId>,
 }

--- a/librad/src/net/protocol/info.rs
+++ b/librad/src/net/protocol/info.rs
@@ -67,6 +67,38 @@ where
     }
 }
 
+impl<Addr> From<PartialPeerInfo<Addr>> for (PeerId, Vec<Addr>)
+where
+    Addr: Clone + Ord,
+{
+    fn from(info: PartialPeerInfo<Addr>) -> Self {
+        (
+            info.peer_id,
+            info.advertised_info
+                .into_iter()
+                .flat_map(|ad| ad.listen_addrs.into_iter())
+                .chain(info.seen_addrs)
+                .collect(),
+        )
+    }
+}
+
+impl<Addr> From<PeerInfo<Addr>> for (PeerId, Vec<Addr>)
+where
+    Addr: Clone + Ord,
+{
+    fn from(info: PeerInfo<Addr>) -> Self {
+        (
+            info.peer_id,
+            info.advertised_info
+                .listen_addrs
+                .into_iter()
+                .chain(info.seen_addrs)
+                .collect(),
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
 #[cbor(array)]
 pub struct GenericPeerInfo<Addr, T>

--- a/librad/src/net/protocol/io.rs
+++ b/librad/src/net/protocol/io.rs
@@ -40,7 +40,11 @@ type MembershipCodec = Codec<membership::Message<SocketAddr>>;
 #[tracing::instrument(skip(state, peer, addrs), fields(remote_id = %peer))]
 pub(super) async fn discovered<S>(state: State<S>, peer: PeerId, addrs: Vec<SocketAddr>)
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + Clone + Send + Sync + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     if state.endpoint.get_connection(peer).is_some() {
         return;
@@ -83,7 +87,11 @@ pub(super) async fn ingress_connections<S, I>(
     mut ingress: I,
 ) -> Result<!, quic::Error>
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + Clone + Send + Sync + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
     I: futures::Stream<Item = quic::Result<(quic::Connection, quic::IncomingStreams<'static>)>>
         + Unpin,
 {
@@ -103,7 +111,11 @@ pub(super) async fn ingress_streams<S>(
     state: State<S>,
     quic::IncomingStreams { bidi, uni }: quic::IncomingStreams<'static>,
 ) where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + Clone + Send + Sync + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     let mut bidi = bidi
         .inspect_ok(|stream| {
@@ -158,7 +170,11 @@ pub(super) async fn ingress_streams<S>(
 
 pub(super) async fn ingress_bidi<S>(state: State<S>, stream: quic::BidiStream)
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + Clone + Send + Sync + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     use upgrade::SomeUpgraded::*;
 
@@ -181,7 +197,11 @@ where
 
 pub(super) async fn ingress_uni<S>(state: State<S>, stream: quic::RecvStream)
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + Clone + Send + Sync + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     use upgrade::SomeUpgraded::*;
 
@@ -203,7 +223,11 @@ where
 
 async fn ingress_gossip<S, T>(state: State<S>, stream: Upgraded<upgrade::Gossip, T>)
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + Clone + Send + Sync + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
     T: RemotePeer + AsyncRead + Unpin,
 {
     let mut recv = FramedRead::new(stream.into_stream(), GossipCodec::new());
@@ -263,7 +287,7 @@ where
 
 async fn ingress_membership<S, T>(state: State<S>, stream: Upgraded<upgrade::Membership, T>)
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + Clone + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload> + Clone + 'static,
     T: RemoteInfo<Addr = SocketAddr> + AsyncRead + Unpin,
 {
     let mut recv = FramedRead::new(stream.into_stream(), MembershipCodec::new());

--- a/librad/src/net/protocol/tick.rs
+++ b/librad/src/net/protocol/tick.rs
@@ -34,7 +34,11 @@ where
 #[tracing::instrument(level = "debug", skip(state))]
 pub(super) async fn tock<S>(state: State<S>, tock: Tock<SocketAddr, gossip::Payload>)
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + Clone + Send + Sync + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     let mut mcfly = FuturesOrdered::new();
     mcfly.push(one_tock(state.clone(), tock));
@@ -67,7 +71,11 @@ fn one_tock<S>(
     tock: Tock<SocketAddr, gossip::Payload>,
 ) -> BoxFuture<'static, Result<(), error::Tock<SocketAddr>>>
 where
-    S: broadcast::LocalStorage<Update = gossip::Payload> + Clone + Send + Sync + 'static,
+    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     use Tock::*;
 


### PR DESCRIPTION
Instead of passing the peer id of the sender, we need to pass the origin, which
preserves relaying semantics. This also means that we actually have address
hints available.
