### PR TITLE
Update deadpool-0.7

### DIFF
--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -54,7 +54,7 @@ uuid = { version = "0.8", features = ["v4"] }
 webpki = "0.21"
 
 [dependencies.deadpool]
-version = "0.5"
+version = "0.7"
 default-features = false
 features = ["managed"]
 


### PR DESCRIPTION
We noticed that `deadpool-0.5` depends on `tokio-0.2`. Updating to >=0.7
means all our dependencies are pointing to `tokio >=1.0`.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>