### PR TITLE
replication: fetch rad/ids for remotes

### DIFF
--- a/librad/src/git/replication.rs
+++ b/librad/src/git/replication.rs
@@ -319,10 +319,19 @@ fn replication(
             .map_err(|e| Error::Fetch(e.into()))?;
         let fetched_peers = project::fetched_peers(&updated)?;
 
+        let mut tips = updated.updated_tips;
+        let peeked = fetcher
+            .fetch(fetch::Fetchspecs::Peek {
+                remotes: fetched_peers.clone(),
+                limit,
+            })
+            .map_err(|e| Error::Fetch(e.into()))?;
+        tips.extend(peeked.updated_tips);
+
         let remote_ident =
             unsafe_into_urn(Reference::rad_id(Namespace::from(&urn)).with_remote(remote_peer));
         Ok((
-            updated.updated_tips,
+            tips,
             Replication::Clone {
                 urn,
                 fetched_peers,


### PR DESCRIPTION
We can't build a fetchspec that says `remote/*/rad/ids/*`. So once we've
fetched all remotes we make a second fetch call using `Peek` to get all
the `rad/ids/*` for all those remotes.

We confirm this works by extending the menage test to check for the
peer's `rad/ids` reference exists.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>