### PR TITLE
Update Cargo.toml: tracing-attributes

### DIFF
--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -47,6 +47,7 @@ tempfile = "3.1"
 thiserror = "1.0"
 time = "0.2"
 tracing = "0.1"
+tracing-attributes = "<0.12.0, ^0.1.13"
 tracing-futures = "0.2"
 unicode-normalization = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
@@ -115,11 +116,6 @@ features = ["logging", "dangerous_configuration"]
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]
-
-# 0.1.12 breaks our builds
-# See: https://github.com/tokio-rs/tracing/issues/1227
-[dependencies.tracing-attributes]
-version = "<= 0.1.11"
 
 [dependencies.tokio]
 version = "1.1"


### PR DESCRIPTION
Since there was a release of tracing-attributes
(https://crates.io/crates/tracing-attributes/0.1.13) we can place a
better range on the versions that is lower than 0.1.12 and anything
upwards of 0.1.13, inclusive.