### PR TITLE
git, net: Add a "capability" trait to mark pooled storage

### DIFF
--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -23,7 +23,7 @@ pub mod pool;
 
 pub use config::Config;
 pub use glob::Pattern;
-pub use pool::{Pool, Pooled};
+pub use pool::{Pool, PoolError, Pooled, PooledRef};
 
 // FIXME: should be at the crate root
 pub use crate::identities::git::Urn;

--- a/librad/src/net/peer/storage.rs
+++ b/librad/src/net/peer/storage.rs
@@ -10,7 +10,12 @@ use git_ext::{self as ext, reference};
 use tokio::task::spawn_blocking;
 
 use crate::{
-    git::{replication, storage::Pool, tracking, Urn},
+    git::{
+        replication,
+        storage::{self, Pool, PoolError, PooledRef},
+        tracking,
+        Urn,
+    },
     identities::urn,
     net::protocol::{broadcast, gossip},
     peer::{Originates, PeerId},
@@ -214,6 +219,13 @@ impl broadcast::LocalStorage<SocketAddr> for Storage {
             want.rev.map(|gossip::Rev::Git(head)| head),
         )
         .await
+    }
+}
+
+#[async_trait]
+impl storage::Pooled for Storage {
+    async fn get(&self) -> Result<PooledRef, PoolError> {
+        self.inner.get().await.map(PooledRef::from)
     }
 }
 

--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -7,13 +7,24 @@ use std::net::SocketAddr;
 
 use futures::stream::{self, StreamExt as _};
 
-use super::{broadcast, event, gossip, io, membership, tick, PeerInfo, RecvError, State};
+use super::{
+    broadcast,
+    event,
+    gossip,
+    io,
+    membership,
+    tick,
+    PeerInfo,
+    ProtocolStorage,
+    RecvError,
+    State,
+};
 use crate::PeerId;
 
 #[tracing::instrument(skip(state, disco))]
 pub(super) async fn disco<S, D>(state: State<S>, disco: D)
 where
-    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload> + 'static,
+    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + 'static,
     D: futures::Stream<Item = (PeerId, Vec<SocketAddr>)>,
 {
     disco
@@ -27,7 +38,7 @@ where
 #[tracing::instrument(skip(state, tasks))]
 pub(super) async fn periodic<S, P>(state: State<S>, tasks: P)
 where
-    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload> + 'static,
+    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + 'static,
     P: futures::Stream<Item = membership::Periodic<SocketAddr>>,
 {
     tasks
@@ -87,7 +98,7 @@ where
 #[tracing::instrument(skip(state, rx))]
 pub(super) async fn ground_control<S, E>(state: State<S>, mut rx: E)
 where
-    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload> + 'static,
+    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + 'static,
     E: futures::Stream<Item = Result<event::Downstream, RecvError>> + Unpin,
 {
     use event::{

--- a/librad/src/net/protocol/error.rs
+++ b/librad/src/net/protocol/error.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 
 use super::{membership, PeerInfo};
 use crate::{
+    git::storage::pool::PoolError,
     net::{
         codec::{CborCodecError, CborError},
         quic,
@@ -20,6 +21,9 @@ use crate::{
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Bootstrap {
+    #[error(transparent)]
+    Pool(#[from] PoolError),
+
     #[error(transparent)]
     Quic(#[from] quic::Error),
 }

--- a/librad/src/net/protocol/tick.rs
+++ b/librad/src/net/protocol/tick.rs
@@ -10,7 +10,7 @@ use futures::{
     stream::{FuturesOrdered, StreamExt as _},
 };
 
-use super::{broadcast, error, gossip, io, membership, PeerInfo, State};
+use super::{error, gossip, io, membership, PeerInfo, ProtocolStorage, State};
 use crate::PeerId;
 
 #[derive(Debug)]
@@ -34,11 +34,7 @@ where
 #[tracing::instrument(level = "debug", skip(state))]
 pub(super) async fn tock<S>(state: State<S>, tock: Tock<SocketAddr, gossip::Payload>)
 where
-    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + Clone + 'static,
 {
     let mut mcfly = FuturesOrdered::new();
     mcfly.push(one_tock(state.clone(), tock));
@@ -71,11 +67,7 @@ fn one_tock<S>(
     tock: Tock<SocketAddr, gossip::Payload>,
 ) -> BoxFuture<'static, Result<(), error::Tock<SocketAddr>>>
 where
-    S: broadcast::LocalStorage<SocketAddr, Update = gossip::Payload>
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + Clone + 'static,
 {
     use Tock::*;
 


### PR DESCRIPTION
It turns out we will need access to a `git::Storage` from some stream
handlers, specifically in pooled form due to `Send`/`Sync` requirements.
As we need to pull that out from a larger structure (respectively
wrappers), a trait is in order. Since we need to thread the constraint
through the various IO function, we defined a composite trait to make
constraint signatures shorter.

Signed-off-by: Kim Altintop <kim@monadic.xyz>