### PR TITLE
type-driven replication development

### DIFF
--- a/librad/src/git/identities/common.rs
+++ b/librad/src/git/identities/common.rs
@@ -22,6 +22,10 @@ impl<'a> From<&'a Urn> for IdRef<'a> {
 }
 
 impl<'a> IdRef<'a> {
+    pub fn oid(&self, storage: &Storage) -> Result<git2::Oid, git2::Error> {
+        Reference::rad_id(Namespace::from(self.0)).oid(storage.as_raw())
+    }
+
     pub fn create(
         &self,
         storage: &Storage,

--- a/librad/src/git/identities/error.rs
+++ b/librad/src/git/identities/error.rs
@@ -55,5 +55,11 @@ pub enum Error {
     Store(#[from] identities::git::error::Store),
 
     #[error(transparent)]
+    PersHist(#[from] identities::git::error::History<identities::git::PersonDoc>),
+
+    #[error(transparent)]
+    ProjHist(#[from] identities::git::error::History<identities::git::ProjectDoc>),
+
+    #[error(transparent)]
     Git(#[from] git2::Error),
 }

--- a/librad/src/git/identities/person.rs
+++ b/librad/src/git/identities/person.rs
@@ -5,7 +5,6 @@
 
 use std::{convert::TryFrom, fmt::Debug};
 
-use nonempty::NonEmpty;
 use radicle_git_ext::{is_not_found_err, OneLevel};
 
 use super::{
@@ -171,25 +170,14 @@ pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Person, Error
     Ok(next)
 }
 
-/// Returns `true` if the `left` or the `right` projects do not share the same
-/// commit history.
-///
-/// # Errors
-///
-///   * If the `left` project could not be found
-///   * If the `right` project could not be found
-pub fn is_fork(storage: &Storage, left: &Urn, right: &Urn) -> Result<bool, Error> {
-    let left = verify(storage, left)?.ok_or_else(|| Error::NotFound(left.clone()))?;
-    let right = verify(storage, right)?.ok_or_else(|| Error::NotFound(right.clone()))?;
-    let verified = verified(&storage);
-    Ok(verified.is_fork(&left, &right)?)
-}
-
-/// Given a list persons -- assumed to be the same person -- return the latest
-/// revision tip.
-pub fn latest_tip(storage: &Storage, persons: NonEmpty<Person>) -> Result<git2::Oid, Error> {
-    // FIXME: Should we ensure that all the projects have the same URN?
-    Ok(identities(storage).latest_tip(persons)?)
+/// Return the newer of `a` and `b`, or an error if their histories are
+/// unrelated.
+pub fn newer(
+    storage: &Storage,
+    a: VerifiedPerson,
+    b: VerifiedPerson,
+) -> Result<VerifiedPerson, Error> {
+    Ok(verified(storage).newer(a, b)?)
 }
 
 fn identities(storage: &Storage) -> Identities<Person> {

--- a/librad/src/git/identities/project.rs
+++ b/librad/src/git/identities/project.rs
@@ -7,7 +7,6 @@ use std::{convert::TryFrom, fmt::Debug};
 
 use either::Either;
 use git_ext::{is_not_found_err, OneLevel};
-use nonempty::NonEmpty;
 
 use super::{
     super::{
@@ -161,25 +160,14 @@ pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Project, Erro
     Ok(next)
 }
 
-/// Returns `true` if the `left` or the `right` projects do not share the same
-/// commit history.
-///
-/// # Errors
-///
-///   * If the `left` project could not be found
-///   * If the `right` project could not be found
-pub fn is_fork(storage: &Storage, left: &Urn, right: &Urn) -> Result<bool, Error> {
-    let left = verify(storage, left)?.ok_or_else(|| Error::NotFound(left.clone()))?;
-    let right = verify(storage, right)?.ok_or_else(|| Error::NotFound(right.clone()))?;
-    let verified = verified(&storage);
-    Ok(verified.is_fork(&left, &right)?)
-}
-
-/// Given a list projects -- assumed to be the same project -- return the latest
-/// revision tip.
-pub fn latest_tip(storage: &Storage, projects: NonEmpty<Project>) -> Result<git2::Oid, Error> {
-    // FIXME: Should we ensure that all the projects have the same URN?
-    Ok(identities(storage).latest_tip(projects)?)
+/// Return the newer of `a` and `b`, or an error if their histories are
+/// unrelated.
+pub fn newer(
+    storage: &Storage,
+    a: VerifiedProject,
+    b: VerifiedProject,
+) -> Result<VerifiedProject, Error> {
+    Ok(verified(storage).newer(a, b)?)
 }
 
 enum ProjectRefs<'a> {

--- a/librad/src/git/replication.rs
+++ b/librad/src/git/replication.rs
@@ -12,7 +12,6 @@ use std::{
 
 use either::Either;
 use git_ext::{self as ext, is_exists_err};
-use nonempty::NonEmpty;
 use std_ext::result::ResultExt as _;
 use thiserror::Error;
 
@@ -25,7 +24,7 @@ use super::{
     types::{reference, Force, Namespace, Reference},
 };
 use crate::{
-    identities::git::{Person, Project, SomeIdentity, VerifiedPerson, VerifiedProject},
+    identities::git::{Person, Project, Revision, SomeIdentity, VerifiedPerson, VerifiedProject},
     peer::PeerId,
 };
 
@@ -99,6 +98,10 @@ pub struct ReplicateResult {
     /// An indicator of whether the local view of the identity document might
     /// need approval of updates.
     pub identity: IdStatus,
+
+    /// Whether the replicated [`Urn`] was previously present in local storage
+    /// or not.
+    pub mode: Mode,
 }
 
 /// The "freshness" of the local view of a repo identity wrt the delegates.
@@ -108,6 +111,29 @@ pub enum IdStatus {
     /// Delegate tips are either behind or ahead. Interactive review is
     /// recommended.
     Uneven,
+}
+
+/// The "mode" `replicate` was operating in.
+pub enum Mode {
+    /// The git tree corresponding to [`Urn`] was previously **not** present
+    /// locally, so the operation was equivalent to `git clone`.
+    Clone,
+    /// The git tree corresponding to [`Urn`] was already present locally, so
+    /// the operation was equivalent to `git fetch`.
+    Fetch,
+}
+
+enum ModeInternal {
+    Clone {
+        urn: Urn,
+        identity: SomeIdentity,
+        fetched_peers: BTreeSet<PeerId>,
+    },
+    Fetch {
+        urn: Urn,
+        identity: SomeIdentity,
+        existing: BTreeSet<PeerId>,
+    },
 }
 
 /// Attempt to fetch `urn` from `remote_peer`, optionally supplying
@@ -160,7 +186,7 @@ where
     }
 
     let mut fetcher = storage.fetcher(urn.clone(), remote_peer, addr_hints)?;
-    let (mut updated_tips, next) = replication(
+    let (mut updated_tips, next) = determine_mode(
         storage,
         &mut fetcher,
         config.fetch_limit,
@@ -168,12 +194,12 @@ where
         remote_peer,
     )?;
     let (result, mut remove) = match next {
-        Replication::Clone {
+        ModeInternal::Clone {
             urn,
             identity,
             fetched_peers,
         } => {
-            let allowed = match identity {
+            let (allowed, id_status) = match identity {
                 SomeIdentity::Project(proj) => {
                     let delegates = project::delegate_views(storage, proj, Some(remote_peer))?;
                     let allowed = delegates.keys().copied().collect();
@@ -182,7 +208,10 @@ where
                     );
                     let proj = identities::project::verify(storage, &rad_id)?
                         .ok_or(Error::MissingIdentity)?;
-                    let mut setup = project::ensure_setup(
+                    let project::SetupResult {
+                        updated_tips: mut project_tips,
+                        identity: id_status,
+                    } = project::ensure_setup(
                         storage,
                         &mut fetcher,
                         config.fetch_limit,
@@ -190,20 +219,21 @@ where
                         &rad_id,
                         proj,
                     )?;
-                    updated_tips.append(&mut setup.updated_tips);
-                    allowed
+                    updated_tips.append(&mut project_tips);
+                    (allowed, id_status)
                 },
                 SomeIdentity::Person(person) => {
                     let rad_id = unsafe_into_urn(
                         Reference::rad_id(Namespace::from(&person.urn())).with_remote(remote_peer),
                     );
-                    person::ensure_setup(storage, &rad_id, person.clone())?;
-                    person
+                    let id_status = person::ensure_setup(storage, &rad_id, person.clone())?;
+                    let allowed = person
                         .delegations()
                         .iter()
                         .copied()
                         .map(PeerId::from)
-                        .collect()
+                        .collect();
+                    (allowed, id_status)
                 },
             };
 
@@ -215,13 +245,14 @@ where
             Ok::<_, Error>((
                 ReplicateResult {
                     updated_tips,
-                    identity: IdStatus::Even,
+                    identity: id_status,
+                    mode: Mode::Clone,
                 },
                 fetched_peers.difference(&allowed).copied().collect(),
             ))
         },
 
-        Replication::Fetch {
+        ModeInternal::Fetch {
             urn,
             identity,
             existing,
@@ -233,7 +264,10 @@ where
                         .ok_or(Error::MissingIdentity)?;
                     let mut updated_delegations = project::all_delegates(&proj);
                     let rad_id = unsafe_into_urn(Reference::rad_id(Namespace::from(&urn)));
-                    let mut result = project::ensure_setup(
+                    let project::SetupResult {
+                        updated_tips: mut project_tips,
+                        identity: id_status,
+                    } = project::ensure_setup(
                         &storage,
                         &mut fetcher,
                         config.fetch_limit,
@@ -241,7 +275,7 @@ where
                         &rad_id,
                         proj,
                     )?;
-                    updated_tips.append(&mut result.updated_tips);
+                    updated_tips.append(&mut project_tips);
 
                     let mut updated_tracked =
                         tracking::tracked(storage, &urn)?.collect::<BTreeSet<_>>();
@@ -249,18 +283,20 @@ where
                     (
                         ReplicateResult {
                             updated_tips,
-                            identity: result.identity,
+                            identity: id_status,
+                            mode: Mode::Fetch,
                         },
                         updated_tracked,
                     )
                 },
                 SomeIdentity::Person(person) => {
                     let rad_id = unsafe_into_urn(Reference::rad_id(Namespace::from(&person.urn())));
-                    person::ensure_setup(storage, &rad_id, person)?;
+                    let id_status = person::ensure_setup(storage, &rad_id, person)?;
                     (
                         ReplicateResult {
                             updated_tips,
-                            identity: IdStatus::Even,
+                            identity: id_status,
+                            mode: Mode::Fetch,
                         },
                         tracking::tracked(storage, &urn)?.collect::<BTreeSet<_>>(),
                     )
@@ -285,18 +321,6 @@ where
     Ok(result)
 }
 
-enum Replication {
-    Clone {
-        urn: Urn,
-        identity: SomeIdentity,
-        fetched_peers: BTreeSet<PeerId>,
-    },
-    Fetch {
-        urn: Urn,
-        identity: SomeIdentity,
-        existing: BTreeSet<PeerId>,
-    },
-}
 /// Identify the type of replication case we're in -- whether it's a new
 /// identity which we're cloning onto our machine or an existing identity that
 /// we are updating.
@@ -312,13 +336,17 @@ enum Replication {
 /// already know about.
 #[allow(clippy::unit_arg)]
 #[tracing::instrument(skip(storage, fetcher, urn), fields(urn = %urn), err)]
-fn replication(
+fn determine_mode<F>(
     storage: &Storage,
-    fetcher: &mut fetch::DefaultFetcher,
+    fetcher: &mut F,
     limit: fetch::Limit,
     urn: Urn,
     remote_peer: PeerId,
-) -> Result<(BTreeMap<ext::RefLike, ext::Oid>, Replication), Error> {
+) -> Result<(BTreeMap<ext::RefLike, ext::Oid>, ModeInternal), Error>
+where
+    F: fetch::Fetcher<PeerId = PeerId>,
+    F::Error: std::error::Error + Send + Sync + 'static,
+{
     if !storage.has_urn(&urn)? {
         let updated = fetcher
             .fetch(fetch::Fetchspecs::PeekAll { limit })
@@ -338,7 +366,7 @@ fn replication(
             unsafe_into_urn(Reference::rad_id(Namespace::from(&urn)).with_remote(remote_peer));
         Ok((
             tips,
-            Replication::Clone {
+            ModeInternal::Clone {
                 urn,
                 fetched_peers,
                 identity: identities::any::get(storage, &remote_ident)?
@@ -367,7 +395,7 @@ fn replication(
 
         Ok((
             updated_tips,
-            Replication::Fetch {
+            ModeInternal::Fetch {
                 urn,
                 identity,
                 existing,
@@ -380,11 +408,20 @@ fn unsafe_into_urn(reference: Reference<git_ext::RefLike>) -> Urn {
     reference.try_into().expect("namespace is set")
 }
 
-#[allow(clippy::unit_arg)]
+/// Set the `rad/id` ref of `urn` to the given [`ext::Oid`].
+///
+/// No-op if the ref already exists. Returns the [`ext::Oid`] the ref points to
+/// after the operation.
 #[tracing::instrument(level = "trace", skip(storage, urn), fields(urn = %urn), err)]
-fn ensure_rad_id(storage: &Storage, urn: &Urn, tip: ext::Oid) -> Result<(), Error> {
-    identities::common::IdRef::from(urn)
+fn ensure_rad_id(storage: &Storage, urn: &Urn, tip: ext::Oid) -> Result<ext::Oid, Error> {
+    let id_ref = identities::common::IdRef::from(urn);
+    id_ref
         .create(storage, tip)
+        .map_err(|e| Error::Store(e.into()))?;
+
+    id_ref
+        .oid(storage)
+        .map(Into::into)
         .map_err(|e| Error::Store(e.into()))
 }
 
@@ -470,7 +507,11 @@ mod person {
     ///     version
     #[allow(clippy::unit_arg)]
     #[tracing::instrument(level = "trace", skip(storage), err)]
-    pub fn ensure_setup(storage: &Storage, rad_id: &Urn, person: Person) -> Result<(), Error> {
+    pub fn ensure_setup(
+        storage: &Storage,
+        rad_id: &Urn,
+        person: Person,
+    ) -> Result<IdStatus, Error> {
         let local_peer = storage.peer_id();
         let urn = person.urn();
 
@@ -495,46 +536,8 @@ mod person {
                 Ok(delegations)
             },
         }?;
-
-        ensure_no_forking(storage, &rad_id, &delegations)?;
-
         // Create `rad/id` here, if not exists
-        adopt_latest(storage, &person.urn(), delegations)?;
-        Ok(())
-    }
-
-    /// Compare the given `rad_id` of the person against each delegate and
-    /// ensure there are no forks.
-    ///
-    /// # Errors
-    ///   * If there is a fork
-    #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage), err)]
-    pub fn ensure_no_forking(
-        storage: &Storage,
-        rad_id: &Urn,
-        delegates: &BTreeSet<PeerId>,
-    ) -> Result<(), Error> {
-        for delegate in delegates.iter() {
-            let delegate =
-                unsafe_into_urn(Reference::rad_id(Namespace::from(rad_id)).with_remote(*delegate));
-            tracing::debug!(mine = %rad_id, theirs = %delegate, "checking for a fork");
-            match identities::person::is_fork(&storage, &rad_id, &delegate) {
-                Ok(false) => { /* all good */ },
-                Ok(true) => {
-                    return Err(Error::Fork {
-                        mine: rad_id.clone(),
-                        theirs: delegate.clone(),
-                    })
-                },
-                Err(identities::error::Error::NotFound(urn)) => {
-                    tracing::debug!(urn = %urn, "URN not found when checking for fork");
-                },
-                Err(err) => return Err(err.into()),
-            }
-        }
-
-        Ok(())
+        adopt_latest(storage, &person.urn(), delegations)
     }
 
     /// Adopt the `rad/id` that has the most up-to-date commit from the set of
@@ -545,22 +548,45 @@ mod person {
         storage: &Storage,
         urn: &Urn,
         delegates: BTreeSet<PeerId>,
-    ) -> Result<(), Error> {
-        let persons = NonEmpty::from_vec(
-            delegates
-                .into_iter()
-                .flat_map(|peer| {
-                    let urn =
-                        unsafe_into_urn(Reference::rad_id(Namespace::from(urn)).with_remote(peer));
-                    identities::person::get(storage, &urn).ok().flatten()
-                })
-                .collect(),
-        );
-        let tip = match persons {
-            Some(persons) => identities::person::latest_tip(storage, persons).map_err(Error::from),
-            None => Err(Error::MissingIdentities(urn.clone())),
-        }?;
-        ensure_rad_id(storage, urn, tip.into())
+    ) -> Result<IdStatus, Error> {
+        use IdStatus::*;
+
+        let local_peer = storage.peer_id();
+        let delegates: BTreeMap<PeerId, VerifiedPerson> = delegates
+            .into_iter()
+            .map(|peer| {
+                let remote_urn =
+                    unsafe_into_urn(Reference::rad_id(Namespace::from(urn)).with_remote(peer));
+                let verified = identities::person::verify(storage, &remote_urn)?
+                    .ok_or_else(|| Error::MissingIdentities(remote_urn.clone()))?;
+
+                Ok((peer, verified))
+            })
+            .collect::<Result<_, Error>>()?;
+        let latest = {
+            let mut prev = None;
+            for pers in delegates.values().cloned() {
+                match prev {
+                    None => prev = Some(pers),
+                    Some(p) => {
+                        let newer = identities::person::newer(storage, p, pers)?;
+                        prev = Some(newer);
+                    },
+                }
+            }
+            prev.expect("empty delegations")
+        };
+
+        let expected = match delegates.get(local_peer) {
+            Some(ours) => ours.content_id,
+            None => latest.content_id,
+        };
+        let actual = ensure_rad_id(storage, urn, expected)?;
+        if actual == expected {
+            Ok(Even)
+        } else {
+            Ok(Uneven)
+        }
     }
 }
 
@@ -572,6 +598,11 @@ mod project {
         pub urn: Urn,
         pub delegate: VerifiedPerson,
         pub project: VerifiedProject,
+    }
+
+    pub struct SetupResult {
+        pub updated_tips: BTreeMap<ext::RefLike, ext::Oid>,
+        pub identity: IdStatus,
     }
 
     /// Process the setup of a `Project` by:
@@ -586,23 +617,23 @@ mod project {
     ///     version
     #[allow(clippy::unit_arg)]
     #[tracing::instrument(level = "trace", skip(storage, fetcher), err)]
-    pub fn ensure_setup(
+    pub fn ensure_setup<F>(
         storage: &Storage,
-        fetcher: &mut fetch::DefaultFetcher,
+        fetcher: &mut F,
         limit: fetch::Limit,
         delegates: BTreeMap<PeerId, project::DelegateView>,
         rad_id: &Urn,
         proj: VerifiedProject,
-    ) -> Result<ReplicateResult, Error> {
+    ) -> Result<SetupResult, Error>
+    where
+        F: fetch::Fetcher<PeerId = PeerId, UrnId = Revision>,
+        F::Error: std::error::Error + Send + Sync + 'static,
+    {
         let local_peer = storage.peer_id();
-        project::ensure_no_forking(
-            storage,
-            rad_id,
-            delegates.values().map(|view| view.urn.clone()).collect(),
-        )?;
-
         let urn = proj.urn();
-        project::track_direct(storage, &proj)?;
+        let id_status = self::adopt_latest(storage, &urn, &delegates)?;
+
+        self::track_direct(storage, &proj)?;
         let (fetch_result, tracked) = replicate_signed_refs(
             storage,
             fetcher,
@@ -618,30 +649,32 @@ mod project {
                 tracking::track(&storage, &urn, peer)?;
             }
         }
-        let diverging = project::adopt_latest(storage, &urn, delegates)?;
 
-        Ok(ReplicateResult {
+        Ok(SetupResult {
             updated_tips: fetch_result.updated_tips,
-            identity: diverging,
+            identity: id_status,
         })
     }
 
     /// Fetch `rad/signed_refs` and `refs/heads` of the delegates and our
     /// tracked graph, returning the set of tracked peers.
-    #[allow(clippy::unit_arg)]
     #[tracing::instrument(
         level = "trace",
         skip(storage, fetcher, urn),
         fields(urn = %urn),
         err
     )]
-    pub fn replicate_signed_refs(
+    pub fn replicate_signed_refs<F>(
         storage: &Storage,
-        fetcher: &mut fetch::DefaultFetcher,
+        fetcher: &mut F,
         limit: fetch::Limit,
         urn: &Urn,
         delegates: BTreeSet<Urn>,
-    ) -> Result<(fetch::FetchResult, BTreeSet<PeerId>), Error> {
+    ) -> Result<(fetch::FetchResult, BTreeSet<PeerId>), Error>
+    where
+        F: fetch::Fetcher<PeerId = PeerId, UrnId = Revision>,
+        F::Error: std::error::Error + Send + Sync + 'static,
+    {
         // Read `signed_refs` for all tracked
         let tracked = tracking::tracked(storage, &urn)?.collect::<BTreeSet<_>>();
         let tracked_sigrefs = tracked
@@ -672,38 +705,6 @@ mod project {
                 .flat_map(|(peer, refs)| iter::once(*peer).chain(refs.remotes.flatten().copied()))
                 .collect(),
         ))
-    }
-
-    /// Compare the given `rad_id` of the project against each delegate and
-    /// ensure there are no forks.
-    ///
-    /// # Errors
-    ///   * If there is a fork
-    #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage), err)]
-    pub fn ensure_no_forking(
-        storage: &Storage,
-        rad_id: &Urn,
-        delegates: BTreeSet<Urn>,
-    ) -> Result<(), Error> {
-        for delegate in delegates.iter() {
-            tracing::debug!(mine = %rad_id, theirs = %delegate, "checking for a fork");
-            match identities::project::is_fork(&storage, &rad_id, &delegate) {
-                Ok(false) => { /* all good */ },
-                Ok(true) => {
-                    return Err(Error::Fork {
-                        mine: rad_id.clone(),
-                        theirs: delegate.clone(),
-                    })
-                },
-                Err(identities::error::Error::NotFound(urn)) => {
-                    tracing::debug!(urn = %urn, "URN not found when checking for fork");
-                },
-                Err(err) => return Err(err.into()),
-            }
-        }
-
-        Ok(())
     }
 
     /// For each delegate in `remotes/<remote_peer>/rad/ids/*` get the view for
@@ -814,39 +815,34 @@ mod project {
     pub fn adopt_latest(
         storage: &Storage,
         urn: &Urn,
-        delegates: BTreeMap<PeerId, DelegateView>,
+        delegates: &BTreeMap<PeerId, DelegateView>,
     ) -> Result<IdStatus, Error> {
         use IdStatus::*;
 
         let local_peer = storage.peer_id();
-        let projects = NonEmpty::from_vec(
-            delegates
-                .values()
-                .map(|view| view.project.clone().into_inner())
-                .collect::<Vec<_>>(),
-        );
+        let latest = {
+            let mut prev = None;
+            for proj in delegates.values().map(|view| view.project.clone()) {
+                match prev {
+                    None => prev = Some(proj),
+                    Some(p) => {
+                        let newer = identities::project::newer(storage, p, proj)?;
+                        prev = Some(newer);
+                    },
+                }
+            }
+            prev.expect("empty delegations")
+        };
 
-        let tip = match projects {
-            Some(projects) => {
-                identities::project::latest_tip(storage, projects).map_err(Error::from)
-            },
-            None => Err(Error::MissingIdentities(urn.clone())),
-        }?;
-
-        // Are we a delegate?
-        match delegates.get(local_peer) {
-            None => {
-                tracing::debug!(tip = %tip, "adopting latest tip");
-                ensure_rad_id(storage, urn, tip.into())?;
-                Ok(Even)
-            },
-            Some(view) => Ok(if view.project.content_id == tip.into() {
-                tracing::debug!("we are at the latest tip");
-                Even
-            } else {
-                tracing::debug!("we need to update the project");
-                Uneven
-            }),
+        let expected = match delegates.get(local_peer) {
+            Some(ours) => ours.project.content_id,
+            None => latest.content_id,
+        };
+        let actual = ensure_rad_id(storage, urn, expected)?;
+        if actual == expected {
+            Ok(Even)
+        } else {
+            Ok(Uneven)
         }
     }
 

--- a/librad/src/git/replication.rs
+++ b/librad/src/git/replication.rs
@@ -191,6 +191,8 @@ impl Provider<SomeIdentity> {
         })
     }
 
+    // FIXME(finto): the naming is wrong here because we can't verify the project since we haven't
+    // resolved any of the delegates as top-level identities
     pub fn try_verify(
         self,
         storage: &Storage,

--- a/librad/src/git/replication/person.rs
+++ b/librad/src/git/replication/person.rs
@@ -1,0 +1,164 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+
+use crate::git::{
+    fetch,
+    storage::Storage,
+    types::{Namespace, Reference},
+};
+
+use super::*;
+
+use crate::{
+    identities::git::VerifiedPerson,
+    peer::PeerId,
+};
+
+pub struct PersonDelegates(Delegates<BTreeMap<PeerId, VerifiedPerson>>);
+
+impl From<Delegates<BTreeMap<PeerId, VerifiedPerson>>> for PersonDelegates {
+    fn from(delegates: Delegates<BTreeMap<PeerId, VerifiedPerson>>) -> Self {
+        PersonDelegates(delegates)
+    }
+}
+
+pub struct ReplicateResult {
+    delegates: PersonDelegates,
+    tracked: Tracked,
+    identity: IdStatus,
+    mode: Mode,
+}
+
+impl From<ReplicateResult> for super::ReplicateResult {
+    fn from(result: ReplicateResult) -> Self {
+        Self {
+            updated_tips: result.delegates.0.result.updated_tips,
+            identity: result.identity,
+            mode: result.mode,
+        }
+    }
+}
+
+pub fn clone(storage: &Storage, fetcher: &mut fetch::DefaultFetcher, config: Config, provider: Provider<VerifiedPerson>) -> Result<ReplicateResult, Error> {
+    let urn = provider.identity.urn();
+    let delegates = PersonDelegates::from_provider(storage, fetcher, config, provider)?;
+    let tracked = Tracked::new(storage, &urn, delegates.remotes())?;
+    let identity = delegates.adopt(storage, &urn)?;
+
+    Ok(ReplicateResult {
+        delegates,
+        tracked,
+        identity,
+        mode: Mode::Clone,
+    })
+}
+
+pub fn fetch(storage: &Storage, fetcher: &mut fetch::DefaultFetcher, config: Config, urn: &Urn) -> Result<ReplicateResult, Error> {
+    let tracked = Tracked::load(storage, urn)?;
+    let delegates = PersonDelegates::from_local(storage, fetcher, config, urn, tracked)?;
+    let tracked = Tracked::new(storage, &urn, delegates.remotes())?;
+    let identity = delegates.adopt(storage, urn)?;
+
+    Ok(ReplicateResult {
+        delegates,
+        tracked,
+        identity,
+        mode: Mode::Fetch,
+    })
+}
+
+impl PersonDelegates {
+    pub fn from_provider(
+        storage: &Storage,
+        fetcher: &mut fetch::DefaultFetcher,
+        config: Config,
+        proivder: Provider<VerifiedPerson>,
+    ) -> Result<Self, Error> {
+        Self::from_identity(storage, fetcher, config, proivder.identity.clone(), proivder.delegates().collect())
+    }
+
+    pub fn from_local(
+        storage: &Storage,
+        fetcher: &mut fetch::DefaultFetcher,
+        config: Config,
+        urn: &Urn,
+        tracked: Tracked,
+    ) -> Result<Self, Error> {
+        let project = identities::person::verify(storage, urn)?.ok_or(Error::MissingIdentity)?;
+        Self::from_identity(storage, fetcher, config, project, tracked.remotes)
+    }
+
+    pub fn remotes(&'_ self) -> impl Iterator<Item = PeerId> + '_ {
+        self.0.views.keys().copied()
+    }
+
+    pub fn rad_ids(&'_ self) -> impl Iterator<Item = Urn> + '_ {
+        self.0.views.iter().map(|(remote, person)| unsafe_into_urn(Reference::rad_id(Namespace::from(person.urn())).with_remote(*remote)))
+    }
+
+    pub fn adopt(&self, storage: &Storage, urn: &Urn) -> Result<IdStatus, Error> {
+        use IdStatus::*;
+
+        let local = storage.peer_id();
+        let latest = {
+            let mut prev = None;
+            for delegate in self.0.views.values().cloned() {
+                match prev {
+                    None => prev = Some(delegate),
+                    Some(p) => {
+                        let newer = identities::person::newer(storage, p, delegate)?;
+                        prev = Some(newer);
+                    },
+                }
+            }
+            prev.expect("empty delegations")
+        };
+
+        let expected = match self.0.views.get(local) {
+            Some(ours) => ours.content_id,
+            None => latest.content_id,
+        };
+        let actual = ensure_rad_id(storage, urn, expected)?;
+        if actual == expected {
+            Ok(Even)
+        } else {
+            Ok(Uneven)
+        }
+    }
+
+    fn from_identity(
+        storage: &Storage,
+        fetcher: &mut fetch::DefaultFetcher,
+        config: Config,
+        person: VerifiedPerson,
+        remotes: BTreeSet<PeerId>,
+    ) -> Result<Self, Error> {
+        let mut delegates = BTreeMap::new();
+        let urn = person.urn();
+
+        let peeked = fetcher
+            .fetch(fetch::Fetchspecs::Peek {
+                remotes: remotes.clone(),
+                limit: config.fetch_limit,
+            })
+            .map_err(|e| Error::Fetch(e.into()))?;
+
+        for key in person.delegations().into_iter() {
+            let remote = PeerId::from(*key);
+            let rad_id = unsafe_into_urn(Reference::rad_id(Namespace::from(&urn)).with_remote(remote));
+            let delegate = identities::person::verify(storage, &rad_id)?.ok_or(Error::MissingIdentity)?;
+            delegates.insert(remote, delegate);
+        }
+
+        Ok(Delegates {
+            result: peeked,
+            fetched: remotes,
+            views: delegates,
+        }.into())
+    }
+}

--- a/librad/src/git/replication/person.rs
+++ b/librad/src/git/replication/person.rs
@@ -5,7 +5,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-
 use crate::git::{
     fetch,
     storage::Storage,
@@ -14,10 +13,7 @@ use crate::git::{
 
 use super::*;
 
-use crate::{
-    identities::git::VerifiedPerson,
-    peer::PeerId,
-};
+use crate::{identities::git::VerifiedPerson, peer::PeerId};
 
 pub struct PersonDelegates(Delegates<BTreeMap<PeerId, VerifiedPerson>>);
 
@@ -44,7 +40,12 @@ impl From<ReplicateResult> for super::ReplicateResult {
     }
 }
 
-pub fn clone(storage: &Storage, fetcher: &mut fetch::DefaultFetcher, config: Config, provider: Provider<VerifiedPerson>) -> Result<ReplicateResult, Error> {
+pub fn clone(
+    storage: &Storage,
+    fetcher: &mut fetch::DefaultFetcher,
+    config: Config,
+    provider: Provider<VerifiedPerson>,
+) -> Result<ReplicateResult, Error> {
     let urn = provider.identity.urn();
     let delegates = PersonDelegates::from_provider(storage, fetcher, config, provider)?;
     let tracked = Tracked::new(storage, &urn, delegates.remotes())?;
@@ -58,7 +59,12 @@ pub fn clone(storage: &Storage, fetcher: &mut fetch::DefaultFetcher, config: Con
     })
 }
 
-pub fn fetch(storage: &Storage, fetcher: &mut fetch::DefaultFetcher, config: Config, urn: &Urn) -> Result<ReplicateResult, Error> {
+pub fn fetch(
+    storage: &Storage,
+    fetcher: &mut fetch::DefaultFetcher,
+    config: Config,
+    urn: &Urn,
+) -> Result<ReplicateResult, Error> {
     let tracked = Tracked::load(storage, urn)?;
     let delegates = PersonDelegates::from_local(storage, fetcher, config, urn, tracked)?;
     let tracked = Tracked::new(storage, &urn, delegates.remotes())?;
@@ -79,7 +85,13 @@ impl PersonDelegates {
         config: Config,
         proivder: Provider<VerifiedPerson>,
     ) -> Result<Self, Error> {
-        Self::from_identity(storage, fetcher, config, proivder.identity.clone(), proivder.delegates().collect())
+        Self::from_identity(
+            storage,
+            fetcher,
+            config,
+            proivder.identity.clone(),
+            proivder.delegates().collect(),
+        )
     }
 
     pub fn from_local(
@@ -98,7 +110,9 @@ impl PersonDelegates {
     }
 
     pub fn rad_ids(&'_ self) -> impl Iterator<Item = Urn> + '_ {
-        self.0.views.iter().map(|(remote, person)| unsafe_into_urn(Reference::rad_id(Namespace::from(person.urn())).with_remote(*remote)))
+        self.0.views.iter().map(|(remote, person)| {
+            unsafe_into_urn(Reference::rad_id(Namespace::from(person.urn())).with_remote(*remote))
+        })
     }
 
     pub fn adopt(&self, storage: &Storage, urn: &Urn) -> Result<IdStatus, Error> {
@@ -150,8 +164,10 @@ impl PersonDelegates {
 
         for key in person.delegations().into_iter() {
             let remote = PeerId::from(*key);
-            let rad_id = unsafe_into_urn(Reference::rad_id(Namespace::from(&urn)).with_remote(remote));
-            let delegate = identities::person::verify(storage, &rad_id)?.ok_or(Error::MissingIdentity)?;
+            let rad_id =
+                unsafe_into_urn(Reference::rad_id(Namespace::from(&urn)).with_remote(remote));
+            let delegate =
+                identities::person::verify(storage, &rad_id)?.ok_or(Error::MissingIdentity)?;
             delegates.insert(remote, delegate);
         }
 
@@ -159,6 +175,7 @@ impl PersonDelegates {
             result: peeked,
             fetched: remotes,
             views: delegates,
-        }.into())
+        }
+        .into())
     }
 }

--- a/librad/src/git/replication/person.rs
+++ b/librad/src/git/replication/person.rs
@@ -23,9 +23,11 @@ impl From<Delegates<BTreeMap<PeerId, VerifiedPerson>>> for PersonDelegates {
     }
 }
 
-/// Clone the [`Person`] from the `provider` by fetching the delegates in the document.
+/// Clone the [`Person`] from the `provider` by fetching the delegates in the
+/// document.
 ///
-/// We track all the delegates in the document and adopt the `rad/id` for this identity.
+/// We track all the delegates in the document and adopt the `rad/id` for this
+/// identity.
 pub fn clone(
     storage: &Storage,
     fetcher: &mut fetch::DefaultFetcher,
@@ -189,12 +191,16 @@ impl PersonDelegates {
             delegates.insert(remote, delegate);
         }
 
-        Ok(Delegates {
-            result: peeked,
-            fetched: remotes,
-            views: delegates,
+        if delegates.is_empty() {
+            Err(Error::NoTrustee)
+        } else {
+            Ok(Delegates {
+                result: peeked,
+                fetched: remotes,
+                views: delegates,
+            }
+            .into())
         }
-        .into())
     }
 
     fn updates(&self) -> BTreeSet<PeerId> {

--- a/librad/src/git/replication/person.rs
+++ b/librad/src/git/replication/person.rs
@@ -46,7 +46,13 @@ pub fn clone(
         Pruned::empty()
     };
 
-    Ok(mk_replicate_result(delegates, tracked, pruned, identity, Mode::Clone))
+    Ok(mk_replicate_result(
+        delegates,
+        tracked,
+        pruned,
+        identity,
+        Mode::Clone,
+    ))
 }
 
 /// Fetch the latest changes for the remotes that we are tracking for `urn`.
@@ -70,7 +76,13 @@ pub fn fetch(
     let identity = delegates.adopt(storage, urn)?;
     let pruned = Pruned::new(storage, urn, previous.removed(&tracked).into_iter())?;
 
-    Ok(mk_replicate_result(delegates, tracked, pruned, identity, Mode::Fetch))
+    Ok(mk_replicate_result(
+        delegates,
+        tracked,
+        pruned,
+        identity,
+        Mode::Fetch,
+    ))
 }
 
 #[tracing::instrument(skip(delegates, tracked, pruned))]

--- a/librad/src/git/replication/project.rs
+++ b/librad/src/git/replication/project.rs
@@ -83,8 +83,8 @@ pub fn fetch(
     urn: &Urn,
 ) -> Result<ReplicateResult, Error> {
     let previous = Tracked::load(storage, urn)?;
-    let delegates =
-        ProjectDelegates::from_local(storage, fetcher, config, urn, previous.clone())?.verify(storage)?;
+    let delegates = ProjectDelegates::from_local(storage, fetcher, config, urn, previous.clone())?
+        .verify(storage)?;
     let tracked = Tracked::new(storage, &urn, delegates.remotes())?;
     let signed_refs = SignedRefs::fetch(storage, fetcher, config, &urn, &delegates, &tracked)?;
     let identity = delegates.adopt(storage, urn)?;
@@ -114,7 +114,7 @@ fn mk_replicate_result(
 
     let sigref_tips = signed_refs.result.updated_tips;
     tracing::debug!(tips = ?sigref_tips, "tips for rad/signed_refs");
-    tracing::debug!(tracked = ?signed_refs.tracked.trace(), "tracked peers");
+    tracing::debug!(tracked = ?signed_refs.tracked.trace(), "tracked peers from signed refs");
     updated_tips.extend(sigref_tips);
 
     tracing::debug!(tracked = ?tracked.trace(), "tracked peers");

--- a/librad/src/git/replication/project.rs
+++ b/librad/src/git/replication/project.rs
@@ -1,0 +1,405 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    iter,
+};
+
+use either::Either;
+
+use crate::git::{
+    fetch,
+    refs::Refs,
+    storage::Storage,
+    types::{Namespace, Reference},
+};
+
+use super::*;
+
+use crate::{
+    identities::git::{Project, VerifiedPerson, VerifiedProject},
+    peer::PeerId,
+};
+
+pub struct ProjectDelegates<P>(Delegates<Vec<DelegateView<P>>>);
+
+impl<P> From<Delegates<Vec<DelegateView<P>>>> for ProjectDelegates<P> {
+    fn from(delegates: Delegates<Vec<DelegateView<P>>>) -> Self {
+        ProjectDelegates(delegates)
+    }
+}
+
+pub struct ReplicateResult {
+    delegates: ProjectDelegates<VerifiedProject>,
+    tracked: Tracked,
+    signed_refs: SignedRefs,
+    identity: IdStatus,
+    mode: Mode,
+}
+
+impl From<ReplicateResult> for super::ReplicateResult {
+    fn from(result: ReplicateResult) -> Self {
+        let mut tips = result.delegates.0.result.updated_tips;
+        tips.extend(result.signed_refs.result.updated_tips);
+        Self {
+            updated_tips: tips,
+            identity: result.identity,
+            mode: result.mode,
+        }
+    }
+}
+
+pub fn clone(storage: &Storage, fetcher: &mut fetch::DefaultFetcher, config: Config, provider: Provider<Project>) -> Result<ReplicateResult, Error> {
+    let urn = provider.identity.urn();
+    let delegates = ProjectDelegates::from_provider(storage, fetcher, config, provider)?;
+    let delegates = delegates.verify(storage, &urn)?;
+    let tracked = Tracked::new(storage, &urn, delegates.remotes())?;
+    let signed_refs = SignedRefs::new(storage, fetcher, config, &urn, &delegates, &tracked)?;
+    let identity = delegates.adopt(storage, &urn)?;
+
+    Ok(ReplicateResult {
+        delegates,
+        tracked,
+        signed_refs,
+        identity,
+        mode: Mode::Clone,
+    })
+}
+
+pub fn fetch(storage: &Storage, fetcher: &mut fetch::DefaultFetcher, config: Config, urn: &Urn) -> Result<ReplicateResult, Error> {
+    let tracked = Tracked::load(storage, urn)?;
+    let delegates = ProjectDelegates::from_local(storage, fetcher, config, urn, tracked)?.verify(storage, urn)?;
+    let tracked = Tracked::new(storage, &urn, delegates.remotes())?;
+    let signed_refs = SignedRefs::new(storage, fetcher, config, &urn, &delegates, &tracked)?;
+    let identity = delegates.adopt(storage, urn)?;
+
+    Ok(ReplicateResult {
+        delegates,
+        tracked,
+        signed_refs,
+        identity,
+        mode: Mode::Fetch,
+    })
+}
+
+/* FIXME: turn this into docs
+ * What do I want to do here?
+ *
+ * clone: We have looked at the rad/ids from the provider and so we can determine who the delegates
+ * are and we fetch those remotes.
+ * But we _should_ have at least one project view for each delegate. If it's anonymous then we
+ * expect there to one and only one remote entry for them. If it's a Person delegation we can have
+ * one or more remote entries.
+ */
+#[derive(Clone)]
+pub enum DelegateView<P> {
+    Direct {
+        remote: PeerId,
+        project: P,
+    },
+    Indirect {
+        person: VerifiedPerson,
+        projects: BTreeMap<PeerId, P>,
+        remotes: BTreeSet<PeerId>,
+    }
+}
+
+impl<P> DelegateView<P> {
+    pub fn views(&'_ self) -> impl Iterator<Item = (PeerId, P)> + '_ where P: Clone {
+        match self {
+            Self::Direct { remote, project } => Either::Left(iter::once((*remote, project.clone()))),
+            Self::Indirect { projects, .. } => Either::Right(projects.iter().map(|(remote, project)| (*remote, project.clone()))),
+        }
+    }
+}
+
+impl DelegateView<Project> {
+    pub fn direct(storage: &Storage, urn: &Urn, remote: PeerId) -> Result<Self, Error> {
+        let urn = unsafe_into_urn(Reference::rad_id(Namespace::from(urn)).with_remote(remote));
+        let project = identities::project::get(storage, &urn)?.ok_or(Error::MissingIdentity)?;
+        Ok(DelegateView::Direct {
+            remote,
+            project,
+        })
+    }
+
+    pub fn indirect<P>(storage: &Storage, urn: &Urn, delegate: &Urn, who: P) -> Result<Self, Error> 
+    where P: Into<Option<PeerId>>,
+    {
+        let who = who.into();
+        let local = storage.peer_id();
+        let in_rad_ids = unsafe_into_urn(Reference::rad_delegate(Namespace::from(urn), delegate).with_remote(who));
+        let mut projects = BTreeMap::new();
+        let mut remotes = BTreeSet::new();
+        let person = identities::person::verify(storage, &in_rad_ids)?.ok_or(Error::MissingIdentity)?;
+        for key in person.delegations().iter() {
+            let remote = PeerId::from(*key);
+            remotes.insert(remote);
+            let project = if &remote == local {
+                identities::project::get(storage, urn)?.ok_or(Error::MissingIdentity)?
+            } else {
+                let urn = unsafe_into_urn(
+                    Reference::rad_id(Namespace::from(urn))
+                        .with_remote(remote),
+                );
+                identities::project::get(storage, &urn)?.ok_or(Error::MissingIdentity)?
+            };
+            projects.insert(remote, project);
+        }
+
+        Ok(Self::Indirect {
+            person,
+            projects,
+            remotes,
+        })
+    }
+
+    pub fn verify(self, storage: &Storage, urn: &Urn) -> Result<DelegateView<VerifiedProject>, Error> {
+        self.adopt_direct(storage, urn)?;
+        match self {
+            DelegateView::Direct { remote, project } => {
+                let urn = unsafe_into_urn(Reference::rad_id(Namespace::from(&project.urn())).with_remote(remote));
+                let project = identities::project::verify(storage, &urn)?.ok_or(Error::MissingIdentity)?;
+                Ok(DelegateView::Direct {
+                    remote,
+                    project,
+                })
+            },
+            DelegateView::Indirect { person, projects, remotes } => {
+                let projects = projects.into_iter().map(|(remote, project)| {
+                    let urn = unsafe_into_urn(
+                        Reference::rad_id(Namespace::from(&project.urn()))
+                            .with_remote(remote),
+                    );
+                    identities::project::verify(storage, &urn).map_err(Error::from).and_then(|project| project.ok_or(Error::MissingIdentity).map(|project| (remote, project)))
+                }).collect::<Result<_, _>>()?;
+                Ok(DelegateView::Indirect { person, projects, remotes })
+            },
+        }
+    }
+
+    pub fn adopt_direct(&self, storage: &Storage, project_urn: &Urn) -> Result<Tracked, Error> {
+        match self {
+            Self::Direct { remote, project } => Tracked::new(storage, &project.urn(), Some(*remote).into_iter()),
+            Self::Indirect { person, remotes, .. } => {
+                let urn = person.urn();
+                let tracked = Tracked::new(storage, &urn, remotes.iter().cloned())?;
+
+                ensure_rad_id(storage, &urn, person.content_id)?;
+                // Now point our view to the top-level
+                Reference::try_from(&urn)
+                    .map_err(|e| Error::RefFromUrn {
+                        urn: urn.clone(),
+                        source: e,
+                    })?
+                    .symbolic_ref::<_, PeerId>(
+                        Reference::rad_delegate(Namespace::from(project_urn), &urn),
+                        Force::False,
+                    )
+                    .create(storage.as_raw())
+                    .and(Ok(()))
+                    .or_matches(is_exists_err, || Ok(()))
+                    .map_err(|e: git2::Error| Error::Store(e.into()))?;
+
+                Ok(tracked)
+            }
+        }
+    }
+}
+
+pub struct SignedRefs {
+    result: fetch::FetchResult,
+    tracked: Tracked,
+}
+
+impl<P> ProjectDelegates<P> {
+    pub fn remotes(&'_ self) -> impl Iterator<Item = PeerId> + '_ {
+        self.0.views.iter().flat_map(|view| match view {
+            DelegateView::Direct { remote, .. } => Either::Left(iter::once(*remote)),
+            DelegateView::Indirect { remotes, ..} => Either::Right(remotes.iter().copied()),
+        })
+    }
+
+}
+
+impl ProjectDelegates<VerifiedProject> {
+    pub fn rad_ids(&'_ self) -> impl Iterator<Item = Urn> + '_ {
+        self.0.views.iter().flat_map(|view| match view {
+            DelegateView::Direct { remote, project } => Either::Left(iter::once(unsafe_into_urn(Reference::rad_id(Namespace::from(project.urn())).with_remote(*remote)))),
+            DelegateView::Indirect { projects, .. } => Either::Right(projects.into_iter().map(|(remote, project)| unsafe_into_urn(Reference::rad_id(Namespace::from(project.urn())).with_remote(*remote)))),
+        })
+    }
+
+    pub fn adopt(&self, storage: &Storage, urn: &Urn) -> Result<IdStatus, Error> {
+        use IdStatus::*;
+
+        let local = storage.peer_id();
+        let mut ours = None;
+        let latest = {
+            let mut prev = None;
+            for (remote, proj) in self.0.views.iter().cloned().flat_map(|view| view.views().collect::<Vec<_>>().into_iter()) {
+                if remote == *local {
+                    ours = Some(proj.clone());
+                }
+                match prev {
+                    None => prev = Some(proj),
+                    Some(p) => {
+                        let newer = identities::project::newer(storage, p, proj)?;
+                        prev = Some(newer);
+                    },
+                }
+            }
+            prev.expect("empty delegations")
+        };
+
+        let expected = match ours {
+            Some(ours) => ours.content_id,
+            None => latest.content_id,
+        };
+        let actual = ensure_rad_id(storage, urn, expected)?;
+        if actual == expected {
+            Ok(Even)
+        } else {
+            Ok(Uneven)
+        }
+    }
+
+}
+
+impl ProjectDelegates<Project> {
+    pub fn from_provider(
+        storage: &Storage,
+        fetcher: &mut fetch::DefaultFetcher,
+        config: Config,
+        proivder: Provider<Project>,
+    ) -> Result<Self, Error> {
+        Self::from_identity(storage, fetcher, config, proivder.identity.clone(), proivder.delegates().collect(), proivder.provider)
+    }
+
+    pub fn from_local(
+        storage: &Storage,
+        fetcher: &mut fetch::DefaultFetcher,
+        config: Config,
+        urn: &Urn,
+        tracked: Tracked,
+    ) -> Result<Self, Error> {
+        let project = identities::project::get(storage, urn)?.ok_or(Error::MissingIdentity)?;
+        Self::from_identity(storage, fetcher, config, project, tracked.remotes, None)
+    }
+
+    pub fn verify(self, storage: &Storage, urn: &Urn) -> Result<ProjectDelegates<VerifiedProject>,Error> {
+        let ProjectDelegates(Delegates { result, fetched, views }) = self;
+        let views = views.into_iter().map(|view| view.verify(storage, urn)).collect::<Result<_, _>>()?;
+        Ok(ProjectDelegates(Delegates { result, fetched, views }))
+    }
+
+    pub fn rad_ids(&'_ self) -> impl Iterator<Item = Urn> + '_ {
+        self.0.views.iter().flat_map(|view| match view {
+            DelegateView::Direct { remote, project } => Either::Left(iter::once(unsafe_into_urn(Reference::rad_id(Namespace::from(project.urn())).with_remote(*remote)))),
+            DelegateView::Indirect { projects, .. } => Either::Right(projects.into_iter().map(|(remote, project)| unsafe_into_urn(Reference::rad_id(Namespace::from(project.urn())).with_remote(*remote)))),
+        })
+    }
+
+    #[allow(clippy::unit_arg)]
+    #[tracing::instrument(skip(storage, fetcher, project, remotes, who), fields(project.urn = %project.urn()), err)]
+    fn from_identity<P>(
+        storage: &Storage,
+        fetcher: &mut fetch::DefaultFetcher,
+        config: Config,
+        project: Project,
+        remotes: BTreeSet<PeerId>,
+        who: P,
+    ) -> Result<Self, Error> 
+    where P: Into<Option<PeerId>> + Clone
+    {
+        let mut delegates = vec![];
+        // FIXME: actually why do I want this?
+        let mut delegate_remotes = BTreeSet::new();
+        let urn = project.urn();
+
+        tracing::debug!(remotes = ?remotes, "peeking remotes");
+        let peeked = fetcher
+            .fetch(fetch::Fetchspecs::Peek {
+                remotes,
+                limit: config.fetch_limit,
+            })
+            .map_err(|e| Error::Fetch(e.into()))?;
+        tracing::debug!(tips = ?peeked.updated_tips);
+
+        for delegate in project.delegations().into_iter() {
+            match delegate {
+                Either::Left(key) => {
+                    let remote = PeerId::from(*key);
+                    delegate_remotes.insert(remote);
+                    delegates.push(DelegateView::direct(storage, &urn, remote)?);
+                },
+                Either::Right(person) => {
+                    let indirect = DelegateView::indirect(storage, &urn, &person.urn(), who.clone())?;
+                    match &indirect {
+                        DelegateView::Indirect { remotes: indirect_remotes, .. } => delegate_remotes.extend(indirect_remotes),
+                        _ => unreachable!(),
+                    }
+                    delegates.push(indirect);
+                },
+            }
+        }
+
+        Ok(Delegates {
+            result: peeked,
+            fetched: delegate_remotes,
+            views: delegates,
+        }.into())
+    }
+}
+
+impl SignedRefs {
+    pub fn new(
+        storage: &Storage,
+        fetcher: &mut fetch::DefaultFetcher,
+        config: Config,
+        urn: &Urn,
+        delegates: &ProjectDelegates<VerifiedProject>,
+        tracked: &Tracked,
+    ) -> Result<Self, Error> {
+        // Read `signed_refs` for all tracked
+        let tracked_sigrefs = tracked
+            .remotes
+            .iter()
+            .copied()
+            .filter_map(|peer| match Refs::load(storage, &urn, peer) {
+                Ok(Some(refs)) => Some(Ok((peer, refs))),
+
+                Ok(None) => None,
+                Err(e) => Some(Err(e)),
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+        // Fetch all the rest
+        let delegates = delegates.rad_ids().collect();
+        tracing::debug!("fetching heads: {:?}, {:?}", tracked_sigrefs, delegates);
+        let result = fetcher
+            .fetch(fetch::Fetchspecs::Replicate {
+                tracked_sigrefs: tracked_sigrefs.clone(),
+                delegates,
+                limit: config.fetch_limit,
+            })
+            .map_err(|e| Error::Fetch(e.into()))?;
+
+        Refs::update(storage, &urn)?;
+        // TODO(finto): Verify we got what we asked for
+        Ok(SignedRefs {
+            result,
+            tracked: Tracked {
+                remotes: tracked_sigrefs
+                    .iter()
+                    .flat_map(|(peer, refs)| {
+                        iter::once(*peer).chain(refs.remotes.flatten().copied())
+                    })
+                    .collect(),
+            },
+        })
+    }
+}

--- a/librad/src/git/types/reference.rs
+++ b/librad/src/git/types/reference.rs
@@ -166,6 +166,16 @@ impl<N, R> Reference<N, R, One> {
         repo.find_reference(&self.to_string())
     }
 
+    /// Resolve the [`git2::Oid`] the reference points to (if it exists).
+    ///
+    /// Avoids allocating a [`git2::Reference`].
+    pub fn oid(&self, repo: &git2::Repository) -> Result<git2::Oid, git2::Error>
+    where
+        Self: ToString,
+    {
+        repo.refname_to_id(&self.to_string())
+    }
+
     pub fn create<'a>(
         &self,
         repo: &'a git2::Repository,

--- a/librad/src/identities/git.rs
+++ b/librad/src/identities/git.rs
@@ -62,13 +62,6 @@ pub enum SomeIdentity {
 }
 
 impl SomeIdentity {
-    pub fn urn(&self) -> Urn {
-        match self {
-            Self::Person(person) => person.urn(),
-            Self::Project(project) => project.urn(),
-        }
-    }
-
     pub fn person(self) -> Option<Person> {
         match self {
             Self::Person(person) => Some(person),

--- a/librad/src/identities/git.rs
+++ b/librad/src/identities/git.rs
@@ -62,6 +62,13 @@ pub enum SomeIdentity {
 }
 
 impl SomeIdentity {
+    pub fn urn(&self) -> Urn {
+        match self {
+            Self::Person(person) => person.urn(),
+            Self::Project(project) => project.urn(),
+        }
+    }
+
     pub fn person(self) -> Option<Person> {
         match self {
             Self::Person(person) => Some(person),

--- a/librad/src/identities/git/error.rs
+++ b/librad/src/identities/git/error.rs
@@ -154,3 +154,16 @@ pub enum Verify {
     #[error(transparent)]
     Person(#[from] VerifyPerson),
 }
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum History<T: Debug> {
+    #[error("unrelated histories")]
+    Fork {
+        left: super::VerifiedIdentity<T>,
+        right: super::VerifiedIdentity<T>,
+    },
+
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+}

--- a/librad/src/identities/git/tests/common.rs
+++ b/librad/src/identities/git/tests/common.rs
@@ -74,6 +74,10 @@ impl<'a> Device<'a> {
         })
     }
 
+    pub fn git<T>(&'a self) -> Identities<'a, T> {
+        self.git.coerce()
+    }
+
     pub fn current(&self) -> &Person {
         &self.cur
     }
@@ -166,15 +170,13 @@ impl<'a> Project<'a> {
         Ok(Self { dev, cur })
     }
 
-    pub fn change_description(self) -> anyhow::Result<Self> {
+    pub fn change_description(self, descr: &str) -> anyhow::Result<Self> {
         let cur = self.dev.git.as_project().update(
             Verifying::from(self.cur.clone()).signed()?,
             Some(
                 payload::Project {
                     name: self.cur.subject().name.clone(),
-                    description: Some(
-                        "The Most Functional Software Project In The Universe".into(),
-                    ),
+                    description: Some(descr.into()),
                     default_branch: self.cur.subject().default_branch.clone(),
                 }
                 .into(),
@@ -252,21 +254,6 @@ impl<'a> Project<'a> {
             )
         );
 
-        Ok(())
-    }
-
-    pub fn assert_forks(
-        &self,
-        mine: &VerifiedProject,
-        theirs: &VerifiedProject,
-    ) -> anyhow::Result<()> {
-        let is_fork = self.dev.git.as_verified_project().is_fork(&mine, &theirs)?;
-        anyhow::ensure!(
-            is_fork,
-            anyhow!(
-            "the projects were expected to be in a forked state but their histories are in sync"
-        )
-        );
         Ok(())
     }
 }


### PR DESCRIPTION
Stacked on top of https://github.com/radicle-dev/radicle-link/pull/560 but is also up-to-date with `master` because I did some rebasing, hence the other commits.

Splitting the replication logic into two file modules:
* project
* person

The aim is to witness the computations in a type-driven fashion.  I'll try to give a breakdown of what's here so far for some early feedback.

The first thing was to split the two scenarios of:
a. the entity doesn't exist in our monorepo
b. the entity does exist

In `a.` we are relying on the provider we are fetching from to give us their representation of the identity. We `Peek` at their refs, determine the identity type, and `clone`. 
For the case of the project, using what we got from the provider we can calculate the set of delegate `PeerId`s we want to fetch from the provider and build up a view of all the delegates. We can proceed to do the dance of verifying, tracking, fetching signed refs, adopting the latest tip.
For the case of the `person`, it's a lot simpler because we don't need to dance with `rad/ids` when verifying.

In `b.` we can rely on our own representation of the identity. This means we can fetch everything based on our tracking graph and do the verification dance.

There are still some things I need to clean up:
- [x] There's no pruning done, just a `Pruned` type that isn't used
- [x] It should be the case that when we build up our delegate views that we can account for each delegate, i.e. for every anonymous peer we should have one remote entry, and for every indirect person, we should have _at least_ one remote from their set of keys.
- [x] Trace the tips, tracked peers, etc.
- [x] Probably some more wrangling of types