### PR TITLE
Introduce Storage Tests

### DIFF
--- a/librad/src/git.rs
+++ b/librad/src/git.rs
@@ -17,6 +17,9 @@ pub mod types;
 
 mod sealed;
 
+#[cfg(test)]
+pub(crate) mod tests;
+
 pub use crate::identities::git::Urn;
 
 /// Initialise the git backend.

--- a/librad/src/git/tests.rs
+++ b/librad/src/git/tests.rs
@@ -1,0 +1,7 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+mod common;
+mod project;

--- a/librad/src/git/tests/common.rs
+++ b/librad/src/git/tests/common.rs
@@ -1,0 +1,43 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::io;
+
+use librad_test::tempdir::WithTmpDir;
+
+use crate::{
+    git::{
+        identities::{self, local},
+        storage::Storage,
+    },
+    identities::payload,
+    keys::SecretKey,
+    paths::Paths,
+};
+
+pub type TmpStorage = WithTmpDir<Storage>;
+
+pub fn storage(signer: SecretKey) -> anyhow::Result<TmpStorage> {
+    Ok(WithTmpDir::new(|path| {
+        let paths = Paths::from_root(path)?;
+        let storage = Storage::open_or_init(&paths, signer)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        Ok::<_, io::Error>(storage)
+    })?)
+}
+
+pub fn dylan(storage: &Storage, key: &SecretKey) -> anyhow::Result<local::LocalIdentity> {
+    let dylan = identities::person::create(
+        storage,
+        payload::Person {
+            name: "dylan".into(),
+        },
+        Some(key.public()).into_iter().collect(),
+    )?;
+    Ok(
+        local::load(&storage, dylan.urn())?
+            .ok_or_else(|| anyhow::anyhow!("where did dylan go?"))?,
+    )
+}

--- a/librad/src/git/tests/project.rs
+++ b/librad/src/git/tests/project.rs
@@ -1,0 +1,45 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use either::Either::Left;
+
+use super::*;
+use crate::{
+    git::identities,
+    identities::{delegation, payload, SomeIdentity},
+    keys::SecretKey,
+};
+
+lazy_static! {
+    static ref DYLAN: SecretKey = SecretKey::from_seed([
+        188, 166, 161, 203, 144, 68, 64, 48, 105, 98, 55, 215, 50, 154, 43, 236, 168, 133, 230, 36,
+        134, 79, 175, 109, 234, 123, 23, 114, 61, 82, 96, 52
+    ]);
+}
+
+#[test]
+fn create_anonymous() -> anyhow::Result<()> {
+    let storage = common::storage(DYLAN.clone())?;
+    let whoami = common::dylan(&storage, &DYLAN)?;
+    let proj = identities::project::create(
+        &storage,
+        whoami,
+        payload::Project {
+            name: "reMarkable 3".into(),
+            description: Some("The next big thing in e-ink technology".into()),
+            default_branch: Some("eink".into()),
+        },
+        delegation::Indirect::try_from_iter(Some(Left(DYLAN.public()))).unwrap(),
+    )?;
+    assert_eq!(
+        Some(proj.clone()),
+        identities::project::get(&storage, &proj.urn())?
+    );
+    assert_eq!(
+        Some(proj.clone()),
+        identities::any::get(&storage, &proj.urn())?.and_then(SomeIdentity::project)
+    );
+    Ok(())
+}

--- a/librad/src/identities/git.rs
+++ b/librad/src/identities/git.rs
@@ -55,9 +55,26 @@ pub type Person = Identity<PersonDoc>;
 pub type Project = Identity<ProjectDoc>;
 
 #[non_exhaustive]
+#[derive(Clone)]
 pub enum SomeIdentity {
     Person(Person),
     Project(Project),
+}
+
+impl SomeIdentity {
+    pub fn person(self) -> Option<Person> {
+        match self {
+            Self::Person(person) => Some(person),
+            _ => None,
+        }
+    }
+
+    pub fn project(self) -> Option<Project> {
+        match self {
+            Self::Project(project) => Some(project),
+            _ => None,
+        }
+    }
 }
 
 pub type SignedPerson = SignedIdentity<PersonDoc>;

--- a/librad/src/identities/git/load.rs
+++ b/librad/src/identities/git/load.rs
@@ -65,6 +65,15 @@ impl<'de> serde::Deserialize<'de> for SomeDoc {
                 }))
             },
 
+            (SomePayload::Project(payload), SomeDelegations::Person(delegations)) => {
+                Ok(Self::Project(Doc {
+                    version: doc.version,
+                    replaces: doc.replaces,
+                    payload,
+                    delegations: (*delegations).iter().copied().map(Either::Left).collect(),
+                }))
+            },
+
             _ => Err(serde::de::Error::custom("payload <-> delegations mismatch")),
         }
     }


### PR DESCRIPTION
Fixes #475 

Feeding two birds with one scone.

1. Introducing the place for tests that involve `Storage` and the `identities` APIs, since this is the main entry point for applications.
2. Fixes a case where a project can be set up using only `PublicKey`s but cannot be retrieced through the `Any` deserializer.

@kim I held off on sharing some of the resources from the other set of `identities::git::tests` (as opposed to these new `git::tests`). What are your thoughts on moving some of the common stuff upwards in the module system?