### PR TITLE
storage: check for tags in has_commit

### DIFF
--- a/librad/src/net/peer/storage.rs
+++ b/librad/src/net/peer/storage.rs
@@ -52,7 +52,7 @@ impl Storage {
 
         spawn_blocking(move || {
             if let Some(head) = head {
-                if git.has_commit(&urn, head)? {
+                if git.has_commit(&urn, head)? || git.has_tag(&urn, head)? {
                     return Err(Error::KnownObject(*head));
                 }
             }
@@ -81,7 +81,10 @@ impl Storage {
         let head = head.into().map(ext::Oid::from);
         spawn_blocking(move || match head {
             None => git.has_urn(&urn).unwrap_or(false),
-            Some(head) => git.has_commit(&urn, head).unwrap_or(false),
+            Some(head) => {
+                git.has_commit(&urn, head).unwrap_or(false)
+                    || git.has_tag(&urn, head).unwrap_or(false)
+            },
         })
         .await
         .expect("`Storage::git_has` panicked")

--- a/librad/tests/smoke/gossip.rs
+++ b/librad/tests/smoke/gossip.rs
@@ -56,6 +56,7 @@ async fn fetches_on_gossip_notify() {
         proj.pull(&peer1, &peer2).await.ok().unwrap();
 
         let TestProject { project, owner: _ } = proj;
+        let peer1_events = peer2.subscribe();
         let peer2_events = peer2.subscribe();
 
         let mastor = reflike!("refs/heads/master");
@@ -114,6 +115,15 @@ async fn fetches_on_gossip_notify() {
         // Wait for peer2 to receive the gossip announcement
         event::upstream::expect(
             peer2_events.boxed(),
+            gossip_from(peer1.peer_id()),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        // Does peer2 forward the gossip?
+        event::upstream::expect(
+            peer1_events.boxed(),
             gossip_from(peer1.peer_id()),
             Duration::from_secs(5),
         )


### PR DESCRIPTION
The use of `find_commit` meant that we were ignoring tag objects. This
patch uses `find_object` instead to check if we have `Commit` or `Tag`
and then confirms if the SHA is in the given reference.

We extend the gossip test to see if the gossip of the tag gets propagated
back to `peer1`.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>