### PR TITLE
net: Relax membership check before discarding gossip as unsolicited

### DIFF
--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -495,6 +495,6 @@ where
     }
 
     fn is_member(&self, peer: &PeerId) -> bool {
-        self.is_active(peer)
+        self.is_known(peer)
     }
 }

--- a/librad/src/net/protocol/membership/hpv.rs
+++ b/librad/src/net/protocol/membership/hpv.rs
@@ -168,6 +168,14 @@ where
         self.0.read().is_active(peer)
     }
 
+    pub fn is_passive(&self, peer: &PeerId) -> bool {
+        self.0.read().is_passive(peer)
+    }
+
+    pub fn is_known(&self, peer: &PeerId) -> bool {
+        self.0.read().is_known(peer)
+    }
+
     pub fn known(&self) -> Vec<PeerId> {
         self.0.read().known().collect()
     }
@@ -262,8 +270,16 @@ where
         self.view.num_passive()
     }
 
+    pub fn is_known(&self, peer: &PeerId) -> bool {
+        self.view.is_known(peer)
+    }
+
     pub fn is_active(&self, peer: &PeerId) -> bool {
         self.view.is_active(peer)
+    }
+
+    pub fn is_passive(&self, peer: &PeerId) -> bool {
+        self.view.is_passive(peer)
     }
 
     pub fn connection_lost(&mut self, remote_peer: PeerId) -> TnT<Addr> {

--- a/librad/src/net/protocol/membership/partial_view.rs
+++ b/librad/src/net/protocol/membership/partial_view.rs
@@ -54,8 +54,16 @@ where
         self.active().chain(self.passive())
     }
 
+    pub fn is_known(&self, peer: &PeerId) -> bool {
+        self.is_active(peer) || self.is_passive(peer)
+    }
+
     pub fn active(&self) -> impl Iterator<Item = PeerId> + '_ {
         self.active.keys().copied()
+    }
+
+    pub fn is_active(&self, peer: &PeerId) -> bool {
+        self.active.contains_key(peer)
     }
 
     pub fn active_info(&self) -> impl Iterator<Item = PartialPeerInfo<A>> + '_ {
@@ -66,12 +74,12 @@ where
         self.passive.keys().copied()
     }
 
-    pub fn passive_info(&self) -> impl Iterator<Item = PeerInfo<A>> + '_ {
-        self.passive.values().cloned()
+    pub fn is_passive(&self, peer: &PeerId) -> bool {
+        self.passive.contains_key(peer)
     }
 
-    pub fn is_active(&self, peer: &PeerId) -> bool {
-        self.active.contains_key(peer)
+    pub fn passive_info(&self) -> impl Iterator<Item = PeerInfo<A>> + '_ {
+        self.passive.values().cloned()
     }
 
     pub fn num_active(&self) -> usize {


### PR DESCRIPTION
Gossip messages must only be accepted from peers in the partial view, as
otherwise it would be too easy to flood the network with random
messages, amplified by faithful peers. However, requiring active set
membership is too strict, as promotion / demotion is not synchronised.

Instead, we check for partial view inclusion regardless of status.