### PR TITLE
identities: Split list into `list` and `list_urns`

### DIFF
--- a/librad/src/git/identities/error.rs
+++ b/librad/src/git/identities/error.rs
@@ -12,6 +12,7 @@ use super::{
 use crate::identities::{
     self,
     git::{Urn, VerificationError},
+    urn,
 };
 
 #[derive(Debug, Error)]
@@ -20,8 +21,11 @@ pub enum Error {
     #[error("the URN {0} does not exist")]
     NotFound(Urn),
 
-    #[error("malformed URN")]
-    Ref(#[from] reference::FromUrnError),
+    #[error("failed to build ref from URN")]
+    RefFromUrn(#[from] reference::FromUrnError),
+
+    #[error("failed to build URN from ref")]
+    UrnFromRef(#[from] urn::FromRefLikeError),
 
     #[error("update of signed_refs failed")]
     Sigrefs(#[from] refs::stored::Error),

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -49,6 +49,7 @@ use crate::{
 pub use tokio::sync::broadcast::error::RecvError;
 
 mod accept;
+mod control;
 
 pub mod broadcast;
 pub mod error;

--- a/librad/src/net/protocol/control.rs
+++ b/librad/src/net/protocol/control.rs
@@ -1,0 +1,86 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::net::SocketAddr;
+
+use futures::stream::{self, StreamExt as _};
+
+use super::{broadcast, event, gossip, io, tick, PeerInfo, ProtocolStorage, State};
+
+pub(super) async fn gossip<S>(state: &State<S>, evt: event::downstream::Gossip)
+where
+    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + 'static,
+{
+    use event::downstream::Gossip;
+
+    let origin = PeerInfo {
+        peer_id: state.local_id,
+        advertised_info: io::peer_advertisement(&state.endpoint),
+        seen_addrs: Default::default(),
+    };
+    // TODO: answer `Want`s from a provider cache
+    let rpc = match evt {
+        Gossip::Announce(payload) => broadcast::Message::Have {
+            origin,
+            val: payload,
+        },
+        Gossip::Query(payload) => broadcast::Message::Want {
+            origin,
+            val: payload,
+        },
+    };
+    stream::iter(
+        state
+            .membership
+            .broadcast_recipients(None)
+            .into_iter()
+            .map(|to| tick::Tock::SendConnected {
+                to,
+                message: rpc.clone().into(),
+            }),
+    )
+    .for_each(|tock| tick::tock(state.clone(), tock))
+    .await
+}
+
+pub(super) fn info<S>(state: &State<S>, evt: event::downstream::Info)
+where
+    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + 'static,
+{
+    use event::downstream::{Info, MembershipInfo, Stats};
+
+    match evt {
+        Info::ConnectedPeers(reply) => {
+            let chan = reply.lock().take();
+            if let Some(tx) = chan {
+                tx.send(state.endpoint.peers()).ok();
+            }
+        },
+
+        Info::Membership(tx) => {
+            if let Some(tx) = tx.lock().take() {
+                tx.send(MembershipInfo {
+                    active: state.membership.active(),
+                    passive: state.membership.passive(),
+                })
+                .ok();
+            }
+        },
+
+        Info::Stats(reply) => {
+            let chan = reply.lock().take();
+            if let Some(tx) = chan {
+                let (active, passive) = state.membership.view_stats();
+                tx.send(Stats {
+                    connections_total: state.endpoint.connections_total(),
+                    connected_peers: state.endpoint.connected_peers(),
+                    membership_active: active,
+                    membership_passive: passive,
+                })
+                .ok();
+            }
+        },
+    }
+}


### PR DESCRIPTION
Sometimes it is useful to only list the top-level URNs without accessing
any objects. `list` can then be implemented in terms of `list_urn` +
storage access.

Signed-off-by: Kim Altintop <kim@monadic.xyz>