### PR TITLE
backport: net: permit logical network identifiers in ALPN

### DIFF
--- a/librad-test/src/rad/testnet.rs
+++ b/librad-test/src/rad/testnet.rs
@@ -64,6 +64,7 @@ where
     let gossip_params = Default::default();
     let disco = seeds.into_iter().collect::<discovery::Static>();
     let storage_config = Default::default();
+    let network = Default::default();
 
     git::storage::Storage::init(&paths, key.clone())?;
 
@@ -73,6 +74,7 @@ where
         listen_addr,
         gossip_params,
         storage_config,
+        network,
     };
 
     Peer::bootstrap(config, disco)

--- a/librad/src/net.rs
+++ b/librad/src/net.rs
@@ -14,3 +14,43 @@ pub mod upgrade;
 pub mod x509;
 
 mod codec;
+
+/// The network protocol version.
+///
+/// The version number denotes compatibility, and as such is subject to change
+/// very infrequently: if two peers advertise the same version number, they MUST
+/// be able to communicate with each other (ie. their implementations must be
+/// compatible both forward and backward).
+///
+/// The protocol version is negotiated during the handshake via [ALPN], which
+/// permits gradual rollout scenarios of major network upgrades.
+///
+/// For the negotiation of optional (compatible _per definitionem_) protocol
+/// features, the [`PeerAdvertisement`] reserves space for advertising
+/// [`info::Capability`]s.
+///
+/// [ALPN]: https://tools.ietf.org/html/rfc7301
+pub const PROTOCOL_VERSION: u8 = 2;
+
+/// Logical network.
+///
+/// This may be used to operate "devnets" without physical network isolation:
+/// connections to and from peers advertising a non-matching [`Network`] SHALL
+/// be rejected. Note, however, that joining multiple logical networks is not
+/// precluded (inherent to "permissionless" protocols).
+///
+/// Custom network identifiers are part of the [ALPN] protocol identifier, and
+/// should be kept short.
+///
+/// [ALPN]: https://tools.ietf.org/html/rfc7301
+#[derive(Clone, Copy, Debug)]
+pub enum Network {
+    Main,
+    Custom(&'static [u8]),
+}
+
+impl Default for Network {
+    fn default() -> Self {
+        Self::Main
+    }
+}

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -37,6 +37,7 @@ use crate::{
         gossip::{self, LocalStorage, PeerInfo, PutResult},
         protocol::{Protocol, ProtocolEvent},
         quic::{self, Endpoint},
+        Network,
     },
     paths::Paths,
     peer::{Originates, PeerId},
@@ -123,6 +124,7 @@ pub struct PeerConfig<Signer> {
     pub listen_addr: SocketAddr,
     pub gossip_params: gossip::MembershipParams,
     pub storage_config: StorageConfig,
+    pub network: Network,
 }
 
 #[derive(Clone, Copy)]
@@ -346,7 +348,7 @@ impl Peer {
 
         let git = GitServer::new(&config.paths);
 
-        let endpoint = Endpoint::bind(config.signer.clone(), config.listen_addr)
+        let endpoint = Endpoint::bind(config.signer.clone(), config.listen_addr, config.network)
             .await
             .map_err(|e| BootstrapError::Bind {
                 addr: config.listen_addr,

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -30,6 +30,7 @@ use librad::{
         gossip::types::PeerInfo,
         peer::{self, Peer, PeerApi, PeerConfig},
         protocol::ProtocolEvent,
+        Network,
     },
     paths,
     peer::PeerId,
@@ -109,6 +110,8 @@ pub struct NodeConfig {
     pub mode: Mode,
     /// Radicle root path.
     pub root: Option<PathBuf>,
+    /// The radicle network to connect to.
+    pub network: Network,
 }
 
 impl Default for NodeConfig {
@@ -117,6 +120,7 @@ impl Default for NodeConfig {
             listen_addr: ([0, 0, 0, 0], 0).into(),
             mode: Mode::TrackEverything,
             root: None,
+            network: Network::default(),
         }
     }
 }
@@ -150,6 +154,7 @@ impl Node {
             listen_addr: config.listen_addr,
             gossip_params,
             storage_config,
+            network: config.network,
         };
 
         Ok(Node {


### PR DESCRIPTION
Backport of #487 (4e8995823171b364bba67f0b91832812f0d538cb) to `next`.