### PR TITLE
ci: Add Hüb workflow

### DIFF
--- a/.github/workflows/fast.yaml
+++ b/.github/workflows/fast.yaml
@@ -1,0 +1,95 @@
+name: fast
+on: [pull_request]
+jobs:
+  fmt:
+    if: github.repository_owner != 'radicle-dev'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/cache@v2
+        env:
+          cache-name: target-cache
+        with:
+          path: target
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.toml', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install Rust
+        run: rustup update nightly-2020-11-10 --no-self-update && rustup default nightly-2020-11-10 && rustup component add clippy rustfmt
+        shell: bash
+      - run: ./ci/clippy
+        shell: bash
+
+  test-linux:
+    if: github.repository_owner != 'radicle-dev'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/cache@v2
+        env:
+          cache-name: target-cache
+        with:
+          path: target
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.toml', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install Rust
+        run: rustup update nightly-2020-11-10 --no-self-update && rustup default nightly-2020-11-10
+        shell: bash
+      - run: ./ci/test-fast
+        shell: bash
+
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/cache@v2
+        env:
+          cache-name: target-cache
+        with:
+          path: target
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.toml', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install Rust
+        run: rustup update nightly-2020-11-10 --no-self-update && rustup default nightly-2020-11-10
+        shell: bash
+      - run: ./ci/test-fast
+        shell: bash
+
+  test-win:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/cache@v2
+        env:
+          cache-name: target-cache
+        with:
+          path: target
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.toml', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install Rust
+        run: rustup update nightly-2020-11-10 --no-self-update && rustup default nightly-2020-11-10
+        shell: bash
+      - name: Install winpcap
+        run: choco install winpcap
+        shell: bash
+      - name: Supplant Packet.lib
+        run: |
+            mkdir D:/dl &&
+            curl -o D:/dl/wpd.zip https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip &&
+            cd D:/dl &&
+            unzip wpd.zip &&
+            cp WpdPack/Lib/x64/Packet.lib C:/Rust/.rustup/toolchains/nightly-2020-11-10-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
+        shell: bash
+      - run: ./ci/test-fast
+        shell: bash

--- a/ci/test-fast
+++ b/ci/test-fast
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+echo '--- Library tests'
+cargo test --lib --all-features


### PR DESCRIPTION
Adds a GitHüb workflow running a minimal set of lints + tests on
proprietary platforms. Additionally, this "fast set" is run for pull
requests from other repositories, so that we can disable running the
(slow) builds for externals on our hardware.