### PR TITLE
net: tickle connections after evaluating periodic tasks

### DIFF
--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -70,7 +70,18 @@ where
             },
         })
         .for_each(|tock| tick::tock(state.clone(), tock))
-        .await
+        .await;
+
+    // Tickle connections in the partial view.
+    //
+    // This is mostly to keep passive connections from being collected. Note
+    // that we're not checking actual liveness, nor interfering with the
+    // membership protocol.
+    for peer in state.membership.known() {
+        if let Some(conn) = state.endpoint.get_connection(peer) {
+            conn.tickle()
+        }
+    }
 }
 
 #[tracing::instrument(skip(state, rx))]

--- a/librad/src/net/quic/connection.rs
+++ b/librad/src/net/quic/connection.rs
@@ -153,7 +153,7 @@ impl Connection {
             .disconnect(&self.id(), CloseReason::ConnectionError);
     }
 
-    pub(super) fn tickle(&self) {
+    pub fn tickle(&self) {
         self.track.tickle(&self.id())
     }
 


### PR DESCRIPTION
See commentary inline. We need to keep passive peers from hitting the
idle timeout, on a best-effort basis.
