### PR TITLE
protocol: expose memebership lists via tincan

### DIFF
--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -18,7 +18,10 @@ use crate::{
 };
 
 pub use super::protocol::{
-    event::{downstream::Stats, Upstream as ProtocolEvent},
+    event::{
+        downstream::{MembershipInfo, Stats},
+        Upstream as ProtocolEvent,
+    },
     PeerInfo,
 };
 pub use deadpool::managed::PoolError;
@@ -182,6 +185,10 @@ where
 
     pub async fn connected_peers(&self) -> Vec<PeerId> {
         self.phone.connected_peers().await
+    }
+
+    pub async fn membership(&self) -> MembershipInfo {
+        self.phone.membership().await
     }
 
     pub async fn stats(&self) -> Stats {

--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -102,7 +102,7 @@ where
     E: futures::Stream<Item = Result<event::Downstream, RecvError>> + Unpin,
 {
     use event::{
-        downstream::{Gossip, Info, Stats},
+        downstream::{Gossip, Info, MembershipInfo, Stats},
         Downstream,
     };
 
@@ -150,6 +150,16 @@ where
                         Info::ConnectedPeers(tx) => {
                             if let Some(tx) = tx.lock().take() {
                                 tx.send(state.endpoint.peers()).ok();
+                            }
+                        },
+
+                        Info::Membership(tx) => {
+                            if let Some(tx) = tx.lock().take() {
+                                tx.send(MembershipInfo {
+                                    active: state.membership.active(),
+                                    passive: state.membership.passive(),
+                                })
+                                .ok();
                             }
                         },
 

--- a/librad/src/net/protocol/event.rs
+++ b/librad/src/net/protocol/event.rs
@@ -42,7 +42,14 @@ pub mod downstream {
     #[derive(Clone)]
     pub enum Info {
         ConnectedPeers(Reply<Vec<PeerId>>),
+        Membership(Reply<MembershipInfo>),
         Stats(Reply<Stats>),
+    }
+
+    #[derive(Clone, Debug, Default)]
+    pub struct MembershipInfo {
+        pub active: Vec<PeerId>,
+        pub passive: Vec<PeerId>,
     }
 
     #[derive(Clone, Debug, Default)]

--- a/librad/src/net/protocol/membership/hpv.rs
+++ b/librad/src/net/protocol/membership/hpv.rs
@@ -164,6 +164,10 @@ where
         (guard.num_active(), guard.num_passive())
     }
 
+    pub fn active(&self) -> Vec<PeerId> {
+        self.0.read().active().collect()
+    }
+
     pub fn is_active(&self, peer: &PeerId) -> bool {
         self.0.read().is_active(peer)
     }
@@ -178,6 +182,10 @@ where
 
     pub fn known(&self) -> Vec<PeerId> {
         self.0.read().known().collect()
+    }
+
+    pub fn passive(&self) -> Vec<PeerId> {
+        self.0.read().passive().collect()
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -258,8 +266,16 @@ where
         }
     }
 
+    pub fn active(&self) -> impl Iterator<Item = PeerId> + '_ {
+        self.view.active()
+    }
+
     pub fn known(&self) -> impl Iterator<Item = PeerId> + '_ {
         self.view.known()
+    }
+
+    pub fn passive(&self) -> impl Iterator<Item = PeerId> + '_ {
+        self.view.passive()
     }
 
     pub fn num_active(&self) -> usize {

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -235,6 +235,10 @@ impl Node {
     /// Handle user requests.
     async fn handle_request(request: Request, api: &Peer<Signer>) -> Result<(), Error> {
         match request {
+            Request::GetMembership(mut reply) => {
+                let info = api.membership().await;
+                reply.send(info).await?;
+            },
             Request::GetPeers(mut reply) => {
                 let peers = api.connected_peers().await;
                 reply.send(peers).await?;


### PR DESCRIPTION
To get an understanding where in the partial view a certain peer is the
protocol can be phoned now to return the list of active, known and
passive peers.

Signed-off-by: Alexander Simmerl <a.simmerl@gmail.com>