### PR TITLE
instrumentation: stream error span + URN display

### DIFF
--- a/librad/src/git/fetch.rs
+++ b/librad/src/git/fetch.rs
@@ -528,7 +528,7 @@ pub struct DefaultFetcher<'a> {
 }
 
 impl<'a> DefaultFetcher<'a> {
-    #[tracing::instrument(skip(storage, addr_hints), err)]
+    #[tracing::instrument(skip(storage, urn, addr_hints), fields(urn = %urn), err)]
     pub fn new<Addrs>(
         storage: &'a Storage,
         urn: git::Urn,

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -225,7 +225,7 @@ pub struct Refs {
 
 impl Refs {
     /// Compute the [`Refs`] from the current storage state at [`Urn`].
-    #[tracing::instrument(level = "debug", skip(storage), err)]
+    #[tracing::instrument(level = "debug", skip(storage, urn), fields(urn = %urn), err)]
     pub fn compute(storage: &Storage, urn: &Urn) -> Result<Self, stored::Error> {
         let namespace = Namespace::from(urn);
         let namespace_prefix = format!("refs/namespaces/{}/", namespace);
@@ -292,7 +292,7 @@ impl Refs {
     ///
     /// If the blob where the signed [`Refs`] are expected to be stored is not
     /// found, `None` is returned.
-    #[tracing::instrument(skip(storage), err)]
+    #[tracing::instrument(skip(storage, urn), fields(urn = %urn), err)]
     pub fn load<P>(storage: &Storage, urn: &Urn, peer: P) -> Result<Option<Self>, stored::Error>
     where
         P: Into<Option<PeerId>> + Debug,
@@ -322,7 +322,7 @@ impl Refs {
     /// If the result of [`Self::compute`] is the same as the alread-stored
     /// [`Refs`], no commit is made and `None` is returned. Otherwise, the
     /// new and persisted [`Refs`] are returned in a `Some`.
-    #[tracing::instrument(skip(storage), err)]
+    #[tracing::instrument(skip(storage, urn), fields(urn = %urn), err)]
     pub fn update(storage: &Storage, urn: &Urn) -> Result<Option<Self>, stored::Error> {
         let branch = Reference::rad_signed_refs(Namespace::from(urn), None);
         tracing::debug!("updating signed refs for {}", branch);

--- a/librad/src/git/replication.rs
+++ b/librad/src/git/replication.rs
@@ -134,7 +134,7 @@ pub enum ReplicateResult {
 /// set, which is enforced by the
 /// [`crate::git::local::transport::LocalTransport`].
 #[allow(clippy::unit_arg)]
-#[tracing::instrument(skip(storage, whoami, addr_hints), err)]
+#[tracing::instrument(skip(storage, whoami, urn, addr_hints), fields(urn = %urn), err)]
 pub fn replicate<Addrs>(
     storage: &Storage,
     config: Config,
@@ -277,7 +277,7 @@ where
 /// If we are fetching updates then we only fetch the relevant remotes that we
 /// already know about.
 #[allow(clippy::unit_arg)]
-#[tracing::instrument(skip(storage, fetcher), err)]
+#[tracing::instrument(skip(storage, fetcher, urn), fields(urn = %urn), err)]
 fn replication(
     storage: &Storage,
     fetcher: &mut fetch::DefaultFetcher,
@@ -332,7 +332,7 @@ fn unsafe_into_urn(reference: Reference<git_ext::RefLike>) -> Urn {
 }
 
 #[allow(clippy::unit_arg)]
-#[tracing::instrument(level = "trace", skip(storage), err)]
+#[tracing::instrument(level = "trace", skip(storage, urn), fields(urn = %urn), err)]
 fn ensure_rad_id(storage: &Storage, urn: &Urn, tip: ext::Oid) -> Result<(), Error> {
     identities::common::IdRef::from(urn)
         .create(storage, tip)
@@ -346,7 +346,12 @@ fn ensure_rad_id(storage: &Storage, urn: &Urn, tip: ext::Oid) -> Result<(), Erro
 /// remotes which were meant for pruning might not have been removed, resulting
 /// in unnecessary remote references.
 #[allow(clippy::unit_arg)]
-#[tracing::instrument(level = "trace", skip(storage, prune_list))]
+#[tracing::instrument(
+    level = "trace",
+    skip(storage, urn, prune_list),
+    fields(urn = %urn),
+    err
+)]
 fn prune<'a>(
     storage: &Storage,
     urn: &Urn,
@@ -561,7 +566,12 @@ mod project {
     /// Fetch `rad/signed_refs` and `refs/heads` of the delegates and our
     /// tracked graph, returning the set of tracked peers.
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage, fetcher), err)]
+    #[tracing::instrument(
+        level = "trace",
+        skip(storage, fetcher, urn),
+        fields(urn = %urn),
+        err
+    )]
     pub fn replicate_signed_refs(
         storage: &Storage,
         fetcher: &mut fetch::DefaultFetcher,

--- a/librad/src/net/quic/connection.rs
+++ b/librad/src/net/quic/connection.rs
@@ -147,6 +147,7 @@ impl Connection {
         self.track.disconnect(&self.id(), reason);
     }
 
+    #[tracing::instrument(skip(self, e))]
     pub(super) fn on_stream_error(&self, e: &io::Error) {
         tracing::warn!(err = ?e, "stream error");
         self.track

--- a/librad/src/net/quic/stream.rs
+++ b/librad/src/net/quic/stream.rs
@@ -98,6 +98,22 @@ impl RecvStream {
     pub fn id(&self) -> quinn::StreamId {
         self.recv.id()
     }
+
+    #[tracing::instrument(
+        skip(self, e),
+        fields(
+            dir = "recv",
+            remote_id = %self.remote_peer_id(),
+            remote_addr = %self.remote_addr(),
+        )
+    )]
+    fn on_stream_error(&self, e: &io::Error) {
+        self.conn.on_stream_error(e)
+    }
+
+    fn tickle(&self) {
+        self.conn.tickle()
+    }
 }
 
 impl RemotePeer for RecvStream {
@@ -125,8 +141,8 @@ impl AsyncRead for RecvStream {
 
         if let Poll::Ready(ready) = &res {
             match ready {
-                Err(e) => this.conn.on_stream_error(e),
-                Ok(_) => this.conn.tickle(),
+                Err(e) => this.on_stream_error(e),
+                Ok(_) => this.tickle(),
             }
         }
 
@@ -146,6 +162,22 @@ impl SendStream {
 
     pub fn id(&self) -> quinn::StreamId {
         self.send.id()
+    }
+
+    #[tracing::instrument(
+        skip(self, e),
+        fields(
+            dir = "send",
+            remote_id = %self.remote_peer_id(),
+            remote_addr = %self.remote_addr(),
+        )
+    )]
+    fn on_stream_error(&self, e: &io::Error) {
+        self.conn.on_stream_error(e)
+    }
+
+    fn tickle(&self) {
+        self.conn.tickle()
     }
 }
 
@@ -170,8 +202,8 @@ impl AsyncWrite for SendStream {
 
         if let Poll::Ready(ready) = &res {
             match ready {
-                Err(e) => this.conn.on_stream_error(e),
-                Ok(_) => this.conn.tickle(),
+                Err(e) => this.on_stream_error(e),
+                Ok(_) => this.tickle(),
             }
         }
 
@@ -184,8 +216,8 @@ impl AsyncWrite for SendStream {
 
         if let Poll::Ready(ready) = &res {
             match ready {
-                Err(e) => this.conn.on_stream_error(e),
-                Ok(()) => this.conn.tickle(),
+                Err(e) => this.on_stream_error(e),
+                Ok(()) => this.tickle(),
             }
         }
 
@@ -198,8 +230,8 @@ impl AsyncWrite for SendStream {
 
         if let Poll::Ready(ready) = &res {
             match ready {
-                Err(e) => this.conn.on_stream_error(e),
-                Ok(()) => this.conn.tickle(),
+                Err(e) => this.on_stream_error(e),
+                Ok(()) => this.tickle(),
             }
         }
 


### PR DESCRIPTION
Fixes a few instances of URNs going through Debug instead of Display for
logging. This is still not ideal, because composite values are often
better logged through Debug, but then the URN field is somewhat less
useful again. Need to investigate with upstream why the Value trait is
sealed.

Also improves the span reporting when a stream error occurs.

Signed-off-by: Kim Altintop <kim@monadic.xyz>