### PR TITLE
Fix smallvec vulnerability

### DIFF
--- a/ci/advisory
+++ b/ci/advisory
@@ -6,6 +6,9 @@ then
     sed -i -e 's|db-path.*|db-path = "/cache/cargo/advisory-db"|' deny.toml
 fi
 
+echo '--- deny: Version'
+cargo deny --version
+
 echo '--- deny: Advisories'
 cargo deny check advisories
 

--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,7 @@ in
     name = "clang-env-with-nightly-rust";
     buildInputs = [
       (pkgs.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust
+      cargo-deny
       clang
       llvmPackages.libclang
       olm

--- a/deny.toml
+++ b/deny.toml
@@ -5,7 +5,7 @@
 # The path where the advisory database is cloned/fetched into
 db-path = "~/cargo/advisory-db"
 # The url of the advisory database to use
-db-url = "https://github.com/rustsec/advisory-db"
+db-urls = [ "https://github.com/rustsec/advisory-db" ]
 # The lint level for security vulnerabilities
 vulnerability = "deny"
 # The lint level for unmaintained crates

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -111,6 +111,12 @@ features = ["logging", "dangerous_configuration"]
 version = "1.0"
 features = ["derive"]
 
+# Note: this is not a direct dependency. governor depends on
+# parking_lot, which depends on smallvec. There is vulnerability
+# in v1.0 and so we're forcing cargo to use this version instead.
+[dependencies.smallvec]
+version = "1.6.1"
+
 [dependencies.tokio]
 version = "0.2"
 features = ["full"]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -114,8 +114,10 @@ features = ["derive"]
 # Note: this is not a direct dependency. governor depends on
 # parking_lot, which depends on smallvec. There is vulnerability
 # in v1.0 and so we're forcing cargo to use this version instead.
+#
+# Tracking issue in governor: https://github.com/antifuchs/governor/issues/60
 [dependencies.smallvec]
-version = "1.6.1"
+version = ">=1.6.1"
 
 [dependencies.tokio]
 version = "0.2"


### PR DESCRIPTION
We force the smallvec dependency to be 1.6.1 due to the vulnerability
outlined in the issue here Amanieu/parking_lot#274. 
We depend on governor which in turn depends on parking_lot.

Also updating the field `db-url` to `db-urls`, and outputting the version of cargo deny for inspection sake.