### PR TITLE
copy: batch create

### DIFF
--- a/copy/Cargo.toml
+++ b/copy/Cargo.toml
@@ -13,6 +13,7 @@ librad = { path = "../librad" }
 nonempty = "0.6"
 radicle-git-ext = { path = "../git-ext" }
 radicle-keystore = "0"
+serde_json = "1.0"
 thiserror = "1.0"
 tracing = "0.1"
 

--- a/copy/src/cli/args.rs
+++ b/copy/src/cli/args.rs
@@ -72,10 +72,23 @@ pub struct Garden {
 }
 
 pub mod garden {
+    use std::{convert::TryFrom as _, fs::File, io::BufReader};
+
+    use serde::Deserialize;
+
+    use librad::{
+        git::{identities::local::LocalIdentity, storage::Storage},
+        git_ext::{OneLevel, RefLike},
+        paths::Paths,
+        signer::BoxedSigner,
+    };
+
     use super::*;
+
     #[derive(Debug, FromArgs)]
     #[argh(subcommand)]
     pub enum Options {
+        Bed(Bed),
         Plant(Plant),
         Repot(Repot),
         Graft(Graft),
@@ -84,8 +97,9 @@ pub mod garden {
     /// 🌱 Plants a fresh, new Radicle project in the provided directory and
     /// using the provided name. The final directory must not already exist,
     /// i.e. <path>/<name> should not already exist.
-    #[derive(Debug, FromArgs)]
+    #[derive(Debug, Deserialize, FromArgs)]
     #[argh(subcommand, name = "plant")]
+    #[serde(rename_all = "camelCase")]
     pub struct Plant {
         /// description of the project we are creating
         #[argh(option, from_str_fn(Cstring::from))]
@@ -101,13 +115,35 @@ pub mod garden {
         pub path: PathBuf,
     }
 
+    impl Plant {
+        pub fn cultivate(
+            self,
+            storage: &Storage,
+            signer: BoxedSigner,
+            paths: Paths,
+            whoami: LocalIdentity,
+        ) -> anyhow::Result<()> {
+            use crate::garden::{plant, plant::Plant};
+
+            let default_branch = OneLevel::from(RefLike::try_from(self.default_branch.as_str())?);
+            let raw = Plant::new(self.description, default_branch, self.name, self.path);
+            let valid = Plant::validate(raw)?;
+            let path = valid.path();
+            let project = plant(paths, signer, &storage, whoami, valid)?;
+
+            project_success(&project.urn(), path);
+            Ok(())
+        }
+    }
+
     /// 🪴 Repots a new Radicle project using an existing git repository as
     /// the working copy. The name of the project will be the last component
     /// of the directory path, e.g. `~/Developer/radicle-link` will have the
     /// name `radicle-link`. The git repository must already exist on your
     /// filesystem, if it doesn't use the `new` command instead.
-    #[derive(Debug, FromArgs)]
+    #[derive(Debug, Deserialize, FromArgs)]
     #[argh(subcommand, name = "repot")]
+    #[serde(rename_all = "camelCase")]
     pub struct Repot {
         /// description of the project we want to create
         #[argh(option, from_str_fn(Cstring::from))]
@@ -118,6 +154,26 @@ pub mod garden {
         /// the directory of the existing git repository
         #[argh(option)]
         pub path: PathBuf,
+    }
+
+    impl Repot {
+        pub fn cultivate(
+            self,
+            storage: &Storage,
+            signer: BoxedSigner,
+            paths: Paths,
+            whoami: LocalIdentity,
+        ) -> anyhow::Result<()> {
+            use crate::garden::{repot, repot::Repot};
+
+            let default_branch = OneLevel::from(RefLike::try_from(self.default_branch.as_str())?);
+            let raw = Repot::new(self.description, default_branch, self.path.clone())?;
+            let valid = Repot::validate(raw)?;
+            let project = repot(paths, signer, &storage, whoami, valid)?;
+
+            project_success(&project.urn(), self.path);
+            Ok(())
+        }
     }
 
     /// 🍄 Grafts a new working copy on your filesystem based off of a Radicle
@@ -142,5 +198,37 @@ pub mod garden {
         /// the path where we are creating the working copy
         #[argh(option)]
         pub path: PathBuf,
+    }
+
+    /// 🌷🌹 Build a garden of projects based off of a manifest file.
+    #[derive(Debug, FromArgs)]
+    #[argh(subcommand, name = "bed")]
+    pub struct Bed {
+        /// the manifest file that contains JSON descriptions of `plant` and
+        /// `repot`.
+        #[argh(option)]
+        pub manifest: PathBuf,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(tag = "type")]
+    pub enum BagOfSeeds {
+        Plant(Plant),
+        Repot(Repot),
+    }
+
+    impl Bed {
+        pub fn load(&self) -> anyhow::Result<Vec<BagOfSeeds>> {
+            let file = File::open(&self.manifest)?;
+            let reader = BufReader::new(file);
+
+            Ok(serde_json::from_reader(reader)?)
+        }
+    }
+
+    fn project_success(urn: &Urn, path: PathBuf) {
+        println!("Your project was created 🎉");
+        println!("The project's URN is `{}`", urn);
+        println!("The working copy exists at `{}`", path.display());
     }
 }


### PR DESCRIPTION
Adding a batch creation option. It allows the person to specify a path
to a manifest file, in JSON format, and iterates over the projects
creating them.