### PR TITLE
git-ext, storage: Add a way to quickly create a commit

### DIFF
--- a/ci/docs
+++ b/ci/docs
@@ -2,4 +2,5 @@
 set -eou pipefail
 
 echo "--- Docs"
+RUSTDOCFLAGS="-D broken-intra-doc-links" \
 cargo doc --no-deps --workspace --document-private-items --all-features

--- a/git-ext/src/lib.rs
+++ b/git-ext/src/lib.rs
@@ -11,6 +11,7 @@ pub mod oid;
 pub mod reference;
 pub mod revwalk;
 pub mod transport;
+pub mod tree;
 
 pub use blob::*;
 pub use error::*;
@@ -18,6 +19,7 @@ pub use oid::*;
 pub use reference::*;
 pub use revwalk::*;
 pub use transport::*;
+pub use tree::Tree;
 
 #[cfg(test)]
 #[macro_use]

--- a/git-ext/src/tree.rs
+++ b/git-ext/src/tree.rs
@@ -1,0 +1,147 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{borrow::Cow, collections::BTreeMap, iter::FromIterator};
+
+/// A simplified representation of a git tree, intended mainly to be created
+/// from literals.
+///
+/// # Example
+///
+/// ```
+/// use radicle_git_ext::tree::{Tree, blob};
+///
+/// let my_tree = vec![
+///     ("README", blob(b"awe")),
+///     ("src", vec![("main.rs", blob(b"fn main() {}"))].into_iter().collect()),
+/// ]
+/// .into_iter()
+/// .collect::<Tree>();
+///
+/// assert_eq!(
+///     format!("{:?}", my_tree),
+///     "Tree(\
+///         {\
+///             \"README\": Blob(\
+///                 [\
+///                     97, \
+///                     119, \
+///                     101\
+///                 ]\
+///             ), \
+///             \"src\": Tree(\
+///                 Tree(\
+///                     {\
+///                         \"main.rs\": Blob(\
+///                             [\
+///                                 102, \
+///                                 110, \
+///                                 32, \
+///                                 109, \
+///                                 97, \
+///                                 105, \
+///                                 110, \
+///                                 40, \
+///                                 41, \
+///                                 32, \
+///                                 123, \
+///                                 125\
+///                             ]\
+///                         )\
+///                     }\
+///                 )\
+///             )\
+///         }\
+///     )"
+/// )
+/// ```
+#[derive(Clone, Debug)]
+pub struct Tree<'a>(BTreeMap<Cow<'a, str>, Node<'a>>);
+
+impl Tree<'_> {
+    pub fn write(&self, repo: &git2::Repository) -> Result<git2::Oid, git2::Error> {
+        use Node::*;
+
+        let mut builder = repo.treebuilder(None)?;
+        for (name, node) in &self.0 {
+            match node {
+                Blob(data) => {
+                    let oid = repo.blob(data)?;
+                    builder.insert(name.as_ref(), oid, 0o100644)?;
+                },
+                Tree(sub) => {
+                    let oid = sub.write(repo)?;
+                    builder.insert(name.as_ref(), oid, 0o04000)?;
+                },
+            }
+        }
+
+        Ok(builder.write()?)
+    }
+}
+
+impl<'a> From<BTreeMap<Cow<'a, str>, Node<'a>>> for Tree<'a> {
+    fn from(map: BTreeMap<Cow<'a, str>, Node<'a>>) -> Self {
+        Self(map)
+    }
+}
+
+impl<'a, K, N> FromIterator<(K, N)> for Tree<'a>
+where
+    K: Into<Cow<'a, str>>,
+    N: Into<Node<'a>>,
+{
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (K, N)>,
+    {
+        Self(
+            iter.into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Node<'a> {
+    Blob(Cow<'a, [u8]>),
+    Tree(Tree<'a>),
+}
+
+pub fn blob(slice: &[u8]) -> Node {
+    Node::from(slice)
+}
+
+impl<'a> From<&'a [u8]> for Node<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self::from(Cow::Borrowed(slice))
+    }
+}
+
+impl<'a> From<Cow<'a, [u8]>> for Node<'a> {
+    fn from(bytes: Cow<'a, [u8]>) -> Self {
+        Self::Blob(bytes)
+    }
+}
+
+impl<'a> From<Tree<'a>> for Node<'a> {
+    fn from(tree: Tree<'a>) -> Self {
+        Self::Tree(tree)
+    }
+}
+
+impl<'a, K, N> FromIterator<(K, N)> for Node<'a>
+where
+    K: Into<Cow<'a, str>>,
+    N: Into<Node<'a>>,
+{
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (K, N)>,
+    {
+        Self::Tree(iter.into_iter().collect())
+    }
+}

--- a/librad/src/git.rs
+++ b/librad/src/git.rs
@@ -17,6 +17,7 @@ pub use storage::Storage;
 pub mod tracking;
 pub mod trailer;
 pub mod types;
+pub mod util;
 
 mod sealed;
 

--- a/librad/src/git/util.rs
+++ b/librad/src/git/util.rs
@@ -1,0 +1,91 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use git_ext::{is_not_found_err, reference};
+use std_ext::result::ResultExt as _;
+
+use super::{
+    refs::{self, Refs},
+    types::Namespace,
+};
+
+pub use super::{Storage, Urn};
+pub use git_ext::Tree;
+
+pub mod error {
+    use super::*;
+    use thiserror::Error;
+
+    #[derive(Debug, Error)]
+    #[non_exhaustive]
+    pub enum QuickCommit {
+        #[error("failed to update refs signature")]
+        Sigrefs(#[from] refs::stored::Error),
+
+        #[error(transparent)]
+        Git(#[from] git2::Error),
+    }
+}
+
+/// Quickly create a commit in the namespace and and on top of the branch
+/// described by [`Urn`], operating directly on [`Storage`].
+///
+/// This function is provided mainly for integration testing purposes, where the
+/// ceremony of a working copy is often undesired.
+///
+/// Note that the given [`Urn`]'s `path` will be sanitised such that it points
+/// to the locally-owned `refs/heads`. That is, `refs/remotes/xx/heads/pu` would
+/// be interpreted as `refs/namespaces/<urn>/refs/heads/xx/heads/pu`.
+///
+/// In other words, you can only use this function to commit to your own
+/// branches, but if you try to circumvent this restriction, the result may be
+/// surprising.
+///
+/// The default branch if the [`Urn`] contains no `path` is "master".
+#[tracing::instrument(
+    level = "debug",
+    skip(storage, urn, tree, message),
+    fields(urn = %urn),
+    err
+)]
+pub fn quick_commit(
+    storage: &Storage,
+    urn: &Urn,
+    tree: Tree,
+    message: &str,
+) -> Result<git2::Oid, error::QuickCommit> {
+    let repo = storage.as_raw();
+
+    let author = repo.signature()?;
+    let branch = {
+        let path = reference::OneLevel::from(urn.path.clone().unwrap_or(reflike!("master")));
+        reflike!("refs/namespaces")
+            .join(Namespace::from(urn))
+            .join(path.into_qualified(reflike!("heads")))
+    };
+    let parent = repo
+        .find_reference(branch.as_str())
+        .and_then(|ref_| ref_.peel_to_commit())
+        .map(Some)
+        .or_matches::<git2::Error, _, _>(is_not_found_err, || Ok(None))?;
+    let tree = {
+        let oid = tree.write(&repo)?;
+        repo.find_tree(oid)?
+    };
+
+    let oid = repo.commit(
+        Some(branch.as_str()),
+        &author,
+        &author,
+        message,
+        &tree,
+        &parent.as_ref().into_iter().collect::<Vec<_>>(),
+    )?;
+    tracing::debug!(oid = %oid, branch = %branch.as_str(), "quick commit created");
+
+    Refs::update(storage, urn)?;
+
+    Ok(oid)
+}

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(incomplete_features)]
 #![allow(private_intra_doc_links)]
 #![warn(clippy::extra_unused_lifetimes)]
+#![deny(broken_intra_doc_links)]
 #![feature(associated_type_bounds)]
 #![feature(backtrace)]
 #![feature(bool_to_option)]

--- a/librad/src/net.rs
+++ b/librad/src/net.rs
@@ -25,8 +25,8 @@ mod codec;
 /// permits gradual rollout scenarios of major network upgrades.
 ///
 /// For the negotiation of optional (compatible _per definitionem_) protocol
-/// features, the [`PeerAdvertisement`] reserves space for advertising
-/// [`info::Capability`]s.
+/// features, the [`protocol::PeerAdvertisement`] reserves space for advertising
+/// [`protocol::Capability`]s.
 ///
 /// [ALPN]: https://tools.ietf.org/html/rfc7301
 pub const PROTOCOL_VERSION: u8 = 2;

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -57,7 +57,7 @@ pub mod gossip;
 pub mod membership;
 
 mod info;
-pub use info::{PartialPeerInfo, PeerAdvertisement, PeerInfo};
+pub use info::{Capability, PartialPeerInfo, PeerAdvertisement, PeerInfo};
 
 mod io;
 mod tick;


### PR DESCRIPTION
Mainly in integration tests, we often want to create some git history.
Currently, the only way to do that is to go through a working copy,
which exercises that flow, but is often inconvenient (and slow).

Since we want to avoid handing out a raw git handle to the underlying
"monorepo" storage, we instead expose a public means to create a commit
in a reasonably safe and almost ergonomic way.

Signed-off-by: Kim Altintop <kim@monadic.xyz>