### PR TITLE
Include more refs categories in signed_refs

### DIFF
--- a/librad/src/git/fetch.rs
+++ b/librad/src/git/fetch.rs
@@ -20,7 +20,14 @@ use super::{
     p2p::url::GitUrl,
     refs::Refs,
     storage::{self, Storage},
-    types::{reference::Reference, AsRemote, Fetchspec, Force, Namespace, Refspec},
+    types::{
+        reference::{Reference, RefsCategory},
+        AsRemote,
+        Fetchspec,
+        Force,
+        Namespace,
+        Refspec,
+    },
 };
 use crate::{
     identities::{
@@ -157,85 +164,18 @@ pub mod refspecs {
         R: HasProtocol + Clone + 'static,
         for<'a> &'a R: Into<Multihash>,
     {
+        let namespace = Namespace::from(urn);
         let mut signed = tracked_sigrefs
             .iter()
-            .map(|(tracked_peer, tracked_sigrefs)| {
-                let namespace = Namespace::from(urn);
-                tracked_sigrefs
-                    .heads
-                    .iter()
-                    .filter_map(move |(name, target)| {
-                        let name_namespaced =
-                        // Either the signed ref is in the "owned" section of
-                        // `remote_peer`'s repo...
-                        if tracked_peer == remote_peer {
-                            reflike!("refs/namespaces")
-                            .join(&namespace)
-                            .join(ext::Qualified::from(name.clone()))
-                        // .. or `remote_peer` is tracking `tracked_peer`, in
-                        // which case it is in the remotes section.
-                        } else {
-                            reflike!("refs/namespaces")
-                                .join(&namespace)
-                                .join(reflike!("refs/remotes"))
-                                .join(tracked_peer)
-                                // Nb.: `name` is `OneLevel`, but we are in the
-                                // remote tracking branches, so we need `heads`
-                                // Like `Qualified::from(name).strip_prefix("refs")`
-                                .join(reflike!("heads")).join(name.clone())
-                        };
-
-                        // Only include the advertised ref if its target OID
-                        // is the same as the signed one.
-                        let targets_match = {
-                            let found = remote_heads.get(&name_namespaced);
-                            match found {
-                                None => {
-                                    tracing::debug!(
-                                        "{} not found in remote heads",
-                                        name_namespaced
-                                    );
-                                    false
-                                },
-
-                                Some(remote_target) => {
-                                    if remote_target == &*target {
-                                        true
-                                    } else {
-                                        tracing::warn!(
-                                            "{} target mismatch: expected {}, got {}",
-                                            name_namespaced,
-                                            target,
-                                            remote_target
-                                        );
-                                        false
-                                    }
-                                },
-                            }
-                        };
-
-                        targets_match.then_some({
-                            let dst = Reference::head(
-                                namespace.clone(),
-                                tracked_peer.clone(),
-                                name.clone().into(),
-                            );
-                            let src = if tracked_peer == remote_peer {
-                                dst.clone().with_remote(None)
-                            } else {
-                                dst.clone()
-                            };
-
-                            Refspec {
-                                src,
-                                dst,
-                                force: Force::True,
-                            }
-                            .into_fetchspec()
-                        })
-                    })
+            .flat_map(|(tracked_peer, refs)| {
+                sigrefs(
+                    namespace.clone(),
+                    remote_peer,
+                    remote_heads,
+                    tracked_peer,
+                    refs,
+                )
             })
-            .flatten()
             .collect::<Vec<_>>();
 
         // Peek at the remote peer
@@ -263,6 +203,125 @@ pub mod refspecs {
         signed.append(&mut peek_remote);
         signed.append(&mut delegates);
         signed
+    }
+
+    fn sigrefs<'a, P, R>(
+        namespace: Namespace<R>,
+        remote_peer: &'a P,
+        remote_heads: &'a RemoteHeads,
+        tracked_peer: &'a P,
+        Refs {
+            heads,
+            rad,
+            tags,
+            notes,
+            remotes: _,
+        }: &'a Refs,
+    ) -> impl Iterator<Item = Fetchspec> + 'a
+    where
+        P: Clone + PartialEq,
+        for<'b> &'b P: AsRemote + Into<ext::RefLike>,
+
+        R: HasProtocol + Clone + 'a,
+        for<'b> &'b R: Into<Multihash>,
+    {
+        heads
+            .iter()
+            .map(move |x| (x, RefsCategory::Heads))
+            .chain(rad.iter().map(move |x| (x, RefsCategory::Rad)))
+            .chain(tags.iter().map(move |x| (x, RefsCategory::Tags)))
+            .chain(notes.iter().map(move |x| (x, RefsCategory::Notes)))
+            .map({
+                let namespace = namespace.clone();
+                move |(x, category)| {
+                    (
+                        x,
+                        namespaced(&namespace, remote_peer, tracked_peer, x.0, category),
+                    )
+                }
+            })
+            .filter_map(move |((name, target), namespaced_name)| {
+                // Only include the advertised ref if its target OID
+                // is the same as the signed one.
+                let targets_match = {
+                    let found = remote_heads.get(&namespaced_name);
+                    match found {
+                        None => {
+                            tracing::debug!("{} not found in remote heads", namespaced_name);
+                            false
+                        },
+
+                        Some(remote_target) => {
+                            if remote_target == &*target {
+                                true
+                            } else {
+                                tracing::warn!(
+                                    "{} target mismatch: expected {}, got {}",
+                                    namespaced_name,
+                                    target,
+                                    remote_target
+                                );
+                                false
+                            }
+                        },
+                    }
+                };
+
+                targets_match.then_some({
+                    let dst = Reference::head(
+                        namespace.clone(),
+                        tracked_peer.clone(),
+                        name.clone().into(),
+                    );
+                    let src = if tracked_peer == remote_peer {
+                        dst.clone().with_remote(None)
+                    } else {
+                        dst.clone()
+                    };
+
+                    Refspec {
+                        src,
+                        dst,
+                        force: Force::True,
+                    }
+                    .into_fetchspec()
+                })
+            })
+    }
+
+    fn namespaced<'a, P, R>(
+        namespace: &'a Namespace<R>,
+        remote_peer: &'a P,
+        tracked_peer: &'a P,
+        name: &'a ext::OneLevel,
+        cat: RefsCategory,
+    ) -> ext::RefLike
+    where
+        P: PartialEq,
+        for<'b> &'b P: AsRemote + Into<ext::RefLike>,
+
+        R: HasProtocol,
+        for<'b> &'b R: Into<Multihash>,
+    {
+        // Either the signed ref is in the "owned" section of
+        // `remote_peer`'s repo...
+        if tracked_peer == remote_peer {
+            reflike!("refs/namespaces")
+                .join(namespace)
+                .join(ext::Qualified::from(name.clone()))
+        // .. or `remote_peer` is tracking `tracked_peer`, in
+        // which case it is in the remotes section.
+        } else {
+            reflike!("refs/namespaces")
+                .join(namespace)
+                .join(reflike!("refs/remotes"))
+                .join(tracked_peer)
+                // Nb.: `name` is `OneLevel`, but we are in the
+                // remote tracking branches, so we need `heads`
+                // Like `Qualified::from(name).strip_prefix("refs")`
+                .join(ext::RefLike::from(cat))
+                .join(name.clone())
+        }
     }
 }
 
@@ -571,6 +630,9 @@ mod tests {
                         .iter()
                         .cloned()
                         .collect(),
+                    rad: Default::default(),
+                    tags: Default::default(),
+                    notes: Default::default(),
                     remotes: Remotes::new(),
                 },
             ),
@@ -584,6 +646,9 @@ mod tests {
                     .iter()
                     .cloned()
                     .collect(),
+                    rad: Default::default(),
+                    tags: Default::default(),
+                    notes: Default::default(),
                     remotes: Remotes::new(),
                 },
             ),

--- a/librad/src/git/fetch.rs
+++ b/librad/src/git/fetch.rs
@@ -210,13 +210,7 @@ pub mod refspecs {
         remote_peer: &'a P,
         remote_heads: &'a RemoteHeads,
         tracked_peer: &'a P,
-        Refs {
-            heads,
-            rad,
-            tags,
-            notes,
-            remotes: _,
-        }: &'a Refs,
+        refs: &'a Refs,
     ) -> impl Iterator<Item = Fetchspec> + 'a
     where
         P: Clone + PartialEq,
@@ -225,12 +219,7 @@ pub mod refspecs {
         R: HasProtocol + Clone + 'a,
         for<'b> &'b R: Into<Multihash>,
     {
-        heads
-            .iter()
-            .map(move |x| (x, RefsCategory::Heads))
-            .chain(rad.iter().map(move |x| (x, RefsCategory::Rad)))
-            .chain(tags.iter().map(move |x| (x, RefsCategory::Tags)))
-            .chain(notes.iter().map(move |x| (x, RefsCategory::Notes)))
+        refs.iter_categorised()
             .map({
                 let namespace = namespace.clone();
                 move |(x, category)| {

--- a/librad/src/git/identities/error.rs
+++ b/librad/src/git/identities/error.rs
@@ -6,7 +6,7 @@
 use thiserror::Error;
 
 use super::{
-    super::{storage, types::reference},
+    super::{refs, storage, types::reference},
     local,
 };
 use crate::identities::{
@@ -22,6 +22,9 @@ pub enum Error {
 
     #[error("malformed URN")]
     Ref(#[from] reference::FromUrnError),
+
+    #[error("update of signed_refs failed")]
+    Sigrefs(#[from] refs::stored::Error),
 
     #[error(transparent)]
     LocalId(#[from] local::ValidationError),

--- a/librad/src/git/identities/person.rs
+++ b/librad/src/git/identities/person.rs
@@ -9,6 +9,7 @@ use radicle_git_ext::is_not_found_err;
 
 use super::{
     super::{
+        refs::Refs,
         storage::{self, Storage},
         types::Reference,
     },
@@ -103,6 +104,7 @@ where
     let urn = person.urn();
     common::IdRef::from(&urn).create(storage, person.content_id)?;
     person.link(storage, &urn)?;
+    Refs::update(storage, &urn)?;
 
     Ok(person.into_inner().into_inner())
 }
@@ -129,6 +131,7 @@ where
     if let Some(local_id) = whoami.into() {
         local_id.link(storage, urn)?;
     }
+    Refs::update(storage, urn)?;
 
     Ok(next)
 }
@@ -150,6 +153,7 @@ pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Person, Error
     let next = identities(storage).update_from(ours, theirs, storage.signer())?;
 
     common::IdRef::from(urn).update(storage, next.content_id, &format!("merge from {}", from))?;
+    Refs::update(storage, urn)?;
 
     Ok(next)
 }

--- a/librad/src/git/identities/project.rs
+++ b/librad/src/git/identities/project.rs
@@ -10,6 +10,7 @@ use git_ext::is_not_found_err;
 
 use super::{
     super::{
+        refs::Refs as Sigrefs,
         storage::{self, Storage},
         types::{namespace, reference, Force, Reference, Single, SymbolicRef},
     },
@@ -90,8 +91,10 @@ where
     P: Into<ProjectPayload> + Debug,
 {
     let project = identities(storage).create(payload.into(), delegations, storage.signer())?;
-    Refs::Create(&project).apply(storage)?;
-    whoami.link(storage, &project.urn())?;
+    let urn = project.urn();
+    ProjectRefs::Create(&project).apply(storage)?;
+    whoami.link(storage, &urn)?;
+    Sigrefs::update(storage, &urn)?;
 
     Ok(project)
 }
@@ -114,10 +117,11 @@ where
     let prev = Verifying::from(prev).signed()?;
     let next = identities(storage).update(prev, payload, delegations, storage.signer())?;
 
-    Refs::Update(&next, "update").apply(storage)?;
+    ProjectRefs::Update(&next, "update").apply(storage)?;
     if let Some(local_id) = whoami.into() {
         local_id.link(storage, urn)?;
     }
+    Sigrefs::update(storage, urn)?;
 
     Ok(next)
 }
@@ -138,17 +142,18 @@ pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Project, Erro
     let theirs = Verifying::from(theirs).signed()?;
     let next = identities(storage).update_from(ours, theirs, storage.signer())?;
 
-    Refs::Update(&next, &format!("merge from {}", from)).apply(storage)?;
+    ProjectRefs::Update(&next, &format!("merge from {}", from)).apply(storage)?;
+    Sigrefs::update(storage, urn)?;
 
     Ok(next)
 }
 
-enum Refs<'a> {
+enum ProjectRefs<'a> {
     Create(&'a Project),
     Update(&'a Project, &'a str),
 }
 
-impl<'a> Refs<'a> {
+impl<'a> ProjectRefs<'a> {
     pub fn apply(&self, storage: &Storage) -> Result<(), Error> {
         for symref in self.delegates() {
             symref.create(storage.as_raw())?;

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -201,10 +201,25 @@ pub mod stored {
     }
 }
 
-/// The current `refs/heads` and [`Remotes`] (transitive tracking graph)
+/// The published state of a local repository.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Refs {
+    /// `refs/heads/*`
     pub heads: BTreeMap<reference::OneLevel, Oid>,
+
+    /// `refs/rad/*`, exluding `refs/rad/signed_refs`
+    pub rad: BTreeMap<reference::OneLevel, Oid>,
+
+    /// `refs/tags/*`
+    pub tags: BTreeMap<reference::OneLevel, Oid>,
+
+    /// `refs/notes/*`
+    pub notes: BTreeMap<reference::OneLevel, Oid>,
+
+    /// The [`Remotes`], ie. tracking graph.
+    ///
+    /// Note that this does does not include the oids, as they can be determined
+    /// by inspecting the `rad/signed_refs` of the respective remote.
     pub remotes: Remotes<PeerId>,
 }
 
@@ -214,29 +229,44 @@ impl Refs {
     pub fn compute(storage: &Storage, urn: &Urn) -> Result<Self, stored::Error> {
         let namespace = Namespace::from(urn);
         let namespace_prefix = format!("refs/namespaces/{}/", namespace);
-        let heads_ref = Reference::heads(namespace, None);
 
-        tracing::debug!("reading heads from {}", &heads_ref);
+        fn peeled(r: Result<git2::Reference, storage::Error>) -> Option<(String, git2::Oid)> {
+            r.ok().and_then(|head| {
+                head.name()
+                    .and_then(|name| head.target().map(|target| (name.to_owned(), target)))
+            })
+        }
+
+        let refined = |(name, oid): (String, git2::Oid)|
+             -> Result<(reference::OneLevel, Oid), stored::Error>
+        {
+            let name = reference::RefLike::try_from(
+                name.strip_prefix(&namespace_prefix).unwrap_or(&name)
+            )?;
+            Ok((reference::OneLevel::from(name), oid.into()))
+        };
 
         let heads = storage
-            .references(&heads_ref)?
-            // FIXME: this is `git_ext::reference::iter::References::peeled()`,
-            // which we need to generalise to allow impl Iterator combinators
-            .filter_map(|reference| {
-                reference.ok().and_then(|head| {
-                    head.name()
-                        .and_then(|name| head.target().map(|target| (name.to_owned(), target)))
-                })
-            })
-            .try_fold(BTreeMap::new(), |mut acc, (name, oid)| {
-                tracing::trace!("raw refname: {}", name);
-                let name = name.strip_prefix(&namespace_prefix).unwrap_or(&name);
-                tracing::trace!("stripped namespace: {}", name);
-                let refname = reference::RefLike::try_from(name)?;
-                acc.insert(reference::OneLevel::from(refname), oid.into());
-
-                Ok::<_, stored::Error>(acc)
-            })?;
+            .references(&Reference::heads(namespace.clone(), None))?
+            .filter_map(peeled)
+            .map(refined)
+            .collect::<Result<_, _>>()?;
+        let rad = storage
+            .references(&Reference::rads(namespace.clone(), None))?
+            .filter_map(peeled)
+            .filter(|(name, _)| !name.ends_with("rad/signed_refs"))
+            .map(refined)
+            .collect::<Result<_, _>>()?;
+        let tags = storage
+            .references(&Reference::tags(namespace.clone(), None))?
+            .filter_map(peeled)
+            .map(refined)
+            .collect::<Result<_, _>>()?;
+        let notes = storage
+            .references(&Reference::notes(namespace, None))?
+            .filter_map(peeled)
+            .map(refined)
+            .collect::<Result<_, _>>()?;
 
         let mut remotes = tracking::tracked(storage, urn)?.collect::<Remotes<PeerId>>();
         for (peer, tracked) in remotes.iter_mut() {
@@ -245,7 +275,13 @@ impl Refs {
             }
         }
 
-        Ok(Self { heads, remotes })
+        Ok(Self {
+            heads,
+            rad,
+            tags,
+            notes,
+            remotes,
+        })
     }
 
     /// Load the [`Refs`] of [`Urn`] (and optionally a remote `peer`) from

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use super::{
     storage::{self, Storage},
     tracking,
-    types::{Namespace, Reference},
+    types::{Namespace, Reference, RefsCategory},
 };
 use crate::{
     internal::canonical::{Cjson, CjsonError},
@@ -387,6 +387,26 @@ impl Refs {
             signature: signature.into(),
             _verified: PhantomData,
         })
+    }
+
+    /// Iterator over all non-remote refs and their targets, paired with their
+    /// corresponding `RefsCategory`.
+    pub fn iter_categorised(
+        &self,
+    ) -> impl Iterator<Item = ((&reference::OneLevel, &Oid), RefsCategory)> {
+        let Refs {
+            heads,
+            rad,
+            tags,
+            notes,
+            remotes: _,
+        } = self;
+        heads
+            .iter()
+            .map(|x| (x, RefsCategory::Heads))
+            .chain(rad.iter().map(|x| (x, RefsCategory::Rad)))
+            .chain(tags.iter().map(|x| (x, RefsCategory::Tags)))
+            .chain(notes.iter().map(|x| (x, RefsCategory::Notes)))
     }
 
     fn canonical_form(&self) -> Result<Vec<u8>, CjsonError> {

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -207,7 +207,7 @@ pub struct Refs {
     /// `refs/heads/*`
     pub heads: BTreeMap<reference::OneLevel, Oid>,
 
-    /// `refs/rad/*`, exluding `refs/rad/signed_refs`
+    /// `refs/rad/*`, excluding `refs/rad/signed_refs`
     pub rad: BTreeMap<reference::OneLevel, Oid>,
 
     /// `refs/tags/*`

--- a/librad/src/git/types/reference.rs
+++ b/librad/src/git/types/reference.rs
@@ -361,7 +361,7 @@ impl<N, R> Reference<N, R, Many> {
     }
 
     /// Build a reference that points to:
-    ///     * `refs[/namespaces/<namespace>]/refs[/remotes/<remote>]/heads/*`
+    ///     * `refs[/namespaces/<namespace>/refs][/remotes/<remote>]/heads/*`
     pub fn heads(namespace: impl Into<Option<N>>, remote: impl Into<Option<R>>) -> Self {
         Self {
             remote: remote.into(),

--- a/librad/src/git/types/reference.rs
+++ b/librad/src/git/types/reference.rs
@@ -350,8 +350,7 @@ impl<N, R> Reference<N, R, Many> {
     }
 
     /// Build a reference that points to:
-    ///
-    ///     refs/namespaces/<namespace>/refs/rad/ids/*
+    ///     * `refs[/namespaces/<namespace>]/refs/rad/ids/*`
     pub fn rad_ids_glob(namespace: impl Into<Option<N>>) -> Self {
         Self {
             remote: None,
@@ -362,8 +361,7 @@ impl<N, R> Reference<N, R, Many> {
     }
 
     /// Build a reference that points to:
-    ///
-    ///     refs/namespaces/<namespace>/refs/rad/[peer_id]/heads/*
+    ///     * `refs[/namespaces/<namespace>]/refs[/remotes/<remote>]/heads/*`
     pub fn heads(namespace: impl Into<Option<N>>, remote: impl Into<Option<R>>) -> Self {
         Self {
             remote: remote.into(),
@@ -373,6 +371,8 @@ impl<N, R> Reference<N, R, Many> {
         }
     }
 
+    /// Build a reference that points to:
+    ///     * `refs[/namespaces/<namespace>]/refs[/remotes/<remote>]/rad/*`
     pub fn rads(namespace: impl Into<Option<N>>, remote: impl Into<Option<R>>) -> Self {
         Self {
             remote: remote.into(),
@@ -382,6 +382,8 @@ impl<N, R> Reference<N, R, Many> {
         }
     }
 
+    /// Build a reference that points to:
+    ///     * `refs[/namespaces/<namespace>]/refs[/remotes/<remote>]/tags/*`
     pub fn tags(namespace: impl Into<Option<N>>, remote: impl Into<Option<R>>) -> Self {
         Self {
             remote: remote.into(),
@@ -391,6 +393,8 @@ impl<N, R> Reference<N, R, Many> {
         }
     }
 
+    /// Build a reference that points to:
+    ///     * `refs[/namespaces/<namespace>]/refs[/remotes/<remote>]/notes/*`
     pub fn notes(namespace: impl Into<Option<N>>, remote: impl Into<Option<R>>) -> Self {
         Self {
             remote: remote.into(),

--- a/librad/src/git/types/reference.rs
+++ b/librad/src/git/types/reference.rs
@@ -350,7 +350,7 @@ impl<N, R> Reference<N, R, Many> {
     }
 
     /// Build a reference that points to:
-    ///     * `refs[/namespaces/<namespace>]/refs/rad/ids/*`
+    ///     * `refs[/namespaces/<namespace>/refs]/rad/ids/*`
     pub fn rad_ids_glob(namespace: impl Into<Option<N>>) -> Self {
         Self {
             remote: None,

--- a/librad/src/git/types/reference.rs
+++ b/librad/src/git/types/reference.rs
@@ -37,6 +37,7 @@ pub enum RefsCategory {
     Heads,
     Rad,
     Tags,
+    Notes,
 }
 
 impl RefsCategory {
@@ -45,6 +46,7 @@ impl RefsCategory {
             "heads" => Some(Self::Heads),
             "rad" => Some(Self::Rad),
             "tags" => Some(Self::Tags),
+            "notes" => Some(Self::Notes),
             _ => None,
         }
     }
@@ -56,6 +58,7 @@ impl Display for RefsCategory {
             Self::Heads => f.write_str("heads"),
             Self::Rad => f.write_str("rad"),
             Self::Tags => f.write_str("tags"),
+            Self::Notes => f.write_str("notes"),
         }
     }
 }
@@ -346,8 +349,9 @@ impl<N, R> Reference<N, R, Many> {
         ext::References::from_globs(repo, &[self.to_string()])
     }
 
-    /// Build a reference that points to
-    /// `refs/namespaces/<namespace>/refs/rad/ids/*`
+    /// Build a reference that points to:
+    ///
+    ///     refs/namespaces/<namespace>/refs/rad/ids/*
     pub fn rad_ids_glob(namespace: impl Into<Option<N>>) -> Self {
         Self {
             remote: None,
@@ -357,12 +361,40 @@ impl<N, R> Reference<N, R, Many> {
         }
     }
 
-    /// Build a reference that points to
-    /// `refs/namespaces/<namespace>/refs/rad/[peer_id]/heads/*`
+    /// Build a reference that points to:
+    ///
+    ///     refs/namespaces/<namespace>/refs/rad/[peer_id]/heads/*
     pub fn heads(namespace: impl Into<Option<N>>, remote: impl Into<Option<R>>) -> Self {
         Self {
             remote: remote.into(),
             category: RefsCategory::Heads,
+            name: refspec_pattern!("*"),
+            namespace: namespace.into(),
+        }
+    }
+
+    pub fn rads(namespace: impl Into<Option<N>>, remote: impl Into<Option<R>>) -> Self {
+        Self {
+            remote: remote.into(),
+            category: RefsCategory::Rad,
+            name: refspec_pattern!("*"),
+            namespace: namespace.into(),
+        }
+    }
+
+    pub fn tags(namespace: impl Into<Option<N>>, remote: impl Into<Option<R>>) -> Self {
+        Self {
+            remote: remote.into(),
+            category: RefsCategory::Tags,
+            name: refspec_pattern!("*"),
+            namespace: namespace.into(),
+        }
+    }
+
+    pub fn notes(namespace: impl Into<Option<N>>, remote: impl Into<Option<R>>) -> Self {
+        Self {
+            remote: remote.into(),
+            category: RefsCategory::Notes,
             name: refspec_pattern!("*"),
             namespace: namespace.into(),
         }


### PR DESCRIPTION
Namely:

* refs/rad
* refs/tags
* refs/notes

The first one is necessary for implementing "radicle applications",
while the other two are more or less for the giggles for now.
