### PR TITLE
Tokio EINS

### DIFF
--- a/ci/build-test
+++ b/ci/build-test
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 echo '--- Build'
-cargo build --workspace --all-features
+cargo build --verbose --workspace --all-features
 
 echo '--- Test'
 GIT_TRACE2=1 RUST_LOG=librad=trace cargo test --workspace --all-features

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -22,4 +22,4 @@ path = "../librad"
 features = ["disco-mdns"]
 
 [dependencies.tokio]
-version = "0.2"
+version = "1.1"

--- a/e2e/src/bin/ephemeral-peer.rs
+++ b/e2e/src/bin/ephemeral-peer.rs
@@ -100,10 +100,10 @@ async fn emit_stats(peer: Peer<SecretKey>) -> anyhow::Result<!> {
         )
     };
 
-    let mut sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await?;
+    let sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await?;
     sock.connect("127.0.0.1:9109").await?;
     loop {
-        tokio::time::delay_for(Duration::from_secs(10)).await;
+        tokio::time::sleep(Duration::from_secs(10)).await;
         let stats = peer.stats().await;
         tracing::info!("stats: {:?}", stats);
 

--- a/librad-test/Cargo.toml
+++ b/librad-test/Cargo.toml
@@ -18,7 +18,7 @@ pretty_assertions = "0"
 serde = "1"
 serde_json = "1"
 tempfile = "3"
-tokio = "0.2"
+tokio = "1.1"
 tracing = ">= 0.1"
 tracing-subscriber = ">= 0.2"
 

--- a/librad-test/src/rad/testnet.rs
+++ b/librad-test/src/rad/testnet.rs
@@ -210,7 +210,7 @@ where
 pub async fn wait_converged<E>(events: E, min_connected: usize)
 where
     E: IntoIterator,
-    E::Item: futures::Stream<Item = Result<protocol::event::Upstream, protocol::RecvError>> + Unpin,
+    E::Item: futures::Stream<Item = Result<protocol::event::Upstream, protocol::RecvError>> + Send,
 {
     if min_connected < 2 {
         return;
@@ -224,6 +224,7 @@ where
                     future::ok(!matches!(evt, protocol::event::Upstream::Membership(_)))
                 })
                 .map_ok(drop)
+                .boxed()
                 .into_future()
                 .map(|(x, _)| x)
         })

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -10,6 +10,7 @@ default = []
 disco-mdns = ["mdns", "madness"]
 
 [dependencies]
+async-stream = "0.3"
 async-trait = "0.1"
 bit-vec = "0.6"
 bs58 = "0.3"
@@ -22,7 +23,7 @@ globset = "0.4"
 governor = ">=0.3.2"
 lazy_static = "1"
 libc = "0.2"
-mdns = { version = "1", optional = true }
+mdns = { version = "3", optional = true }
 multibase = "0.9"
 multihash = "0.11"
 nom = "5"
@@ -83,7 +84,7 @@ features = []
 
 [dependencies.madness]
 git = "https://github.com/meilisearch/madness"
-rev = "cb12159a06f3698d0ba4ea078e95f8a915a9a9d3"
+rev = "12a7386952923990179fe400e0cd932cbdd90dfc"
 optional = true
 
 [dependencies.minicbor]
@@ -92,7 +93,7 @@ features = ["std", "derive"]
 
 [dependencies.quinn]
 git = "https://github.com/quinn-rs/quinn"
-rev = "47232c83d1615e96b4a8480ec25fbf7fcf6771f5"
+rev = "05bb6cdd5f53484f538a20da37407ef13faf42e0"
 default-features = false
 features = ["tls-rustls"]
 
@@ -107,20 +108,24 @@ path = "../std-ext"
 
 # Note: this MUST always match the exact patch version `quinn` uses
 [dependencies.rustls]
-git = "https://github.com/ctz/rustls"
-rev = "fee894f7e030"
+version  = "0.19"
 features = ["logging", "dangerous_configuration"]
 
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]
 
+# 0.1.12 breaks our builds
+# See: https://github.com/tokio-rs/tracing/issues/1227
+[dependencies.tracing-attributes]
+version = "<= 0.1.11"
+
 [dependencies.tokio]
-version = "0.2"
+version = "1.1"
 features = ["full"]
 
 [dependencies.tokio-util]
-version = "0.3"
+version = "0.6"
 features = ["compat"]
 
 [dependencies.url]

--- a/librad/tests/scenario/collaboration.rs
+++ b/librad/tests/scenario/collaboration.rs
@@ -18,7 +18,7 @@ use librad_test::{
 
 const NUM_PEERS: usize = 2;
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn can_add_maintainer() {
     logging::init();
 

--- a/librad/tests/scenario/menage.rs
+++ b/librad/tests/scenario/menage.rs
@@ -23,7 +23,7 @@ use librad_test::{
 
 const NUM_PEERS: usize = 3;
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_trois() {
     logging::init();
 

--- a/librad/tests/scenario/working_copy.rs
+++ b/librad/tests/scenario/working_copy.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use futures::StreamExt as _;
 use tempfile::tempdir;
 
 use librad::{
@@ -64,7 +65,7 @@ const NUM_PEERS: usize = 2;
 /// 7. peer2 creates an include file, based of the tracked users of the project
 /// i.e. peer1 8. peer2 includes this file in their working copy's config
 /// 9. peer2 fetches in the working copy and sees the commit
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn can_fetch() {
     logging::init();
 
@@ -112,7 +113,7 @@ async fn can_fetch() {
                     .await
                     .unwrap();
             event::upstream::expect(
-                peer2_events,
+                peer2_events.boxed(),
                 gossip_from(peer1.peer_id()),
                 Duration::from_secs(5),
             )

--- a/librad/tests/smoke/gossip.rs
+++ b/librad/tests/smoke/gossip.rs
@@ -33,7 +33,7 @@ use tempfile::tempdir;
 
 const NUM_PEERS: usize = 2;
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn fetches_on_gossip_notify() {
     logging::init();
 
@@ -102,7 +102,7 @@ async fn fetches_on_gossip_notify() {
 
         // Wait for peer2 to receive the gossip announcement
         event::upstream::expect(
-            peer2_events,
+            peer2_events.boxed(),
             gossip_from(peer1.peer_id()),
             Duration::from_secs(5),
         )

--- a/seed/Cargo.toml
+++ b/seed/Cargo.toml
@@ -11,5 +11,5 @@ futures = "0.3"
 librad = { path = "../librad" }
 radicle-keystore = "0"
 thiserror = "1"
-tokio = { version = "0.2", features = ["time"] }
+tokio = { version = "1.1", features = ["time"] }
 tracing = "0.1"

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -168,7 +168,7 @@ impl Node {
     /// occurs.
     pub async fn run(self, mut transmit: chan::Sender<Event>) -> Result<(), Error> {
         let peer = Peer::new(self.peer_config);
-        let mut events = peer.subscribe().fuse();
+        let mut events = peer.subscribe().boxed().fuse();
         let mut requests = self.requests;
         let mode = &self.config.mode;
 
@@ -186,7 +186,7 @@ impl Node {
                         },
                         Err(e) => {
                             tracing::error!(err = ?e, "Bind error");
-                            tokio::time::delay_for(Duration::from_secs(2)).await
+                            tokio::time::sleep(Duration::from_secs(2)).await
                         },
                     }
                 }


### PR DESCRIPTION
Leaving this as draft until `next`, `net/next` all converged on a single trunk.