### PR TITLE
tracing-attributes version bound

### DIFF
--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -112,6 +112,11 @@ features = ["logging", "dangerous_configuration"]
 version = "1.0"
 features = ["derive"]
 
+# 0.1.12 breaks our builds
+# See: https://github.com/tokio-rs/tracing/issues/1227
+[dependencies.tracing-attributes]
+version = "<= 0.1.11"
+
 [dependencies.tokio]
 version = "0.2"
 features = ["full"]


### PR DESCRIPTION
0.1.12 breaks our builds at the moment so we should specify an upper
bound of 0.1.11.

See: https://github.com/tokio-rs/tracing/issues/1227

Feel free to fix/merge while I'm out next week :smile: 