### PR TITLE
Fix URN in merge code

### DIFF
--- a/git-ext/src/reference/name.rs
+++ b/git-ext/src/reference/name.rs
@@ -281,18 +281,14 @@ impl OneLevel {
     }
 
     pub fn from_qualified(Qualified(path): Qualified) -> (Self, Option<RefLike>) {
-        if path.starts_with("refs/") {
-            let mut path = path.iter().skip(1);
-            match path.next() {
-                Some(category) => {
-                    let mut cat = PathBuf::new();
-                    cat.push(category);
-                    (Self(path.collect()), Some(RefLike(cat)))
-                },
-                None => (Self(path.collect()), None),
-            }
-        } else {
-            (Self(path), None)
+        // skip "refs/"
+        let mut path = path.iter().skip(1);
+        match path.next() {
+            Some(category) => {
+                let category = Path::new(category).to_path_buf();
+                (Self(path.collect()), Some(RefLike(category)))
+            },
+            None => (Self(path.collect()), None),
         }
     }
 

--- a/git-ext/src/reference/name.rs
+++ b/git-ext/src/reference/name.rs
@@ -245,6 +245,29 @@ impl Display for RefLike {
 ///     &*OneLevel::from(RefLike::try_from("mistress").unwrap()),
 ///     Path::new("mistress")
 /// );
+///
+/// assert_eq!(
+///     OneLevel::from_qualified(Qualified::from(RefLike::try_from("refs/tags/grace").unwrap())),
+///     (
+///         OneLevel::from(RefLike::try_from("grace").unwrap()),
+///         Some(RefLike::try_from("tags").unwrap())
+///     ),
+/// );
+///
+/// assert_eq!(
+///     OneLevel::from_qualified(Qualified::from(RefLike::try_from("refs/remotes/origin/hopper").unwrap())),
+///     (
+///         OneLevel::from(RefLike::try_from("origin/hopper").unwrap()),
+///         Some(RefLike::try_from("remotes").unwrap())
+///     ),
+/// );
+///
+/// assert_eq!(
+///     &*OneLevel::from(RefLike::try_from("origin/hopper").unwrap()).into_qualified(
+///         RefLike::try_from("remotes").unwrap()
+///     ),
+///     Path::new("refs/remotes/origin/hopper"),
+/// );
 /// ```
 #[derive(
     Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash, serde::Serialize, serde::Deserialize,
@@ -255,6 +278,26 @@ pub struct OneLevel(PathBuf);
 impl OneLevel {
     pub fn as_str(&self) -> &str {
         self.as_ref()
+    }
+
+    pub fn from_qualified(Qualified(path): Qualified) -> (Self, Option<RefLike>) {
+        if path.starts_with("refs/") {
+            let mut path = path.iter().skip(1);
+            match path.next() {
+                Some(category) => {
+                    let mut cat = PathBuf::new();
+                    cat.push(category);
+                    (Self(path.collect()), Some(RefLike(cat)))
+                },
+                None => (Self(path.collect()), None),
+            }
+        } else {
+            (Self(path), None)
+        }
+    }
+
+    pub fn into_qualified(self, category: RefLike) -> Qualified {
+        Qualified(Path::new("refs").join(category).join(self))
     }
 }
 

--- a/librad/src/git/identities/person.rs
+++ b/librad/src/git/identities/person.rs
@@ -138,9 +138,10 @@ where
 pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Person, Error> {
     let ours = get(storage, urn)?.ok_or_else(|| Error::NotFound(urn.clone()))?;
     let theirs = {
+        let rad_id = urn::DEFAULT_PATH.strip_prefix("refs").unwrap();
         let their_urn = Urn {
             id: urn.id,
-            path: Some(reflike!("remotes").join(from).join(&*urn::DEFAULT_PATH)),
+            path: Some(reflike!("remotes").join(from).join(rad_id)),
         };
         get(storage, &their_urn)?.ok_or(Error::NotFound(their_urn))?
     };

--- a/librad/src/git/identities/person.rs
+++ b/librad/src/git/identities/person.rs
@@ -5,7 +5,7 @@
 
 use std::{convert::TryFrom, fmt::Debug};
 
-use radicle_git_ext::is_not_found_err;
+use radicle_git_ext::{is_not_found_err, OneLevel};
 
 use super::{
     super::{
@@ -138,10 +138,11 @@ where
 pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Person, Error> {
     let ours = get(storage, urn)?.ok_or_else(|| Error::NotFound(urn.clone()))?;
     let theirs = {
-        let rad_id = urn::DEFAULT_PATH.strip_prefix("refs").unwrap();
+        let (path, rad) = OneLevel::from_qualified(urn::DEFAULT_PATH.clone());
+        let rad = rad.expect("default path should be refs/rad/id");
         let their_urn = Urn {
             id: urn.id,
-            path: Some(reflike!("refs/remotes").join(from).join(rad_id)),
+            path: Some(reflike!("refs/remotes").join(from).join(rad).join(path)),
         };
         get(storage, &their_urn)?.ok_or(Error::NotFound(their_urn))?
     };

--- a/librad/src/git/identities/person.rs
+++ b/librad/src/git/identities/person.rs
@@ -141,7 +141,7 @@ pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Person, Error
         let rad_id = urn::DEFAULT_PATH.strip_prefix("refs").unwrap();
         let their_urn = Urn {
             id: urn.id,
-            path: Some(reflike!("remotes").join(from).join(rad_id)),
+            path: Some(reflike!("refs/remotes").join(from).join(rad_id)),
         };
         get(storage, &their_urn)?.ok_or(Error::NotFound(their_urn))?
     };

--- a/librad/src/git/identities/project.rs
+++ b/librad/src/git/identities/project.rs
@@ -6,7 +6,7 @@
 use std::{convert::TryFrom, fmt::Debug};
 
 use either::Either;
-use git_ext::is_not_found_err;
+use git_ext::{is_not_found_err, OneLevel};
 
 use super::{
     super::{
@@ -127,10 +127,11 @@ where
 pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Project, Error> {
     let ours = get(storage, urn)?.ok_or_else(|| Error::NotFound(urn.clone()))?;
     let theirs = {
-        let rad_id = urn::DEFAULT_PATH.strip_prefix("refs").unwrap();
+        let (path, rad) = OneLevel::from_qualified(urn::DEFAULT_PATH.clone());
+        let rad = rad.expect("default path should be refs/rad/id");
         let their_urn = Urn {
             id: urn.id,
-            path: Some(reflike!("refs/remotes").join(from).join(rad_id)),
+            path: Some(reflike!("refs/remotes").join(from).join(rad).join(path)),
         };
         get(storage, &their_urn)?.ok_or(Error::NotFound(their_urn))?
     };

--- a/librad/src/git/identities/project.rs
+++ b/librad/src/git/identities/project.rs
@@ -127,9 +127,10 @@ where
 pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Project, Error> {
     let ours = get(storage, urn)?.ok_or_else(|| Error::NotFound(urn.clone()))?;
     let theirs = {
+        let rad_id = urn::DEFAULT_PATH.strip_prefix("refs").unwrap();
         let their_urn = Urn {
             id: urn.id,
-            path: Some(reflike!("remotes").join(from).join(&*urn::DEFAULT_PATH)),
+            path: Some(reflike!("remotes").join(from).join(rad_id)),
         };
         get(storage, &their_urn)?.ok_or(Error::NotFound(their_urn))?
     };

--- a/librad/src/git/identities/project.rs
+++ b/librad/src/git/identities/project.rs
@@ -130,7 +130,7 @@ pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Project, Erro
         let rad_id = urn::DEFAULT_PATH.strip_prefix("refs").unwrap();
         let their_urn = Urn {
             id: urn.id,
-            path: Some(reflike!("remotes").join(from).join(rad_id)),
+            path: Some(reflike!("refs/remotes").join(from).join(rad_id)),
         };
         get(storage, &their_urn)?.ok_or(Error::NotFound(their_urn))?
     };

--- a/librad/src/git/types/reference.rs
+++ b/librad/src/git/types/reference.rs
@@ -560,7 +560,7 @@ mod tests {
         let urn = Urn::new(git2::Oid::zero().into());
         let as_ref = Reference::try_from(&urn).unwrap();
         assert_eq!(
-            urn.with_path(identities::urn::DEFAULT_PATH.clone()),
+            urn.with_path(ext::RefLike::from(identities::urn::DEFAULT_PATH.clone())),
             Urn::try_from(as_ref).unwrap()
         )
     }

--- a/librad/src/identities/urn.rs
+++ b/librad/src/identities/urn.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 use super::sealed;
 
 lazy_static! {
-    pub static ref DEFAULT_PATH: ext::RefLike = reflike!("refs/rad/id");
+    pub static ref DEFAULT_PATH: ext::Qualified = ext::Qualified::from(reflike!("refs/rad/id"));
 }
 
 pub trait HasProtocol: sealed::Sealed {

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -469,9 +469,11 @@ impl PeerStorage {
 fn urn_context(local_peer_id: PeerId, urn: Either<Urn, Originates<Urn>>) -> Urn {
     fn remote(urn: Urn, peer: PeerId) -> Urn {
         let path = reflike!("refs/remotes").join(peer).join(
-            ext::RefLike::from(reference::Qualified::from(
-                urn.path.unwrap_or_else(|| urn::DEFAULT_PATH.clone()),
-            ))
+            ext::RefLike::from(
+                urn.path
+                    .map(reference::Qualified::from)
+                    .unwrap_or_else(|| urn::DEFAULT_PATH.clone()),
+            )
             .strip_prefix("refs")
             .unwrap(),
         );
@@ -484,8 +486,8 @@ fn urn_context(local_peer_id: PeerId, urn: Either<Urn, Originates<Urn>>) -> Urn 
 
     fn local(urn: Urn) -> Urn {
         urn.map_path(|path| {
-            path.or_else(|| Some(urn::DEFAULT_PATH.clone()))
-                .map(reference::Qualified::from)
+            path.map(reference::Qualified::from)
+                .or_else(|| Some(urn::DEFAULT_PATH.clone()))
                 .map(ext::RefLike::from)
         })
     }
@@ -617,7 +619,10 @@ mod tests {
         fn direct_empty() {
             let urn = Urn::new(*ZERO_OID);
             let ctx = urn_context(*LOCAL_PEER_ID, Left(urn.clone()));
-            assert_eq!(urn.with_path(urn::DEFAULT_PATH.clone()), ctx)
+            assert_eq!(
+                urn.with_path(ext::RefLike::from(urn::DEFAULT_PATH.clone())),
+                ctx
+            )
         }
 
         #[test]
@@ -646,9 +651,11 @@ mod tests {
             );
             assert_eq!(
                 urn.with_path(
-                    reflike!("refs/remotes")
-                        .join(*OTHER_PEER_ID)
-                        .join(urn::DEFAULT_PATH.strip_prefix("refs").unwrap())
+                    reflike!("refs/remotes").join(*OTHER_PEER_ID).join(
+                        ext::RefLike::from(urn::DEFAULT_PATH.clone())
+                            .strip_prefix("refs")
+                            .unwrap()
+                    )
                 ),
                 ctx
             )
@@ -704,7 +711,10 @@ mod tests {
                     value: urn.clone(),
                 }),
             );
-            assert_eq!(urn.with_path(urn::DEFAULT_PATH.clone()), ctx)
+            assert_eq!(
+                urn.with_path(ext::RefLike::from(urn::DEFAULT_PATH.clone())),
+                ctx
+            )
         }
 
         #[test]


### PR DESCRIPTION
The urn::DEFAULT_PATH has the value of `refs/rad/id`. When we want to
look at a remote's `rad/id` we have to remove the refs` prefix.