### PR TITLE
net: Fix `Disconnect` not being sent on demotion

### DIFF
--- a/librad/src/net/protocol/membership/tick.rs
+++ b/librad/src/net/protocol/membership/tick.rs
@@ -52,6 +52,10 @@ where
         use Transition::*;
 
         match t {
+            Demoted(info) => Some(Try {
+                recipient: info,
+                message: Message::Disconnect,
+            }),
             Evicted(info) => Some(Forget { peer: info.peer_id }),
             _ => None,
         }


### PR DESCRIPTION
When a peer is demoted from the active view, the other end needs to be
notified of that. This was not the case, because past self outsmarted
himself.

Note that this does not invalidate #542, as gossip could be in-flight
before the `Disconnect` arrives.