### PR TITLE
net: cache mDNS responses

### DIFF
--- a/librad/src/net/discovery/mdns.rs
+++ b/librad/src/net/discovery/mdns.rs
@@ -4,11 +4,14 @@
 // Linking Exception. For full terms see the included LICENSE file.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    cmp,
+    collections::{BTreeMap, BTreeSet, BinaryHeap},
+    hash::{Hash, Hasher as _},
     net::{IpAddr, SocketAddr},
     pin::Pin,
+    sync::{Arc, RwLock, Weak},
     task::{Context, Poll},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use futures::{channel::mpsc, stream::StreamExt as _, SinkExt as _};
@@ -18,6 +21,7 @@ use madness::{
     MdnsService,
     Packet,
 };
+use rustc_hash::FxHashMap;
 
 use super::Discovery;
 use crate::peer::PeerId;
@@ -26,6 +30,7 @@ const SERVICE_NAME: &str = "_radicle-link._udp.local";
 
 pub struct Mdns {
     _query: ServiceDiscovery,
+    _cache: Arc<RwLock<Discoveries<PeerId, u64>>>,
     chan: mpsc::Receiver<(PeerId, Vec<SocketAddr>)>,
 }
 
@@ -34,6 +39,7 @@ impl Mdns {
         local_peer: PeerId,
         listen_addrs: Vec<SocketAddr>,
         query_interval: Duration,
+        cache_ttl: Duration,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut srv = MdnsService::new(true)?;
         srv.register(SERVICE_NAME);
@@ -41,34 +47,92 @@ impl Mdns {
 
         let ptr = format!("{}.{}", local_peer, SERVICE_NAME);
         let cname = format!("{}.radicle.local", local_peer);
+        let cache = Arc::new(RwLock::new(Discoveries::new(cmp::max(
+            cache_ttl,
+            query_interval,
+        ))));
+        let (tx, rx) = mpsc::channel(64);
 
-        let (mut tx, rx) = mpsc::channel(1);
-        tokio::spawn(async move {
-            tracing::info!("starting mDNS service discovery");
-            loop {
-                let packet = srv.next().await;
-                match packet {
-                    Packet::Query(queries) => {
-                        for query in queries {
-                            respond(&ptr, &cname, &listen_addrs, &mut srv, query)
-                        }
-                    },
-                    Packet::Response(resp) => {
-                        for info in discover(&cname, resp) {
-                            if tx.send(info).await.is_err() {
-                                tracing::info!("stopping the madness");
-                                return;
-                            }
-                        }
-                    },
-                }
-            }
-        });
+        tokio::spawn(run(
+            srv,
+            ptr,
+            cname,
+            listen_addrs,
+            Arc::downgrade(&cache),
+            tx,
+        ));
 
         Ok(Self {
             _query: query,
+            _cache: cache,
             chan: rx,
         })
+    }
+
+    #[cfg(test)]
+    pub fn is_pending(&mut self) -> bool {
+        use futures::Stream as _;
+
+        let waker = futures::task::noop_waker();
+        match Pin::new(&mut self.chan).poll_next(&mut Context::from_waker(&waker)) {
+            Poll::Pending => true,
+            _ => false,
+        }
+    }
+}
+
+#[tracing::instrument(skip(srv, ptr, cname, listen_addrs, cache, tx))]
+async fn run(
+    mut srv: MdnsService,
+    ptr: String,
+    cname: String,
+    listen_addrs: Vec<SocketAddr>,
+    cache: Weak<RwLock<Discoveries<PeerId, u64>>>,
+    mut tx: mpsc::Sender<(PeerId, Vec<SocketAddr>)>,
+) {
+    use std::collections::hash_map::DefaultHasher;
+
+    tracing::info!("starting mDNS service discovery");
+
+    loop {
+        let packet = srv.next().await;
+        tracing::trace!(packet = ?packet, "received");
+        match Weak::upgrade(&cache) {
+            None => {
+                tracing::info!("stopping the madness");
+                return;
+            },
+
+            Some(cache) => match packet {
+                Packet::Query(queries) => {
+                    for query in queries {
+                        respond(&ptr, &cname, &listen_addrs, &mut srv, query)
+                    }
+                },
+                Packet::Response(resp) => {
+                    for (peer, addrs) in discover(&cname, resp) {
+                        let addrs_hash = {
+                            let mut hasher = DefaultHasher::new();
+                            addrs.hash(&mut hasher);
+                            hasher.finish()
+                        };
+                        let discovered = cache.write().unwrap().insert(peer, addrs_hash);
+                        match discovered {
+                            Discovered::New((peer, _)) | Discovered::Refreshed((peer, _)) => {
+                                tracing::debug!("{} is new or refreshed", peer);
+                                if let Err(e) = tx.send((peer, addrs)).await {
+                                    tracing::warn!(err = ?e, "channel send error");
+                                }
+                            },
+
+                            Discovered::Known => {
+                                tracing::trace!("ignoring known peer {}", peer);
+                            },
+                        }
+                    }
+                },
+            },
+        }
     }
 }
 
@@ -86,6 +150,106 @@ impl Discovery for Mdns {
 
     fn discover(self) -> Self::Stream {
         self
+    }
+}
+
+struct Timestamped<T> {
+    timestamp: Instant,
+    inner: T,
+}
+
+impl<T> PartialOrd for Timestamped<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.timestamp.cmp(&other.timestamp).reverse())
+    }
+}
+
+impl<T> Ord for Timestamped<T> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.timestamp.cmp(&other.timestamp).reverse()
+    }
+}
+
+impl<T> PartialEq for Timestamped<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp.eq(&other.timestamp)
+    }
+}
+
+impl<T> Eq for Timestamped<T> {}
+
+#[derive(Debug)]
+enum Discovered<T> {
+    Known,
+    New(T),
+    Refreshed(T),
+}
+
+struct Discoveries<K, V> {
+    all: FxHashMap<K, (Instant, V)>,
+    hip: BinaryHeap<Timestamped<K>>,
+    ttl: Duration,
+}
+
+impl<K, V> Discoveries<K, V>
+where
+    K: Clone + Eq + Hash,
+    V: Clone + PartialEq,
+{
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            all: Default::default(),
+            hip: Default::default(),
+            ttl,
+        }
+    }
+
+    pub fn insert(&mut self, k: K, v: V) -> Discovered<(K, V)> {
+        use std::collections::hash_map::Entry::*;
+        use Discovered::*;
+
+        let now = Instant::now();
+        self.evict(now - self.ttl);
+        match self.all.entry(k) {
+            Occupied(mut entry) => {
+                let prev = entry.get_mut();
+                if prev.1 != v {
+                    *prev = (now, v.clone());
+                    Refreshed((entry.key().clone(), v))
+                } else {
+                    Known
+                }
+            },
+
+            Vacant(entry) => {
+                let key = entry.key().clone();
+                entry.insert((now, v.clone()));
+                self.hip.push(Timestamped {
+                    timestamp: now,
+                    inner: key.clone(),
+                });
+                New((key.clone(), v))
+            },
+        }
+    }
+
+    fn evict(&mut self, deadline: Instant) {
+        while let Some(Timestamped { timestamp, .. }) = self.hip.peek() {
+            if *timestamp > deadline {
+                return;
+            }
+
+            let key = self.hip.pop().expect("we peeked, therefore we pop").inner;
+            let value_timestamp = self.all[&key].0;
+            if value_timestamp > deadline {
+                self.hip.push(Timestamped {
+                    timestamp: value_timestamp,
+                    inner: key,
+                });
+            } else {
+                self.all.remove(&key);
+            }
+        }
     }
 }
 
@@ -198,15 +362,22 @@ mod tests {
     use super::*;
 
     use pretty_assertions::assert_eq;
-    use std::net::Ipv4Addr;
+    use std::{collections::HashSet, net::Ipv4Addr};
 
     use crate::{keys::SecretKey, peer::PeerId};
 
-    // `madness` uses tokio, so no choice here -- MADNESS!
+    // Watch out for MADNESS:
+    //
+    // * `madness` requires the tokio runtime (hence the tokio::test)
+    // * CI (actually: docker) doesn't support multicast UDP (hence the ignore)
+    // * `madness` doesn't support specifying the multicast address or port, so
+    //     * the test must run in an isolated environment
+    //     * we cannot have more than one test function running in parallel
     #[tokio::test]
-    // CI doesn't support multicast UDP
     #[ignore]
-    async fn ohai() {
+    async fn smoke() {
+        librad_test::logging::init();
+
         let lolek_id = PeerId::from(SecretKey::new());
         let lolek_addrs = vec![SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
@@ -217,14 +388,82 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             777,
         )];
+        let tola_id = PeerId::from(SecretKey::new());
+        let tola_addrs = vec![SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            888,
+        )];
 
-        let interval = Duration::from_secs(10);
+        let interval = Duration::from_millis(500);
+        let ttl = Duration::from_secs(60);
 
-        let mut lolek = Mdns::new(lolek_id, lolek_addrs.clone(), interval).unwrap();
-        let mut bolek = Mdns::new(bolek_id, bolek_addrs.clone(), interval).unwrap();
+        let mut lolek = Mdns::new(lolek_id, lolek_addrs.clone(), interval, ttl).unwrap();
+        let mut bolek = Mdns::new(bolek_id, bolek_addrs.clone(), interval, ttl).unwrap();
 
+        // assert that lolek and bolek discover each other, and nobody else
         let (lolek_disco, bolek_disco) = futures::join!(lolek.next(), bolek.next());
-        assert_eq!(lolek_disco, Some((bolek_id, bolek_addrs)));
-        assert_eq!(bolek_disco, Some((lolek_id, lolek_addrs)));
+        assert_eq!(lolek_disco, Some((bolek_id, bolek_addrs.clone())));
+        assert_eq!(bolek_disco, Some((lolek_id, lolek_addrs.clone())));
+        assert!(bolek.is_pending());
+
+        // assert that a new peer is discovered, while the previous one (still
+        // running) is detected as already seen
+        let _tola = Mdns::new(tola_id, tola_addrs.clone(), interval, ttl).unwrap();
+        let bolek_disco = bolek.next().await;
+        assert_eq!(
+            bolek_disco,
+            Some((tola_id, tola_addrs.clone())),
+            "lolek should be cached"
+        );
+        assert!(bolek.is_pending());
+
+        // assert that, when reset, bolek will see the survivors
+        let mut bolek = Mdns::new(bolek_id, bolek_addrs.clone(), interval, ttl).unwrap();
+        let mut bolek_disco = HashSet::new();
+        for _ in 0..2 {
+            bolek_disco.insert(bolek.next().await.unwrap());
+        }
+        assert_eq!(
+            bolek_disco,
+            [
+                (lolek_id, lolek_addrs.clone()),
+                (tola_id, tola_addrs.clone())
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+            "cache should have been reset"
+        );
+        assert!(bolek.is_pending());
+
+        // assert that the cache ttl is observed by effectively disabling it
+        let mut bolek = Mdns::new(bolek_id, bolek_addrs.clone(), interval, interval).unwrap();
+        for _ in 0..2 {
+            let mut bolek_disco = HashSet::new();
+            for _ in 0..2 {
+                bolek_disco.insert(bolek.next().await.unwrap());
+            }
+            assert_eq!(
+                bolek_disco,
+                [
+                    (lolek_id, lolek_addrs.clone()),
+                    (tola_id, tola_addrs.clone())
+                ]
+                .iter()
+                .cloned()
+                .collect(),
+            );
+            assert!(bolek.is_pending())
+        }
+
+        // assert that advertising new addresses will re-discover that peer
+        let _lolek = Mdns::new(lolek_id, tola_addrs.clone(), interval, ttl).unwrap();
+        let bolek_disco = bolek.next().await;
+        assert_eq!(
+            bolek_disco,
+            Some((lolek_id, tola_addrs.clone())),
+            "lolek should've been determined refreshed"
+        );
+        assert!(bolek.is_pending());
     }
 }

--- a/librad/src/net/discovery/mdns.rs
+++ b/librad/src/net/discovery/mdns.rs
@@ -228,7 +228,7 @@ where
                     timestamp: now,
                     inner: key.clone(),
                 });
-                New((key.clone(), v))
+                New((key, v))
             },
         }
     }
@@ -239,7 +239,7 @@ where
                 return;
             }
 
-            let key = self.hip.pop().expect("we peeked, therefore we pop").inner;
+            let key = self.hip.pop().expect("I peeked, therefore I pop").inner;
             let value_timestamp = self.all[&key].0;
             if value_timestamp > deadline {
                 self.hip.push(Timestamped {

--- a/librad/src/net/discovery/mdns.rs
+++ b/librad/src/net/discovery/mdns.rs
@@ -120,9 +120,7 @@ async fn run(
                         match discovered {
                             Discovered::New((peer, _)) | Discovered::Refreshed((peer, _)) => {
                                 tracing::debug!("{} is new or refreshed", peer);
-                                if let Err(e) = tx.send((peer, addrs)).await {
-                                    tracing::warn!(err = ?e, "channel send error");
-                                }
+                                tx.send((peer, addrs)).await.ok();
                             },
 
                             Discovered::Known => {

--- a/librad/src/net/discovery/mdns.rs
+++ b/librad/src/net/discovery/mdns.rs
@@ -74,10 +74,10 @@ impl Mdns {
         use futures::Stream as _;
 
         let waker = futures::task::noop_waker();
-        match Pin::new(&mut self.chan).poll_next(&mut Context::from_waker(&waker)) {
-            Poll::Pending => true,
-            _ => false,
-        }
+        matches!(
+            Pin::new(&mut self.chan).poll_next(&mut Context::from_waker(&waker)),
+            Poll::Pending
+        )
     }
 }
 


### PR DESCRIPTION
The mDNS discovery will discover they same set of peers every
`query_interval` (if they are still responding). To not interfere with
the membership protocol, it should not yield repeatedly discovered peers
(at least for a while): otherwise, the connectivity of the local peer
would converge to the fastest responders on the local network, and
nothing else.
