### PR TITLE
Add profiles and profile-scoped paths

### DIFF
--- a/git-helpers/src/remote_helper.rs
+++ b/git-helpers/src/remote_helper.rs
@@ -16,7 +16,7 @@ use librad::{
         url::LocalUrl,
     },
     keys::{PublicKey, SecretKey},
-    paths::Paths,
+    profile::Profile,
     signer::{BoxedSigner, SomeSigner},
 };
 use radicle_keystore::{
@@ -40,7 +40,8 @@ pub fn run() -> anyhow::Result<()> {
     let git_dir = env::var("GIT_DIR").map(PathBuf::from)?;
 
     let mut transport = {
-        let paths = Paths::from_env()?;
+        let profile = Profile::load()?;
+        let paths = profile.paths().to_owned();
         let signer = get_signer(&git_dir, paths.keys_dir(), &url)?;
         let settings: Box<dyn CanOpenStorage> = Box::new(Settings { paths, signer });
         Ok::<_, anyhow::Error>(LocalTransport::from(settings))

--- a/git-helpers/tests/remote.rs
+++ b/git-helpers/tests/remote.rs
@@ -18,6 +18,7 @@ use librad::{
     git::{local::url::LocalUrl, storage::Storage, Urn},
     keys::{PublicKey, SecretKey},
     paths::Paths,
+    profile::Profile,
 };
 use librad_test::{logging, rad::identities::create_test_project};
 
@@ -28,7 +29,8 @@ fn smoke() {
     logging::init();
 
     let rad_dir = tempdir().unwrap();
-    let rad_paths = Paths::from_root(rad_dir.path()).unwrap();
+    let profile = Profile::from_root(rad_dir.path(), None).unwrap();
+    let rad_paths = profile.paths();
     let key = SecretKey::new();
 
     let urn = setup_project(&rad_paths, key.clone()).unwrap();

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -45,6 +45,7 @@ time = "0.2"
 tracing = "0.1"
 tracing-futures = "0.2"
 unicode-normalization = "0.1"
+uuid = { version = "0.8", features = ["v4"] }
 webpki = "0.21"
 
 [dependencies.deadpool]

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -33,6 +33,7 @@ pub mod keys;
 pub mod net;
 pub mod paths;
 pub mod peer;
+pub mod profile;
 pub mod signer;
 
 // Re-exports

--- a/librad/src/profile.rs
+++ b/librad/src/profile.rs
@@ -1,0 +1,245 @@
+// Copyright © 2019-2021 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    env,
+    fs,
+    io,
+    path,
+    path::{Path, PathBuf},
+};
+use uuid::Uuid;
+
+use crate::paths::{project_dirs, Paths};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid profile ID in RAD_PROFILE environment variable: {id}")]
+    InvalidProfileIdFromEnv { id: String },
+    #[error("invalid profile ID loaded from {path}: {id}")]
+    InvalidProfileIdFromFile { id: String, path: PathBuf },
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+/// A [`Profile`] provides [`Paths`] scoped by an identifier.
+///
+/// Profiles with different identifiers have distinct paths.
+#[derive(Debug, Clone)]
+pub struct Profile {
+    id: String,
+    paths: Paths,
+}
+
+impl Profile {
+    /// Creates a profile by loading the profile identifier and paths from
+    /// the environment variables or well-known file.
+    ///
+    /// By default, the profile identifier is read from the `active_profile`
+    /// file in a system specific location. The paths returned by
+    /// [`Profile::paths`] are based on system paths (see [`directories::
+    /// ProjectDirs`]) and include the profile identifier. If the file
+    /// containing the identifier does not exist, it is created and a new
+    /// identifier is generated and written to the file.
+    ///
+    /// If the `RAD_PROFILE` environment variable is set, its value is used as
+    /// the profile identifier. The `active_profile` file is ignored.
+    ///
+    /// If the `RAD_HOME` environment variable is set, its value is used instead
+    /// of system specific project directories. See also
+    /// [`Profile::from_root`].
+    ///
+    /// The profile identifier must not empty, must not contain path separators,
+    /// must not be a windows path prefix like `C:`, and must not be a
+    /// special component like `.` or `..`. Otherwise an error is returned
+    ///
+    /// On Linux, the path to the active profile is
+    /// `$XDG_CONFIG_HOME/radicle-link/active_profile` and profile specific
+    /// system paths are `$XDG_CONFIG_HOME/radicle-link/<profile_id>` and
+    /// `XDG_DATA_HOME/radicle-link/<profile-id>`.
+    pub fn load() -> Result<Self, Error> {
+        let env_profile_id = env::var("RAD_PROFILE").ok();
+
+        if let Some(ref id) = env_profile_id {
+            if !is_valid_profile_id(id) {
+                return Err(Error::InvalidProfileIdFromEnv { id: id.clone() });
+            }
+        }
+
+        if let Ok(rad_home) = env::var("RAD_HOME") {
+            Self::from_root(Path::new(&rad_home), env_profile_id)
+        } else {
+            let id = if let Some(id) = env_profile_id {
+                id
+            } else {
+                load_profile_id(project_dirs()?.config_dir())?
+            };
+
+            let paths = Paths::new(&id)?;
+
+            Ok(Self { id, paths })
+        }
+    }
+
+    /// Creates a profile where `<root>/<profile_id>` is used as the base path
+    /// for profile specific data.
+    ///
+    /// If `profile_id` is `None`, then the profile is read from
+    /// `<root>/active_profile` if the file exists. Otherwise, a new profile
+    /// ID is generated and written to `<root>/active_profile`.
+    ///
+    /// [`Paths::from_root`] for more information.
+    pub fn from_root(root: &Path, profile_id: Option<String>) -> Result<Self, Error> {
+        let id = if let Some(profile_id) = profile_id {
+            profile_id
+        } else {
+            load_profile_id(root)?
+        };
+
+        let paths = Paths::from_root(root.join(&id))?;
+
+        Ok(Self { id, paths })
+    }
+
+    /// Returns the profile identifier
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns [`Paths`] for this profile.
+    pub fn paths(&self) -> &Paths {
+        &self.paths
+    }
+}
+
+/// Returns `true` if `id` is a valid profile ID.
+///
+/// A valid profile ID is not empty, does not contain path separators, is not
+/// a windows path prefix like `C:`, and is not a special component like `.` or
+/// `..`.
+fn is_valid_profile_id(id: &str) -> bool {
+    let mut components = Path::new(id).components();
+
+    match components.next() {
+        Some(path::Component::Normal(_)) => {},
+        _ => return false,
+    }
+
+    if components.next().is_some() {
+        return false;
+    }
+
+    true
+}
+
+/// Read the profile ID from a file or create the file and write a newly
+/// generated profile ID to it.
+///
+/// The profile ID is the first line of the file. If the file does not exist a
+/// new ID is generated and written to the file.
+///
+/// The profile ID is validated.
+fn load_profile_id(config_dir: &Path) -> Result<String, Error> {
+    let active_profile_path = config_dir.join("active_profile");
+
+    let maybe_id = match fs::read_to_string(&active_profile_path) {
+        Ok(content) => Some(content.lines().next().unwrap_or("").to_string()),
+        Err(err) => {
+            if err.kind() == io::ErrorKind::NotFound {
+                None
+            } else {
+                return Err(Error::from(err));
+            }
+        },
+    };
+
+    if let Some(id) = maybe_id {
+        if !is_valid_profile_id(&id) {
+            return Err(Error::InvalidProfileIdFromFile {
+                path: active_profile_path,
+                id,
+            });
+        }
+
+        Ok(id)
+    } else {
+        let id = Uuid::new_v4().to_hyphenated().to_string();
+        fs::create_dir_all(config_dir)?;
+        fs::write(active_profile_path, &id)?;
+        Ok(id)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn load_profile_id_test() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let id1 = load_profile_id(tempdir.path()).unwrap();
+        let id2 = load_profile_id(tempdir.path()).unwrap();
+        assert_eq!(id2, id1);
+        fs::remove_dir_all(tempdir.path()).unwrap();
+
+        let id3 = load_profile_id(tempdir.path()).unwrap();
+        assert_ne!(id3, id1);
+    }
+
+    #[test]
+    fn profile_paths() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let id = "foo";
+
+        let profile_id_path = tempdir.path().join("active_profile");
+        std::fs::write(profile_id_path, id).unwrap();
+
+        let profile = Profile::from_root(tempdir.path(), None).unwrap();
+        assert_eq!(profile.id(), id);
+        assert!(profile
+            .paths()
+            .git_dir()
+            .starts_with(tempdir.path().join(id)));
+    }
+
+    #[test]
+    fn invalid_profile_id_from_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let profile_id_path = tempdir.path().join("active_profile");
+        let invalid_id = "foo/bar";
+        std::fs::write(profile_id_path, invalid_id).unwrap();
+
+        let result = load_profile_id(tempdir.path());
+        assert!(matches!(
+            result,
+            Err(Error::InvalidProfileIdFromFile { .. })
+        ));
+    }
+
+    #[test]
+    fn load_profile_strip() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let profile_id_path = tempdir.path().join("active_profile");
+        let content = "foo\nbar";
+        std::fs::write(profile_id_path, content).unwrap();
+        let id = load_profile_id(tempdir.path()).unwrap();
+        assert_eq!(id, "foo");
+    }
+
+    #[test]
+    fn empty_profile_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let profile_id_path = tempdir.path().join("active_profile");
+        let content = "";
+        std::fs::write(profile_id_path, content).unwrap();
+        let err = load_profile_id(tempdir.path()).unwrap_err();
+        assert!(matches!(err, Error::InvalidProfileIdFromFile { .. }))
+    }
+}

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -34,6 +34,7 @@ use librad::{
     },
     paths,
     peer::PeerId,
+    profile,
 };
 
 pub use crate::{
@@ -78,6 +79,9 @@ pub enum Error {
 
     #[error(transparent)]
     Channel(#[from] chan::SendError),
+
+    #[error(transparent)]
+    Profile(#[from] profile::Error),
 }
 
 /// Seed operational mode.
@@ -144,7 +148,7 @@ impl Node {
         let paths = if let Some(root) = &config.root {
             paths::Paths::from_root(root)?
         } else {
-            paths::Paths::new()?
+            profile::Profile::load()?.paths().to_owned()
         };
         let gossip_params = Default::default();
         let storage_config = Default::default();


### PR DESCRIPTION
To address #488 we add the `Profile` struct.

This pull request is against `next`. I will try to write automatic migration code for this so we can include it in `maint` without a breaking change.

We’ve also simplified some methods on `Paths` and made them private.