### PR TITLE
git-ext: `minicbor` impls

### DIFF
--- a/git-ext/Cargo.toml
+++ b/git-ext/Cargo.toml
@@ -17,9 +17,15 @@ version = ">= 0.13.12, 0.13"
 default-features = false
 features = []
 
+[dependencies.minicbor]
+version = ">= 0.6, 0"
+features = ["std"]
+optional = true
+
 [dependencies.serde]
 version = "1"
 features = ["derive"]
+optional = true
 
 [dependencies.radicle-std-ext]
 path = "../std-ext"

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -101,6 +101,7 @@ features = ["tls-rustls"]
 
 [dependencies.radicle-git-ext]
 path = "../git-ext"
+features = ["serde", "minicbor"]
 
 [dependencies.radicle-macros]
 path = "../macros"


### PR DESCRIPTION
Add minicbor impls for refnames and Oid. Also pretend to be a good
library by hiding minicbor + serde impl behind features.
