### PR TITLE
git::identities: add root functions

### DIFF
--- a/librad/src/git/identities/person.rs
+++ b/librad/src/git/identities/person.rs
@@ -79,6 +79,16 @@ pub fn verify(storage: &Storage, urn: &Urn) -> Result<Option<VerifiedPerson>, Er
     }
 }
 
+/// Get the root [`Urn`] for the given `payload` and set of `delegations`.
+#[tracing::instrument(level = "debug", skip(storage), err)]
+pub fn urn<P>(storage: &Storage, payload: P, delegations: delegation::Direct) -> Result<Urn, Error>
+where
+    P: Into<PersonPayload> + Debug,
+{
+    let (_, revision) = identities(storage).base(payload.into(), delegations)?;
+    Ok(Urn::new(revision))
+}
+
 /// Create a new [`Person`].
 ///
 /// The `delegations` must include the [`Storage`]'s [`crate::signer::Signer`]

--- a/librad/src/git/identities/project.rs
+++ b/librad/src/git/identities/project.rs
@@ -80,6 +80,16 @@ pub fn verify(storage: &Storage, urn: &Urn) -> Result<Option<VerifiedProject>, E
     }
 }
 
+/// Get the root [`Urn`] for the given `payload` and set of `delegations`.
+#[tracing::instrument(level = "debug", skip(storage), err)]
+pub fn urn<P>(storage: &Storage, payload: P, delegations: IndirectDelegation) -> Result<Urn, Error>
+where
+    P: Into<ProjectPayload> + Debug,
+{
+    let (_, revision) = identities(storage).base(payload.into(), delegations)?;
+    Ok(Urn::new(revision))
+}
+
 /// Create a new [`Project`].
 #[tracing::instrument(level = "debug", skip(storage, whoami), err)]
 pub fn create<P>(


### PR DESCRIPTION
We add `root` functions for the `Person` and `Project` documents. This
allows us to have a top-level function that will give us the expected
`Urn` for the given payload and delegates.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>