### PR TITLE
git-helpers: Add informative git-remote-rad error message

### DIFF
--- a/git-helpers/src/remote_helper.rs
+++ b/git-helpers/src/remote_helper.rs
@@ -31,6 +31,14 @@ const SECRET_KEY_FILE: &str = "librad.key";
 pub fn run() -> anyhow::Result<()> {
     let url = {
         let args = env::args().skip(1).take(2).collect::<Vec<_>>();
+        if args.is_empty() {
+            return Err(anyhow::anyhow!(
+                r#"This remote helper is transparently used by Git when you use commands
+such as "git fetch <URL>", "git clone <URL>", "git push <URL>" or
+"git remote add <nick> <URL>", where <URL> begins with "rad://".
+See https://git-scm.com/docs/git-remote-ext for more detail."#
+            ));
+        }
         args[0]
             .parse()
             .or_else(|_| args[1].parse())


### PR DESCRIPTION
This pull-request apply the suggestion of #471 and adds a more informative message when `git-remote-rad` is ran from the command line directly.

The error message is now

```
Error: This remote helper is transparently used by Git when you use commands
such as "git fetch <URL>", "git clone <URL>", "git push <URL>" or
"git remote add <nick> <URL>", where <URL> begins with "rad://".
See https://git-scm.com/docs/git-remote-ext for more detail.
``` 

instead of

```
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', /cache/cargo/git/checkouts/radicle-link-009c17032bc5eda9/308d2dd/git-helpers/src/remote_helper.rs:46:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Closes #471