### PR TITLE
Adding radicle-patience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "librad",
   "librad-test",
   "macros",
+  "patience",
   "seed",
   "std-ext",
   "tracker",

--- a/patience/Cargo.toml
+++ b/patience/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "radicle-patience"
+version = "0.1.0"
+authors = ["The Radicle Team <dev@radicle.xyz>"]
+edition = "2018"
+license = "GPL-3.0-or-later"
+
+[dependencies]
+either = "1"
+librad = { path = "../librad" }
+serde_millis = "0.1"
+thiserror = "1.0"
+
+[dependencies.serde]
+version = "1.0"
+features = ["derive"]
+
+[dev-dependencies]
+assert_matches = "1"
+pretty_assertions = "0"

--- a/patience/src/lib.rs
+++ b/patience/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! 🩺 Patience is a virtue, so please take a ticket for the waiting room and be
+//! patient.
+//!
+//! An API for keeping track of requests and their state transitions.
+//!
+//! See [`Request`] and [`WaitingRoom`] for a high-level view of
+//! the API.
+
+pub mod request;
+pub mod types;
+pub mod waiting_room;
+
+// Re-export types
+pub use request::{Request, SomeRequest};
+pub use waiting_room::WaitingRoom;
+
+/// Private trait for sealing the traits we use here.
+mod sealed;

--- a/patience/src/request.rs
+++ b/patience/src/request.rs
@@ -1,0 +1,328 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{collections::HashMap, ops::Deref};
+
+use either::Either;
+use serde::{Deserialize, Serialize};
+
+use librad::{identities::Urn, peer::PeerId};
+
+use crate::{
+    request::states::{
+        Cancel,
+        Cancelled,
+        Cloned,
+        Cloning,
+        Created,
+        Found,
+        HasPeers,
+        QueryAttempt,
+        Requested,
+        Status,
+        TimeOut,
+        TimedOut,
+    },
+    types::{Attempts, Clones, Queries},
+};
+
+pub mod existential;
+pub use existential::SomeRequest;
+
+pub mod states;
+
+/// A `Request` represents the lifetime of requesting an identity in the network
+/// via its [`Urn`].
+///
+/// The `Request`'s state is represented by the `S` type parameter. This
+/// parameter makes sure that a `Request` transitions through specific states in
+/// a type safe manner.
+///
+/// These transitions are pictured below:
+///
+/// ```text
+///      +----------------------------------v
+///      |                             +---------+
+///      |                   +-------->+cancelled+<------+
+///      |                   |         +----+----+       |
+///      |                   |              ^            |
+///      |                   |              |            |
+/// +----+----+       +------+--+       +---+-+      +---+---+       +------+
+/// | created +------>+requested+------>+found+----->+cloning+------>+cloned|
+/// +---------+       +------+--+       +--+--+      +---+---+       +------+
+///                          |  ^-------+  |  ^------+   |
+///                          |    failed   |   failed    |
+///                          |             v             |
+///                          |          +--+------+      |
+///                          +--------->+timed out+------+
+///                                     +---------+
+/// ```
+///
+/// The `T` type parameter represents some timestamp that is chosen by the user
+/// of the `Request` API. Note that it makes it easy to test by just choosing
+/// `()` for the timestamp.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Request<S, T> {
+    /// The identifier of the identity on the network.
+    pub(crate) urn: Urn,
+    /// The number of attempts this request has made to complete its job.
+    pub(crate) attempts: Attempts,
+    /// The timestamp of the latest action to be taken on this request.
+    #[serde(with = "serde_millis", bound = "T: serde_millis::Milliseconds")]
+    pub(crate) timestamp: T,
+    /// The state of the request, as mentioned above.
+    pub(crate) state: S,
+}
+
+impl<S, T> Deref for Request<S, T> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl<S, T> Request<S, T> {
+    /// Get the [`Urn`] that this `Request` is searching for.
+    pub const fn urn(&self) -> &Urn {
+        &self.urn
+    }
+
+    /// Get the the current timestamp of the `Request`.
+    pub const fn timestamp(&self) -> &T {
+        &self.timestamp
+    }
+
+    /// Transition this `Request` into an `Cancelled` state. We can only
+    /// transition a particular subset of the states which are: `{Created,
+    /// Requested, Found, Cloning, Cancelled}`.
+    ///
+    /// That is, attempting to cancel a `Cloned` `Request` is not permitted and
+    /// will complain at compile time.
+    pub fn cancel(self, timestamp: T) -> Request<Cancelled, T>
+    where
+        S: Cancel,
+    {
+        Request {
+            urn: self.urn,
+            attempts: self.attempts,
+            timestamp,
+            state: self.state.cancel(),
+        }
+    }
+
+    /// If a state keeps track of found peers then it can transition back to
+    /// itself by adding a `PeerId` to the existing set of peers.
+    pub fn found(mut self, peer: PeerId, timestamp: T) -> Request<S, T>
+    where
+        S: HasPeers,
+    {
+        self.state.peers().entry(peer).or_insert(Status::Available);
+        self.timestamp = timestamp;
+        self
+    }
+
+    /// A `Request` transitions into a timed out state if it exceeds the maximum
+    /// number of queries or maximum number of clones. Otherwise, the
+    /// `Request` proceeds as normal.
+    ///
+    /// The subset of states that can transition to the `TimedOut` state consist
+    /// of `{Requested, Found, Cloning}`.
+    pub fn timed_out(
+        mut self,
+        max_queries: Queries,
+        max_clones: Clones,
+        timestamp: T,
+    ) -> Either<Self, Request<TimedOut, T>>
+    where
+        S: TimeOut,
+    {
+        if self.attempts.queries > max_queries {
+            Either::Right(Request {
+                urn: self.urn,
+                attempts: self.attempts,
+                timestamp,
+                state: self.state.time_out(TimedOut::Query),
+            })
+        } else if self.attempts.clones > max_clones {
+            Either::Right(Request {
+                urn: self.urn,
+                attempts: self.attempts,
+                timestamp,
+                state: self.state.time_out(TimedOut::Clone),
+            })
+        } else {
+            self.timestamp = timestamp;
+            Either::Left(self)
+        }
+    }
+
+    /// When a `Request` is queried, we increment the `queries` count -- tracked
+    /// via the `attempts` of the `Request`. If incrementing this count
+    /// makes it exceed the maximum then the `Request` transitions into the
+    /// `TimedOut` state.
+    pub fn queried(
+        mut self,
+        max_queries: Queries,
+        max_clones: Clones,
+        timestamp: T,
+    ) -> Either<Request<TimedOut, T>, Self>
+    where
+        S: TimeOut + QueryAttempt,
+    {
+        self.attempts.queries += 1;
+        self.timed_out(max_queries, max_clones, timestamp).flip()
+    }
+}
+
+impl<T> Request<Created, T> {
+    /// Create a fresh `Request` for the given `urn`.
+    ///
+    /// Once this request has been made, we can transition this `Request` to the
+    /// `Requested` state by calling [`Request::request`].
+    pub fn new(urn: Urn, timestamp: T) -> Self {
+        let urn = Urn { path: None, ..urn };
+        Self {
+            urn,
+            attempts: Attempts::new(),
+            timestamp,
+            state: Created {},
+        }
+    }
+
+    /// Transition the `Request` from the `Created` state to the `Requested`
+    /// state.
+    ///
+    /// This signifies that the `Request` has been queried and will be looking
+    /// for peers to fulfill the request.
+    ///
+    /// The number of queries is incremented by 1.
+    pub fn request(self, timestamp: T) -> Request<Requested, T> {
+        Request {
+            urn: self.urn,
+            attempts: Attempts {
+                queries: self.attempts.queries + 1,
+                ..self.attempts
+            },
+            timestamp,
+            state: Requested {
+                peers: HashMap::new(),
+            },
+        }
+    }
+}
+
+impl<T> Request<Requested, T> {
+    /// Transition the `Request` from the `Requested` state to the `Found`
+    /// state.
+    ///
+    /// This signifies that the `Request` found its first peer and will be ready
+    /// to attempt to clone from the peer.
+    pub fn into_found(self, peer: PeerId, timestamp: T) -> Request<Found, T> {
+        let mut peers = self.state.peers;
+        peers.entry(peer).or_insert(Status::Available);
+        Request {
+            urn: self.urn,
+            attempts: self.attempts,
+            timestamp,
+            state: Found { peers },
+        }
+    }
+}
+
+impl<T> Request<Found, T> {
+    /// Transition the `Request` from the `Found` state to the `Cloning` state.
+    ///
+    /// This signifies that the `Request` is attempting to clone from the
+    /// provided `peer`.
+    pub fn cloning(
+        self,
+        max_queries: Queries,
+        max_clones: Clones,
+        peer: PeerId,
+        timestamp: T,
+    ) -> Either<Request<TimedOut, T>, Request<Cloning, T>>
+    where
+        T: Clone,
+    {
+        let mut peers = self.state.peers;
+        peers
+            .entry(peer)
+            .and_modify(|status| *status = status.join(Status::InProgress))
+            .or_insert(Status::InProgress);
+        let this = Request {
+            urn: self.urn,
+            attempts: Attempts {
+                queries: self.attempts.queries,
+                clones: self.attempts.clones + 1,
+            },
+            timestamp: timestamp.clone(),
+            state: Cloning { peers },
+        };
+        this.timed_out(max_queries, max_clones, timestamp).flip()
+    }
+
+    /// Transition the `Request` from the `Found` back to the `Requested` state.
+    ///
+    /// This signifies that the `Request` has exhausted its list of peers to
+    /// attempt cloning from and needs to re-attempt the request for the
+    /// search.
+    ///
+    /// Should be used in tandem with [`HasPeers::all_failed`] to ensure that we
+    /// transition back when all peers have failed to clone.
+    pub fn failed(self) -> Either<Request<Requested, T>, Request<Found, T>> {
+        if self.state.all_failed() {
+            Either::Left(Request {
+                urn: self.urn,
+                attempts: self.attempts,
+                timestamp: self.timestamp,
+                state: Requested {
+                    peers: self.state.peers,
+                },
+            })
+        } else {
+            Either::Right(self)
+        }
+    }
+}
+
+impl<T> Request<Cloning, T> {
+    /// Transition from the `Cloning` state back to the `Found` state.
+    ///
+    /// This signifies that the `peer` failed to clone the identity and we mark
+    /// it as failed.
+    pub fn failed(
+        self,
+        peer: PeerId,
+        timestamp: T,
+    ) -> Either<Request<Requested, T>, Request<Found, T>> {
+        let mut peers = self.state.peers;
+        peers
+            .entry(peer)
+            .and_modify(|status| *status = status.join(Status::Failed))
+            .or_insert(Status::Failed);
+        Request {
+            urn: self.urn,
+            attempts: self.attempts,
+            timestamp,
+            state: Found { peers },
+        }
+        .failed()
+    }
+
+    /// Transition from the `Cloning` to the `Cloned` state.
+    ///
+    /// This signifies that the clone was successful and that the whole request
+    /// was successful, congratulations.
+    pub fn cloned(self, remote_peer: PeerId, timestamp: T) -> Request<Cloned, T> {
+        Request {
+            urn: self.urn.clone(),
+            attempts: self.attempts,
+            timestamp,
+            state: Cloned { remote_peer },
+        }
+    }
+}

--- a/patience/src/request/existential.rs
+++ b/patience/src/request/existential.rs
@@ -1,0 +1,221 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! The enumeration of different [`super::Request`] states unified under a
+//! single enum called [`SomeRequest`].
+
+use serde::{Deserialize, Serialize};
+
+use either::Either;
+use librad::git::Urn;
+
+use crate::{
+    request::{
+        states::{Cancelled, Cloned, Cloning, Created, Found, RequestState, Requested, TimedOut},
+        Request,
+    },
+    types::{Attempts, Clones, Queries},
+};
+
+/// Since a `Request` is parameterised over its state, it makes it difficult to
+/// talk about a `Request` in general without the compiler complaining at us.
+/// For example, we cannot have something like `vec![created, requested,
+/// cloning, timedout]` since they all have distinct types where they differ in
+/// states.
+///
+/// To allow us to do this we unify all the states into `SomeRequest` where each
+/// state is a variant in the enumeration.
+///
+/// When we pattern match we get back the request parameterised over the
+/// specific state and can work in a type safe manner with this request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    bound = "T: serde_millis::Milliseconds",
+    rename_all = "camelCase",
+    tag = "type"
+)]
+pub enum SomeRequest<T> {
+    /// The `Request` has been created.
+    Created(Request<Created, T>),
+
+    /// The `Request` has been requested.
+    Requested(Request<Requested, T>),
+
+    /// The `Request` has found a peer and is possibly searching for more.
+    Found(Request<Found, T>),
+
+    /// The `Request` is attempting to clone from a peer.
+    Cloning(Request<Cloning, T>),
+
+    /// The `Request` has successfully cloned from a peer.
+    Cloned(Request<Cloned, T>),
+
+    /// The `Request` has been cancelled.
+    Cancelled(Request<Cancelled, T>),
+
+    /// The `Request` has timed out on querying or cloning.
+    TimedOut(Request<TimedOut, T>),
+}
+
+impl<T> From<&SomeRequest<T>> for RequestState {
+    fn from(other: &SomeRequest<T>) -> RequestState {
+        match other {
+            SomeRequest::Created(_) => Self::Created,
+            SomeRequest::Requested(_) => Self::Requested,
+            SomeRequest::Found(_) => Self::Found,
+            SomeRequest::Cloning(_) => Self::Cloning,
+            SomeRequest::Cloned(_) => Self::Cloned,
+            SomeRequest::Cancelled(_) => Self::Cancelled,
+            SomeRequest::TimedOut(_) => Self::TimedOut,
+        }
+    }
+}
+
+impl<T> From<Request<Created, T>> for SomeRequest<T> {
+    fn from(request: Request<Created, T>) -> Self {
+        Self::Created(request)
+    }
+}
+
+impl<T> From<Request<Requested, T>> for SomeRequest<T> {
+    fn from(request: Request<Requested, T>) -> Self {
+        Self::Requested(request)
+    }
+}
+
+impl<T> From<Request<Found, T>> for SomeRequest<T> {
+    fn from(request: Request<Found, T>) -> Self {
+        Self::Found(request)
+    }
+}
+
+impl<T> From<Request<Cloning, T>> for SomeRequest<T> {
+    fn from(request: Request<Cloning, T>) -> Self {
+        Self::Cloning(request)
+    }
+}
+
+impl<T> From<Request<Cloned, T>> for SomeRequest<T> {
+    fn from(request: Request<Cloned, T>) -> Self {
+        Self::Cloned(request)
+    }
+}
+
+impl<T> From<Request<Cancelled, T>> for SomeRequest<T> {
+    fn from(request: Request<Cancelled, T>) -> Self {
+        Self::Cancelled(request)
+    }
+}
+
+impl<T> From<Request<TimedOut, T>> for SomeRequest<T> {
+    fn from(request: Request<TimedOut, T>) -> Self {
+        Self::TimedOut(request)
+    }
+}
+
+impl<T, L: Into<SomeRequest<T>>, R: Into<SomeRequest<T>>> From<Either<L, R>> for SomeRequest<T> {
+    fn from(other: Either<L, R>) -> Self {
+        other.either(L::into, R::into)
+    }
+}
+
+impl<T> SomeRequest<T> {
+    /// Get the `Urn` of whatever kind of [`Request`] is below.
+    pub const fn urn(&self) -> &Urn {
+        match self {
+            SomeRequest::Created(request) => request.urn(),
+            SomeRequest::Requested(request) => request.urn(),
+            SomeRequest::Found(request) => request.urn(),
+            SomeRequest::Cloning(request) => request.urn(),
+            SomeRequest::Cloned(request) => request.urn(),
+            SomeRequest::Cancelled(request) => request.urn(),
+            SomeRequest::TimedOut(request) => request.urn(),
+        }
+    }
+
+    /// Get the [`Attempts`] of whatever kind of [`Request`] is below.
+    pub const fn attempts(&self) -> &Attempts {
+        match self {
+            SomeRequest::Created(request) => &request.attempts,
+            SomeRequest::Requested(request) => &request.attempts,
+            SomeRequest::Found(request) => &request.attempts,
+            SomeRequest::Cloning(request) => &request.attempts,
+            SomeRequest::Cloned(request) => &request.attempts,
+            SomeRequest::Cancelled(request) => &request.attempts,
+            SomeRequest::TimedOut(request) => &request.attempts,
+        }
+    }
+
+    /// Get the current timestamp of the underlying `Request`.
+    pub const fn timestamp(&self) -> &T {
+        match self {
+            SomeRequest::Created(request) => request.timestamp(),
+            SomeRequest::Requested(request) => request.timestamp(),
+            SomeRequest::Found(request) => request.timestamp(),
+            SomeRequest::Cloning(request) => request.timestamp(),
+            SomeRequest::Cloned(request) => request.timestamp(),
+            SomeRequest::Cancelled(request) => request.timestamp(),
+            SomeRequest::TimedOut(request) => request.timestamp(),
+        }
+    }
+
+    /// We can cancel an underlying `Request` if it is allowed to be cancelled.
+    /// In the case that it is allowed, then we get back the cancelled
+    /// request in the `Right` variant. Otherwise we get back our original
+    /// `SomeRequest` in the `Left` variant.
+    pub fn cancel(self, timestamp: T) -> Either<SomeRequest<T>, Request<Cancelled, T>> {
+        match self {
+            SomeRequest::Created(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Requested(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Found(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Cloning(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Cancelled(request) => Either::Right(request.cancel(timestamp)),
+            request => Either::Left(request),
+        }
+    }
+
+    /// We can see if our underlying `Request` timed out if it is in a state
+    /// where a time out can occur. In the case that it can time out, then
+    /// we get back the timed out request in the `Right` variant. Otherwise
+    /// we get back our original `SomeRequest` in the `Left` variant.
+    pub fn timed_out(
+        self,
+        max_queries: Queries,
+        max_clones: Clones,
+        timestamp: T,
+    ) -> Either<SomeRequest<T>, Request<TimedOut, T>> {
+        match self {
+            SomeRequest::Requested(request) => request
+                .timed_out(max_queries, max_clones, timestamp)
+                .map_left(SomeRequest::Requested),
+            SomeRequest::Found(request) => request
+                .timed_out(max_queries, max_clones, timestamp)
+                .map_left(SomeRequest::Found),
+            SomeRequest::Cloning(request) => request
+                .timed_out(max_queries, max_clones, timestamp)
+                .map_left(SomeRequest::Cloning),
+            request => Either::Left(request),
+        }
+    }
+
+    /// If we have some way of picking a specific `Request` from `SomeRequest`
+    /// and a function that transitions that `Request` into a next state
+    /// then we follow that transition.
+    ///
+    /// If not we leave the `SomeRequest` as is.
+    pub fn transition<Prev, Next>(
+        self,
+        matcher: impl FnOnce(SomeRequest<T>) -> Option<Prev>,
+        transition: impl FnOnce(Prev) -> Next,
+    ) -> Either<SomeRequest<T>, Next>
+    where
+        T: Clone,
+    {
+        match matcher(self.clone()) {
+            Some(previous) => Either::Right(transition(previous)),
+            None => Either::Left(self),
+        }
+    }
+}

--- a/patience/src/request/states.rs
+++ b/patience/src/request/states.rs
@@ -1,0 +1,270 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! The state types and traits that we can use for [`super::Request`]'s `S`
+//! parameter.
+
+use std::{collections::HashMap, fmt, ops::Deref};
+
+use serde::{Deserialize, Serialize};
+
+use librad::peer::PeerId;
+
+use crate::sealed;
+
+impl sealed::Sealed for Created {}
+impl sealed::Sealed for Requested {}
+impl sealed::Sealed for Found {}
+impl sealed::Sealed for Cloning {}
+impl sealed::Sealed for Cancelled {}
+
+// State Types
+
+/// An enumeration of the different states a `Request` can be in. This is useful
+/// if we want to convey the state information without any of the other state
+/// data.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum RequestState {
+    /// The initial state where the `Request` has been created.
+    Created,
+
+    /// The state where the `Request` has been requested.
+    Requested,
+
+    /// The state where the `Request` has found at least one peer.
+    Found,
+
+    /// The state where the `Request` is cloning from a peer.
+    Cloning,
+
+    /// The state where the `Request` has successfully cloned from a peer.
+    Cloned,
+
+    /// The state where the `Request` has been cancelled.
+    Cancelled,
+
+    /// The state where the `Request` has timed out.
+    TimedOut,
+}
+
+impl fmt::Display for RequestState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// The initial state for a `Request`. It has simply been created.
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Created {}
+
+/// The state signifying that the `Request` has been kicked-off.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Requested {
+    /// A set of found peers and the lifecycle of clone attempts made on those
+    /// peers.
+    pub(super) peers: HashMap<PeerId, Status>,
+}
+
+/// `Status` represents the lifecycle of some action on data. The data could be
+/// available to take the action on, the action could be in progress, or it
+/// could have failed.
+///
+/// Note that the related data isn't in the `Status` variants. The status is
+/// free to be associated with any external data, e.g. using it as a value in a
+/// `HashMap`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Status {
+    /// The status of the related data is: ready to go!
+    Available,
+    /// The status of the related data is: in progress!
+    InProgress,
+    /// The status of the related data is: failed :(
+    Failed,
+}
+
+impl Status {
+    /// Joining two `Status` favours `Failed` over any other `Status`, then
+    /// `InProgress`, and finally `Available`.
+    ///
+    /// This translates to the fact that if something has `Failed` then that's
+    /// it, there's no going back.
+    /// If it's `InProgress`, it doesn't matter that the other `Status` is
+    /// saying its `Available`, because you know what? It's actually in
+    /// progress. And finally, the last case is that both `Status`es agree
+    /// the `Status` is `Available`.
+    #[must_use]
+    pub const fn join(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Failed, _) | (_, Self::Failed) => Self::Failed,
+            (Self::InProgress, _) | (_, Self::InProgress) => Self::InProgress,
+            (Self::Available, Self::Available) => Self::Available,
+        }
+    }
+}
+
+/// The `Found` state means that we have found at least one peer and can
+/// possibly find more.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Found {
+    /// A set of found peers and the lifecycle of clone attempts made on those
+    /// peers.
+    pub(crate) peers: HashMap<PeerId, Status>,
+}
+
+impl Deref for Found {
+    type Target = HashMap<PeerId, Status>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.peers
+    }
+}
+
+/// The `Cloning` state means that we have found at least one peer and we are
+/// attempting a clone on one of them.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cloning {
+    /// A set of found peers and the lifecycle of clone attempts made on those
+    /// peers.
+    pub(crate) peers: HashMap<PeerId, Status>,
+}
+
+impl Deref for Cloning {
+    type Target = HashMap<PeerId, Status>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.peers
+    }
+}
+
+/// The `Cloned` state means that we have successfully cloned the desired
+/// identity.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cloned {
+    /// The identity that we were attempting to find and the peer that we found
+    /// it from.
+    pub(crate) remote_peer: PeerId,
+}
+/// One of the terminal states for a `Request` where the task has been
+/// cancelled.
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cancelled {}
+
+/// One of the terminal states for a `Request` where the task made too many
+/// attempts.
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TimedOut {
+    /// The `Request` made too many query attempts.
+    Query,
+    /// The `Request` made too many clone attempts.
+    Clone,
+}
+
+impl fmt::Display for TimedOut {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Query => write!(f, "query"),
+            Self::Clone => write!(f, "clone"),
+        }
+    }
+}
+
+// State Traits
+
+/// If a state type implements this trait then it means that the type is allowed
+/// to increment the query attempts in a `Request`.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait QueryAttempt: sealed::Sealed {}
+impl QueryAttempt for Requested {}
+
+/// If a state type implements this trait then it means that the type holds a
+/// `HashMap` of peers and their status of cloning.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait HasPeers: sealed::Sealed
+where
+    Self: Sized + Deref<Target = HashMap<PeerId, Status>>,
+{
+    /// Give back the underlying `HashMap` of peers that is contained in `Self`.
+    fn peers(&mut self) -> &mut HashMap<PeerId, Status>;
+
+    /// Returns `false` if the `peers` are empty or if any of them are
+    /// `Status::Available` or `Status::InProgress`.
+    ///
+    /// Otherwise, if all are in the `Status::Failed` state, then we return
+    /// `true`.
+    fn all_failed(&self) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+
+        self.iter().all(|(_, status)| *status == Status::Failed)
+    }
+}
+
+impl HasPeers for Found {
+    fn peers(&mut self) -> &mut HashMap<PeerId, Status> {
+        &mut self.peers
+    }
+}
+
+impl HasPeers for Cloning {
+    fn peers(&mut self) -> &mut HashMap<PeerId, Status> {
+        &mut self.peers
+    }
+}
+
+/// If a state type implements this trait it means that there is a valid
+/// transition from that state to the `Cancelled` state.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait Cancel: sealed::Sealed
+where
+    Self: Sized,
+{
+    /// Transition the state into `Cancelled`. This ignores whatever state we
+    /// were in and defaults by returning the `Cancelled` state.
+    fn cancel(self) -> Cancelled {
+        Cancelled {}
+    }
+}
+
+impl Cancel for Created {}
+impl Cancel for Requested {}
+impl Cancel for Found {}
+impl Cancel for Cloning {}
+impl Cancel for Cancelled {}
+
+/// If a state type implements this trait it means that there is a valid
+/// transition from that state to the `TimedOut` state.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait TimeOut: sealed::Sealed
+where
+    Self: Sized,
+{
+    /// Transition the state into `TimedOut`. This ignores whatever state we
+    /// were in and defaults by returning the `TimedOut` state by returning
+    /// the `kind` of timeout.
+    fn time_out(self, kind: TimedOut) -> TimedOut {
+        kind
+    }
+}
+
+impl TimeOut for Requested {}
+impl TimeOut for Found {}
+impl TimeOut for Cloning {}

--- a/patience/src/sealed.rs
+++ b/patience/src/sealed.rs
@@ -1,0 +1,7 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+/// A private trait to seal away traits that we use in `states`.
+pub trait Sealed {}

--- a/patience/src/types.rs
+++ b/patience/src/types.rs
@@ -1,0 +1,146 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::ops::{Add, AddAssign};
+
+use serde::{Deserialize, Serialize};
+
+use super::sealed;
+
+/// `Queries` is a wrapper around `usize` so that we can differentiate it from
+/// [`Clones`].
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Queries {
+    /// The max number of queries allowed per request.
+    Max(usize),
+    /// The max number is infinite, and so we allow the request to never time
+    /// out.
+    Infinite,
+}
+
+impl Queries {
+    /// Create a new `Queries` wrapping around `n`.
+    #[must_use]
+    pub const fn new(n: usize) -> Self {
+        Self::Max(n)
+    }
+}
+
+impl From<Queries> for Option<usize> {
+    fn from(other: Queries) -> Self {
+        match other {
+            Queries::Max(i) => Some(i),
+            Queries::Infinite => None,
+        }
+    }
+}
+
+impl Add<usize> for Queries {
+    type Output = Self;
+
+    fn add(self, other: usize) -> Self::Output {
+        match self {
+            Self::Max(i) => Self::Max(i + other),
+            Self::Infinite => Self::Infinite,
+        }
+    }
+}
+
+impl AddAssign<usize> for Queries {
+    fn add_assign(&mut self, other: usize) {
+        match self {
+            Self::Max(i) => *i += other,
+            Self::Infinite => {},
+        }
+    }
+}
+
+/// `Clones` is a wrapper around `usize` so that we can differentiate it from
+/// [`Queries`].
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Clones {
+    /// The max number of clones allowed per request.
+    Max(usize),
+    /// The max number is infinite, and so we allow the request to never time
+    /// out.
+    Infinite,
+}
+
+impl Clones {
+    /// Create a new `Clones` wrapping around `n`.
+    #[must_use]
+    pub const fn new(n: usize) -> Self {
+        Self::Max(n)
+    }
+}
+
+impl From<Clones> for Option<usize> {
+    fn from(other: Clones) -> Self {
+        match other {
+            Clones::Max(i) => Some(i),
+            Clones::Infinite => None,
+        }
+    }
+}
+
+impl Add<usize> for Clones {
+    type Output = Self;
+
+    fn add(self, other: usize) -> Self::Output {
+        match self {
+            Self::Max(i) => Self::Max(i + other),
+            Self::Infinite => Self::Infinite,
+        }
+    }
+}
+
+impl AddAssign<usize> for Clones {
+    fn add_assign(&mut self, other: usize) {
+        match self {
+            Self::Max(i) => *i += other,
+            Self::Infinite => {},
+        }
+    }
+}
+
+/// The number of different attempts a `Request` has made during its lifetime.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Attempts {
+    /// The number of query attempts we have made.
+    pub(super) queries: Queries,
+    /// The number of clone attempts we have made.
+    pub(super) clones: Clones,
+}
+
+impl Attempts {
+    /// Get a new `Attempts` where the number of queires and clones is initially
+    /// `0`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Attempts {
+            queries: Queries::Max(0),
+            clones: Clones::Max(0),
+        }
+    }
+
+    /// Construct an `Attempts` where the number of queries and clones is
+    /// `Infinite`.
+    #[must_use]
+    pub const fn infinite() -> Self {
+        Attempts {
+            queries: Queries::Infinite,
+            clones: Clones::Infinite,
+        }
+    }
+}
+
+impl Default for Attempts {
+    fn default() -> Self {
+        Attempts::new()
+    }
+}
+
+impl sealed::Sealed for Attempts {}

--- a/patience/src/waiting_room.rs
+++ b/patience/src/waiting_room.rs
@@ -1,0 +1,823 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! The `WaitingRoom` is the in-memory container for keeping track of
+//! `Request`s. It can be serialized and deserialized for persistence purposes.
+
+use std::{
+    cmp::PartialOrd,
+    collections::HashMap,
+    convert::TryFrom,
+    ops::{Add, Mul},
+};
+
+use either::Either;
+use serde::{Deserialize, Serialize};
+
+use librad::{git::identities::Revision, identities::Urn, peer::PeerId};
+
+use crate::{
+    request::{
+        states::{RequestState, Status, TimedOut},
+        Request,
+        SomeRequest,
+    },
+    types::{Clones, Queries},
+};
+
+/// The maximum number of query attempts that can be made for a single request.
+const MAX_QUERIES: Queries = Queries::Infinite;
+
+/// The maximum number of clone attempts that can be made for a single request.
+const MAX_CLONES: Clones = Clones::Infinite;
+
+/// An error that can occur when interacting with the [`WaitingRoom`] API.
+#[derive(Clone, Debug, thiserror::Error, PartialEq)]
+pub enum Error {
+    /// When looking up a `RadUrn` in the [`WaitingRoom`] it was missing.
+    #[error("the URN '{0}' was not found in the waiting room")]
+    MissingUrn(Urn),
+
+    /// When performing an operation on the a [`Request`] in the [`WaitingRoom`]
+    /// it was found to be in the wrong state for the desired operation.
+    ///
+    /// For example, if we tried to call `cloning` on a request that has only
+    /// been created then this would be an invalid transition.
+    #[error("the state fetched '{0}' from the waiting room was not one of the expected states")]
+    StateMismatch(RequestState),
+
+    /// The [`Request`] timed out when performing an operation on it by
+    /// exceeding the number of attempts it was allowed to make.
+    #[error("encountered {timeout} time out after {attempts:?} attempts")]
+    TimeOut {
+        /// What kind of the time out that occurred.
+        timeout: TimedOut,
+        /// The number of attempts that were made when we timed out.
+        attempts: Option<usize>,
+    },
+}
+
+impl<T> From<Request<TimedOut, T>> for Error {
+    fn from(other: Request<TimedOut, T>) -> Self {
+        match &other.state {
+            TimedOut::Query => Error::TimeOut {
+                timeout: other.state,
+                attempts: other.attempts.queries.into(),
+            },
+            TimedOut::Clone => Error::TimeOut {
+                timeout: other.state,
+                attempts: other.attempts.clones.into(),
+            },
+        }
+    }
+}
+
+/// Holds either the newly created request or the request already present for
+/// the requested urn.
+pub type Created<T> = Either<SomeRequest<T>, SomeRequest<T>>;
+
+/// A `WaitingRoom` knows about a set of `Request`s that have been made, and can
+/// look them up via their `RadUrn`.
+///
+/// It keeps track of these states as the user tells the waiting room what is
+/// happening to the request on the outside.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WaitingRoom<T, D> {
+    /// The set of requests keyed by their `RadUrn`. This helps us keep only
+    /// unique requests in the waiting room.
+    #[serde(bound = "T: serde_millis::Milliseconds")]
+    requests: HashMap<Revision, SomeRequest<T>>,
+
+    /// The configuration of the waiting room.
+    config: Config<D>,
+}
+
+/// The `Config` for the waiting room tells it what are the maximum number of
+/// query and clone attempts that can be made for a single request.
+///
+/// The recommended approach to initialising the `Config` is to use its
+/// `Default` implementation, i.e. `Config::default()`, followed by setting the
+/// `delta`, since the usual default values for number values are `0`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Config<D> {
+    /// The maximum number of query attempts that can be made.
+    pub max_queries: Queries,
+    /// The maximum number of clone attempts that can be made.
+    pub max_clones: Clones,
+    /// The minimum elapsed time between some provided time and a request's
+    /// timestamp. For example, if we had the following setup:
+    ///   * `delta = 1`
+    ///   * `now = 3`
+    ///   * `request.timestamp = 2`
+    /// then the `delta` would be compared against `now - request.timestamp`.
+    pub delta: D,
+}
+
+impl<D> Default for Config<D>
+where
+    D: Default,
+{
+    fn default() -> Self {
+        Self {
+            max_queries: MAX_QUERIES,
+            max_clones: MAX_CLONES,
+            delta: D::default(),
+        }
+    }
+}
+
+impl<T, D> WaitingRoom<T, D> {
+    /// Initialise a new `WaitingRoom` with the supplied `config`.
+    #[must_use]
+    pub fn new(config: Config<D>) -> Self {
+        Self {
+            requests: HashMap::new(),
+            config,
+        }
+    }
+
+    /// Check that the `WaitingRoom` has the given `urn`.
+    pub fn has(&self, urn: &Urn) -> bool {
+        self.requests.contains_key(&urn.id)
+    }
+
+    /// Get the underlying [`SomeRequest`] for the given `urn`.
+    ///
+    /// Returns `None` if there is no such request.
+    #[must_use]
+    pub fn get(&self, urn: &Urn) -> Option<&SomeRequest<T>> {
+        self.requests.get(&urn.id)
+    }
+
+    /// Permanently remove a request from the `WaitingRoom`. If the `urn` did
+    /// exist in the `WaitingRoom` then the request will be returned.
+    ///
+    /// Otherwise, it will return `None` if no such request existed.
+    pub fn remove(&mut self, urn: &Urn) -> Option<SomeRequest<T>> {
+        self.requests.remove(&urn.id)
+    }
+
+    /// This will return the request for the given `urn` if one exists in the
+    /// `WaitingRoom`.
+    ///
+    /// If there is no such `urn` then it create a fresh `Request` using the
+    /// `urn` and `timestamp` and it will return `None`.
+    pub fn request(&mut self, urn: &Urn, timestamp: T) -> Either<SomeRequest<T>, SomeRequest<T>>
+    where
+        T: Clone,
+    {
+        match self.get(urn) {
+            None => {
+                let request = SomeRequest::Created(Request::new(urn.clone(), timestamp));
+                self.requests.insert(urn.id, request.clone());
+                Either::Left(request)
+            },
+            Some(request) => Either::Right(request.clone()),
+        }
+    }
+
+    /// Transition the `Request` found at the provided `urn` and call the
+    /// transition function to move it into its `Next` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    ///   * If the transition function supplied returns an error.
+    fn transition<Prev, Next>(
+        &mut self,
+        matcher: impl FnOnce(SomeRequest<T>) -> Option<Prev>,
+        transition: impl FnOnce(Prev) -> Either<Request<TimedOut, T>, Next>,
+        urn: &Urn,
+    ) -> Result<(), Error>
+    where
+        T: Clone,
+        Prev: Clone,
+        Next: Into<SomeRequest<T>> + Clone,
+    {
+        match self.get(urn) {
+            None => Err(Error::MissingUrn(urn.clone())),
+            Some(request) => match request.clone().transition(matcher, transition) {
+                Either::Right(Either::Right(next)) => {
+                    self.requests.insert(urn.id, next.into());
+                    Ok(())
+                },
+                Either::Right(Either::Left(timeout)) => {
+                    self.requests.insert(urn.id, timeout.clone().into());
+                    Err(timeout.into())
+                },
+                Either::Left(mismatch) => Err(Error::StateMismatch((&mismatch).into())),
+            },
+        }
+    }
+
+    /// Tell the `WaitingRoom` that a query was made for the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `Created` state then it will
+    /// transition to the `IsRequested` state.
+    ///
+    /// If the underlying `Request` was in the `IsRequested` state then it
+    /// increments the query attempt.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    ///   * If the underlying `Request` timed out.
+    pub fn queried(&mut self, urn: &Urn, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        let max_queries = self.config.max_queries;
+        let max_clones = self.config.max_clones;
+        self.transition(
+            |request| match request {
+                SomeRequest::Created(request) => Some(Either::Right(request.request(timestamp))),
+                SomeRequest::Requested(request) => {
+                    Some(request.queried(max_queries, max_clones, timestamp))
+                },
+                _ => None,
+            },
+            |previous| previous,
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that a `peer` was found for the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `IsRequested` state then it will
+    /// transition to the `Found` state.
+    ///
+    /// If the underlying `Request` was in the `Found` or `Cloning` state then
+    /// it add this `peer` to the set of found peers.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    pub fn found(&mut self, urn: &Urn, remote_peer: PeerId, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        self.transition(
+            |request| match request {
+                SomeRequest::Requested(request) => {
+                    Some(request.into_found(remote_peer, timestamp).into())
+                },
+                SomeRequest::Found(request) => {
+                    let some_request: SomeRequest<T> = request.found(remote_peer, timestamp).into();
+                    Some(some_request)
+                },
+                SomeRequest::Cloning(request) => {
+                    let some_request: SomeRequest<T> = request.found(remote_peer, timestamp).into();
+                    Some(some_request)
+                },
+                _ => None,
+            },
+            Either::Right,
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that we are attempting a clone from the `peer`
+    /// for the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `Found` state then it will
+    /// transition to the `Cloning` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    ///   * If the underlying `Request` timed out.
+    pub fn cloning(&mut self, urn: &Urn, remote_peer: PeerId, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        let max_queries = self.config.max_queries;
+        let max_clones = self.config.max_clones;
+        self.transition(
+            |request| match request {
+                SomeRequest::Found(request) => Some(request),
+                _ => None,
+            },
+            |previous| previous.cloning(max_queries, max_clones, remote_peer, timestamp),
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that we failed the attempt to clone from the
+    /// `peer` for the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `Cloning` state then it will
+    /// transition to the `Found` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    pub fn cloning_failed(
+        &mut self,
+        urn: &Urn,
+        remote_peer: PeerId,
+        timestamp: T,
+    ) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        self.transition(
+            |request| match request {
+                SomeRequest::Cloning(request) => Some(request),
+                _ => None,
+            },
+            |previous| Either::Right(previous.failed(remote_peer, timestamp)),
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that we successfully cloned the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `Cloning` state then it will
+    /// transition to the `Cloned` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    pub fn cloned(&mut self, urn: &Urn, remote_peer: PeerId, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        self.transition(
+            |request| match request {
+                SomeRequest::Cloning(request) => Some(request),
+                _ => None,
+            },
+            |previous| Either::Right(previous.cloned(remote_peer, timestamp)),
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that we are cancelling the request for the given
+    /// `urn`.
+    ///
+    /// If the underlying `Request` was in the `{Created, IsRequested, Found,
+    /// Cloning, Cancelled}` state then it will transition to the
+    /// `Cancelled` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    pub fn canceled(&mut self, urn: &Urn, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        self.transition(
+            |request| request.cancel(timestamp).right(),
+            Either::Right,
+            urn,
+        )
+    }
+
+    /// Return the list of all `RadUrn`/`SomeRequest` pairs in the
+    /// `WaitingRoom`.
+    pub fn iter(&self) -> impl Iterator<Item = (Urn, &SomeRequest<T>)> {
+        self.requests
+            .iter()
+            .map(|(id, request)| (Urn::new(*id), request))
+    }
+
+    /// Filter the `WaitingRoom` by:
+    ///   * Choosing which [`RequestState`] you are looking for
+    pub fn filter_by_state(
+        &self,
+        request_state: RequestState,
+    ) -> impl Iterator<Item = (Urn, &SomeRequest<T>)> {
+        self.iter()
+            .filter(move |(_, request)| RequestState::from(*request) == request_state.clone())
+    }
+
+    /// Find the first occurring request based on the call to
+    /// [`WaitingRoom::filter_by_state`].
+    pub fn find_by_state(&self, request_state: RequestState) -> Option<(Urn, &SomeRequest<T>)> {
+        self.filter_by_state(request_state).next()
+    }
+
+    /// Get the next `Request` that is in a query state, i.e. `Created` or
+    /// `Requested`.
+    ///
+    /// In the case of the `Requested` state we check if:
+    ///   * The request is a fresh request that hasn't had an attempt to clone
+    ///     yet
+    ///   * Or the elapsed time between the `timestamp` and the `Request`'s
+    ///     timestamp is greater than the `delta` provided in the [`Config`].
+    pub fn next_query(&self, timestamp: T) -> Option<Urn>
+    where
+        T: Add<D, Output = T> + PartialOrd + Clone,
+        D: Mul<u32, Output = D> + Ord + Clone,
+    {
+        let backoff = |tries: Queries| match tries {
+            Queries::Max(i) => self.config.delta.clone() * u32::try_from(i).unwrap_or(u32::MAX),
+            Queries::Infinite => self.config.delta.clone(),
+        };
+        let created = self.find_by_state(RequestState::Created);
+        let requested = self
+            .filter_by_state(RequestState::Requested)
+            .find(move |(_, request)| {
+                request.timestamp().clone() + backoff(request.attempts().queries) <= timestamp
+            });
+
+        created.or(requested).map(|(urn, _request)| urn)
+    }
+
+    /// Get the next `Request` that is in the the `Found` state and the status
+    /// of the peer is `Available`.
+    pub fn next_clone(&self) -> Option<(Urn, PeerId)> {
+        self.find_by_state(RequestState::Found)
+            .and_then(|(urn, request)| match request {
+                SomeRequest::Found(request) => {
+                    request.iter().find_map(|(peer_id, status)| match status {
+                        Status::Available => Some((urn.clone(), *peer_id)),
+                        _ => None,
+                    })
+                },
+                _ => None,
+            })
+    }
+
+    #[cfg(test)]
+    pub fn insert<R>(&mut self, urn: &Urn, request: R)
+    where
+        R: Into<SomeRequest<T>>,
+    {
+        self.requests.insert(urn.id, request.into());
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{error, str::FromStr};
+
+    use assert_matches::assert_matches;
+    use librad::{git_ext::Oid, identities::Urn, keys::SecretKey, peer::PeerId};
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn happy_path_of_full_request() -> Result<(), Box<dyn error::Error + 'static>> {
+        let mut waiting_room: WaitingRoom<usize, usize> = WaitingRoom::new(Config::default());
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let remote_peer = PeerId::from(SecretKey::new());
+        let have = waiting_room.request(&urn, 0);
+        let want = waiting_room.get(&urn).unwrap();
+
+        assert_eq!(have, Either::Left(want.clone()));
+
+        let created = waiting_room.find_by_state(RequestState::Created);
+        assert_eq!(
+            created,
+            Some((
+                urn.clone(),
+                &SomeRequest::Created(Request::new(urn.clone(), 0))
+            )),
+        );
+
+        waiting_room.queried(&urn, 0)?;
+        let expected = SomeRequest::Requested(Request::new(urn.clone(), 0).request(0));
+        assert_eq!(waiting_room.get(&urn), Some(&expected));
+
+        waiting_room.found(&urn, remote_peer, 0)?;
+        let expected = SomeRequest::Found(
+            Request::new(urn.clone(), 0)
+                .request(0)
+                .into_found(remote_peer, 0),
+        );
+        assert_eq!(waiting_room.get(&urn), Some(&expected));
+
+        waiting_room.cloning(&urn, remote_peer, 0)?;
+        let expected = SomeRequest::Cloning(
+            Request::new(urn.clone(), 0)
+                .request(0)
+                .into_found(remote_peer, 0)
+                .cloning(MAX_QUERIES, MAX_CLONES, remote_peer, 0)
+                .unwrap_right(),
+        );
+        assert_eq!(waiting_room.get(&urn), Some(&expected));
+
+        waiting_room.cloned(&urn, remote_peer, 0)?;
+        let expected = SomeRequest::Cloned(
+            Request::new(urn.clone(), 0)
+                .request(0)
+                .into_found(remote_peer, 0)
+                .cloning(MAX_QUERIES, MAX_CLONES, remote_peer, 0)
+                .unwrap_right()
+                .cloned(remote_peer, 0),
+        );
+        assert_eq!(waiting_room.get(&urn), Some(&expected));
+
+        Ok(())
+    }
+
+    #[test]
+    fn cannot_create_twice() -> Result<(), Box<dyn error::Error>> {
+        let mut waiting_room: WaitingRoom<(), ()> = WaitingRoom::new(Config::default());
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        waiting_room.request(&urn, ());
+        let request = waiting_room.request(&urn, ());
+
+        assert_eq!(
+            request,
+            Either::Right(SomeRequest::Created(Request::new(urn.clone(), ())))
+        );
+
+        waiting_room.queried(&urn, ())?;
+        let request = waiting_room.request(&urn, ());
+
+        assert_eq!(
+            request,
+            Either::Right(SomeRequest::Requested(Request::new(urn, ()).request(())))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn timeout_on_delta() -> Result<(), Box<dyn std::error::Error>> {
+        let mut waiting_room: WaitingRoom<u32, u32> = WaitingRoom::new(Config {
+            delta: 5,
+            ..Config::default()
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let _ = waiting_room.request(&urn, 0);
+
+        // Initial schedule to be querying after it has been requested.
+        let request = waiting_room.next_query(1);
+        assert_eq!(request, Some(urn.clone()));
+
+        waiting_room.queried(&urn, 2)?;
+
+        // Should not return the urn again before delta has elapsed.
+        let request = waiting_room.next_query(3);
+        assert_eq!(request, None);
+
+        // Should return the urn again after delta has elapsed.
+        let request = waiting_room.next_query(7);
+        assert_eq!(request, Some(urn));
+
+        Ok(())
+    }
+
+    #[test]
+    fn timeout_on_requests() -> Result<(), Box<dyn error::Error + 'static>> {
+        const NUM_QUERIES: usize = 16;
+        let mut waiting_room: WaitingRoom<(), ()> = WaitingRoom::new(Config {
+            max_queries: Queries::new(NUM_QUERIES),
+            max_clones: Clones::new(0),
+            delta: (),
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+
+        let _ = waiting_room.request(&urn, ());
+        for _ in 0..NUM_QUERIES {
+            waiting_room.queried(&urn, ())?;
+        }
+
+        assert_eq!(
+            waiting_room.queried(&urn, ()),
+            Err(Error::TimeOut {
+                timeout: TimedOut::Query,
+                attempts: Some(17),
+            })
+        );
+
+        assert_matches!(waiting_room.get(&urn), Some(SomeRequest::TimedOut(_)));
+
+        Ok(())
+    }
+
+    #[allow(clippy::indexing_slicing)]
+    #[test]
+    fn timeout_on_clones() -> Result<(), Box<dyn error::Error + 'static>> {
+        const NUM_CLONES: usize = 16;
+        let mut waiting_room: WaitingRoom<(), ()> = WaitingRoom::new(Config {
+            max_queries: Queries::new(1),
+            max_clones: Clones::new(NUM_CLONES),
+            delta: (),
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+
+        let mut peers = vec![];
+        for _ in 0..=NUM_CLONES {
+            peers.push(PeerId::from(SecretKey::new()));
+        }
+
+        let _ = waiting_room.request(&urn, ());
+        waiting_room.queried(&urn, ())?;
+
+        for remote_peer in &peers {
+            waiting_room.found(&urn, *remote_peer, ())?;
+        }
+
+        for remote_peer in &peers[0..NUM_CLONES] {
+            waiting_room.cloning(&urn, *remote_peer, ())?;
+            waiting_room.cloning_failed(&urn, *remote_peer, ())?;
+        }
+
+        assert_eq!(
+            waiting_room.cloning(
+                &urn,
+                *peers
+                    .last()
+                    .expect("unless you changed NUM_CLONES to < -1 we should be fine here. qed."),
+                ()
+            ),
+            Err(Error::TimeOut {
+                timeout: TimedOut::Clone,
+                attempts: Some(17),
+            })
+        );
+
+        assert_matches!(waiting_room.get(&urn), Some(SomeRequest::TimedOut(_)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn cloning_fails_back_to_requested() -> Result<(), Box<dyn error::Error + 'static>> {
+        const NUM_CLONES: usize = 5;
+        let mut waiting_room: WaitingRoom<u32, u32> = WaitingRoom::new(Config {
+            max_queries: Queries::new(1),
+            max_clones: Clones::new(NUM_CLONES),
+            delta: 5,
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+
+        let mut peers = vec![];
+        for _ in 0..NUM_CLONES {
+            peers.push(PeerId::from(SecretKey::new()));
+        }
+
+        let _ = waiting_room.request(&urn, 0);
+        waiting_room.queried(&urn, 1)?;
+
+        for remote_peer in peers {
+            waiting_room.found(&urn, remote_peer, 2)?;
+            waiting_room.cloning(&urn, remote_peer, 2)?;
+            waiting_room.cloning_failed(&urn, remote_peer, 2)?;
+        }
+
+        assert_matches!(waiting_room.get(&urn), Some(SomeRequest::Requested(_)));
+
+        let request = waiting_room.next_query(3);
+        assert_eq!(request, None);
+
+        let request = waiting_room.next_query(7);
+        assert_eq!(request, Some(urn));
+
+        Ok(())
+    }
+
+    #[test]
+    fn cancel_transitions() -> Result<(), Box<dyn error::Error + 'static>> {
+        let config = Config::default();
+        let mut waiting_room: WaitingRoom<(), ()> = WaitingRoom::new(config);
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let peer = PeerId::from(SecretKey::new());
+
+        // created
+        let _ = waiting_room.request(&urn, ());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(
+                Request::new(urn.clone(), ()).cancel(())
+            ))
+        );
+
+        // requested
+        let is_requested = Request::new(urn.clone(), ()).request(());
+        waiting_room.insert(&urn, is_requested.clone());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(is_requested.clone().cancel(())))
+        );
+
+        // found
+        let found = is_requested.into_found(peer, ());
+        waiting_room.insert(&urn, found.clone());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(found.clone().cancel(())))
+        );
+
+        // cloning
+        let cloning = found
+            .cloning(config.max_queries, config.max_clones, peer, ())
+            .unwrap_right();
+        waiting_room.insert(&urn, cloning.clone());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(cloning.clone().cancel(())))
+        );
+
+        // cloned
+        let cloned = cloning.cloned(peer, ());
+        waiting_room.insert(&urn, cloned);
+        assert_eq!(
+            waiting_room.canceled(&urn, ()),
+            Err(Error::StateMismatch(RequestState::Cloned))
+        );
+
+        // cancel
+        let cancelled = Request::new(urn.clone(), ()).cancel(());
+        waiting_room.insert(&urn, cancelled.clone());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(cancelled))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_get_request_that_is_ready() -> Result<(), Box<dyn error::Error + 'static>> {
+        let config = Config::default();
+        let mut waiting_room: WaitingRoom<usize, usize> = WaitingRoom::new(config);
+
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let remote_peer = PeerId::from(SecretKey::new());
+
+        let ready = waiting_room.find_by_state(RequestState::Cloned);
+        assert_eq!(ready, None);
+
+        let _ = waiting_room.request(&urn, 0);
+        waiting_room.queried(&urn, 0)?;
+        waiting_room.found(&urn, remote_peer, 0)?;
+        waiting_room.cloning(&urn, remote_peer, 0)?;
+        waiting_room.cloned(&urn, remote_peer, 0)?;
+
+        let ready = waiting_room.find_by_state(RequestState::Cloned);
+        let expected = SomeRequest::Cloned(
+            Request::new(urn.clone(), 0)
+                .request(0)
+                .into_found(remote_peer, 0)
+                .cloning(config.max_queries, config.max_clones, remote_peer, 0)
+                .unwrap_right()
+                .cloned(remote_peer, 0),
+        );
+        assert_eq!(ready, Some((urn, &expected)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_remove_requests() -> Result<(), Box<dyn error::Error + 'static>> {
+        let mut waiting_room: WaitingRoom<usize, usize> = WaitingRoom::new(Config::default());
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        assert_eq!(waiting_room.remove(&urn), None);
+
+        let expected = {
+            waiting_room.request(&urn, 0);
+            waiting_room.get(&urn).cloned()
+        };
+        let removed = waiting_room.remove(&urn);
+        assert_eq!(removed, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn can_backoff_requests() -> Result<(), Box<dyn std::error::Error>> {
+        let mut waiting_room: WaitingRoom<u32, u32> = WaitingRoom::new(Config {
+            delta: 5,
+            ..Config::default()
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let _ = waiting_room.request(&urn, 0);
+
+        // Initial schedule to be querying after it has been requested.
+        let request = waiting_room.next_query(1);
+        assert_eq!(request, Some(urn.clone()));
+
+        waiting_room.queried(&urn, 5)?;
+
+        // Should not return the urn again before delta + backoff has elapsed, i.e. 5 +
+        // (5 * 1) = 10.
+        let request = waiting_room.next_query(8);
+        assert_eq!(request, None);
+
+        // The delta + backoff has elapsed.
+        let request = waiting_room.next_query(10);
+        assert_eq!(request, Some(urn));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
`radicle-patience` is the new home of the WaitingRoom and Request API. The
purpose of this API is provide a means for keeping track of requests
made for a URN. It acts a simple state machine that can be transitioned,
by making calls to the WaitingRoom, as the outside world witnesses how a
request progresses (or regresses in the case of failure).

This is pretty much a straight migration from the `proxy` code. The only changes were reorganisation of some modules and types, as well as fixing up some docs.