### PR TITLE
net: permit logical network identifiers in ALPN

### DIFF
--- a/librad-test/src/rad/testnet.rs
+++ b/librad-test/src/rad/testnet.rs
@@ -83,6 +83,7 @@ where
         paths,
         listen_addr,
         membership: Default::default(),
+        network: Default::default(),
     };
     let disco = seeds.into_iter().collect::<discovery::Static>();
     let storage_pools = peer::PoolSizes::default();

--- a/librad/src/net.rs
+++ b/librad/src/net.rs
@@ -13,3 +13,43 @@ pub mod upgrade;
 pub mod x509;
 
 mod codec;
+
+/// The network protocol version.
+///
+/// The version number denotes compatibility, and as such is subject to change
+/// very infrequently: if two peers advertise the same version number, they MUST
+/// be able to communicate with each other (ie. their implementations must be
+/// compatible both forward and backward).
+///
+/// The protocol version is negotiated during the handshake via [ALPN], which
+/// permits gradual rollout scenarios of major network upgrades.
+///
+/// For the negotiation of optional (compatible _per definitionem_) protocol
+/// features, the [`PeerAdvertisement`] reserves space for advertising
+/// [`info::Capability`]s.
+///
+/// [ALPN]: https://tools.ietf.org/html/rfc7301
+pub const PROTOCOL_VERSION: u8 = 2;
+
+/// Logical network.
+///
+/// This may be used to operate "devnets" without physical network isolation:
+/// connections to and from peers advertising a non-matching [`Network`] SHALL
+/// be rejected. Note, however, that joining multiple logical networks is not
+/// precluded (inherent to "permissionless" protocols).
+///
+/// Custom network identifiers are part of the [ALPN] protocol identifier, and
+/// should be kept short.
+///
+/// [ALPN]: https://tools.ietf.org/html/rfc7301
+#[derive(Clone, Copy, Debug)]
+pub enum Network {
+    Main,
+    Custom(&'static [u8]),
+}
+
+impl Default for Network {
+    fn default() -> Self {
+        Self::Main
+    }
+}

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -25,7 +25,7 @@ use rand_pcg::Pcg64Mcg;
 use tokio::sync::broadcast as tincan;
 use tracing::Instrument as _;
 
-use super::{quic, upgrade};
+use super::{quic, upgrade, Network};
 use crate::{
     git::{
         self,
@@ -60,6 +60,7 @@ pub struct Config {
     pub paths: Paths,
     pub listen_addr: SocketAddr,
     pub membership: membership::Params,
+    pub network: Network,
     // TODO: transport, ...
 }
 
@@ -209,7 +210,7 @@ where
     let local_id = PeerId::from_signer(&signer);
     let git = GitServer::new(&config.paths);
     let quic::BoundEndpoint { endpoint, incoming } =
-        quic::Endpoint::bind(signer, config.listen_addr).await?;
+        quic::Endpoint::bind(signer, config.listen_addr, config.network).await?;
     let (membership, periodic) = membership::Hpv::<_, SocketAddr>::new(
         local_id,
         Pcg64Mcg::new(rand::random()),

--- a/librad/src/net/quic.rs
+++ b/librad/src/net/quic.rs
@@ -17,14 +17,10 @@ pub use error::{Error, Result};
 mod stream;
 pub use stream::{BidiStream, RecvStream, SendStream};
 
+const ALPN_PREFIX: &[u8] = b"rad";
+
 // XXX: we _may_ want to allow runtime configuration of below consts at some
 // point
-
-/// The ALPN protocol(s) for the radicle-link protocol stack.
-///
-/// Not currently of significance, but established in order to allow future
-/// major protocol upgrades.
-const ALPN: &[&[u8]] = &[b"rad/1"];
 
 /// Connection keep alive interval.
 ///

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -27,6 +27,7 @@ use librad::{
         discovery::{self, Discovery as _},
         peer::{self, Peer, ProtocolEvent},
         protocol::{self, PeerInfo},
+        Network,
     },
     paths,
     PeerId,
@@ -97,6 +98,8 @@ pub struct NodeConfig {
     pub mode: Mode,
     /// Radicle root path.
     pub root: Option<PathBuf>,
+    /// The radicle network to connect to.
+    pub network: Network,
 }
 
 impl Default for NodeConfig {
@@ -105,6 +108,7 @@ impl Default for NodeConfig {
             listen_addr: ([0, 0, 0, 0], 0).into(),
             mode: Mode::TrackEverything,
             root: None,
+            network: Network::default(),
         }
     }
 }
@@ -136,6 +140,7 @@ impl Node {
                 paths,
                 listen_addr: config.listen_addr,
                 membership: Default::default(),
+                network: config.network,
             },
             storage_pools: Default::default(),
         };


### PR DESCRIPTION
For operating "devnets" without physical network isolation.

Also, spell out the protocol versioning policy, and bump the version as
`net/next` is incompatible.
