### PR TITLE
net: advance membership on connection errors

### DIFF
--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -16,7 +16,7 @@ use std::{
 use futures::{
     channel::mpsc,
     future::{BoxFuture, FutureExt as _, TryFutureExt as _},
-    stream::{BoxStream, StreamExt as _},
+    stream::StreamExt as _,
 };
 use governor::{Quota, RateLimiter};
 use nonzero_ext::nonzero;
@@ -79,7 +79,7 @@ pub struct Config {
 pub struct Bound<S> {
     phone: TinCans,
     state: State<S>,
-    incoming: BoxStream<'static, quic::Result<(quic::Connection, quic::IncomingStreams<'static>)>>,
+    incoming: quic::IncomingConnections<'static>,
     periodic: mpsc::Receiver<membership::Periodic<SocketAddr>>,
 }
 

--- a/librad/src/net/protocol/io/recv.rs
+++ b/librad/src/net/protocol/io/recv.rs
@@ -7,4 +7,4 @@ mod gossip;
 pub(in crate::net::protocol) use gossip::gossip;
 
 mod membership;
-pub(in crate::net::protocol) use membership::membership;
+pub(in crate::net::protocol) use membership::{connection_lost, membership};

--- a/librad/src/net/protocol/membership/hpv.rs
+++ b/librad/src/net/protocol/membership/hpv.rs
@@ -302,17 +302,19 @@ where
         use Tick::*;
 
         tracing::debug!("connection lost");
-        let mut tnt = self
-            .view
-            .demote(&remote_peer)
-            .into_iter()
-            .collect::<TnT<_>>();
-        tnt.extend(
-            self.choose_passive_to_promote()
-                .into_iter()
-                .map(|to| Connect { to }),
-        );
-        tnt
+        let demoted = self.view.demote(&remote_peer);
+        if demoted.is_empty() {
+            TnT::default()
+        } else {
+            TnT {
+                trans: demoted,
+                ticks: self
+                    .choose_passive_to_promote()
+                    .into_iter()
+                    .map(|to| Connect { to })
+                    .collect(),
+            }
+        }
     }
 
     pub fn connection_established(&mut self, info: PartialPeerInfo<Addr>) -> TnT<Addr> {

--- a/librad/src/net/quic.rs
+++ b/librad/src/net/quic.rs
@@ -6,10 +6,10 @@
 use std::time::Duration;
 
 mod connection;
-pub use connection::{Connection, ConnectionId, Conntrack, IncomingStreams};
+pub use connection::{BoxedIncomingStreams, Connection, ConnectionId, Conntrack, IncomingStreams};
 
 mod endpoint;
-pub use endpoint::{BoundEndpoint, Endpoint};
+pub use endpoint::{BoundEndpoint, Endpoint, IncomingConnections};
 
 pub mod error;
 pub use error::{Error, Result};

--- a/librad/src/net/quic/connection.rs
+++ b/librad/src/net/quic/connection.rs
@@ -3,9 +3,15 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::{io, net::SocketAddr};
+use std::{
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use futures::stream::{BoxStream, TryStreamExt as _};
+use either::Either;
+use futures::stream::{self, BoxStream, Stream, StreamExt as _, TryStreamExt as _};
 use quinn::NewConnection;
 
 use super::{BidiStream, Error, RecvStream, Result, SendStream};
@@ -17,9 +23,93 @@ use crate::{
 mod tracking;
 pub use tracking::Conntrack;
 
-pub struct IncomingStreams<'a> {
-    pub bidi: BoxStream<'a, Result<BidiStream>>,
-    pub uni: BoxStream<'a, Result<RecvStream>>,
+pub type BoxedIncomingStreams<'a> =
+    IncomingStreams<BoxStream<'a, Result<Either<BidiStream, RecvStream>>>>;
+
+pub struct IncomingStreams<S> {
+    conn: Connection,
+    inner: S,
+}
+
+impl<'a, S> IncomingStreams<S>
+where
+    S: Stream<Item = Result<Either<BidiStream, RecvStream>>> + Send + 'a,
+{
+    pub fn boxed(self) -> BoxedIncomingStreams<'a> {
+        IncomingStreams {
+            conn: self.conn,
+            inner: Box::pin(self.inner),
+        }
+    }
+}
+
+fn incoming_streams(
+    conn: Connection,
+    bi_streams: quinn::IncomingBiStreams,
+    uni_streams: quinn::IncomingUniStreams,
+) -> IncomingStreams<impl Stream<Item = Result<Either<BidiStream, RecvStream>>>> {
+    use Either::{Left, Right};
+
+    let conn_id = conn.id();
+    let track = conn.track.clone();
+    let bidi = {
+        let conn = conn.clone();
+        bi_streams.map_ok(move |(send, recv)| {
+            conn.tickle();
+            Left(BidiStream {
+                conn: conn.clone(),
+                send: SendStream {
+                    conn: conn.clone(),
+                    send,
+                },
+                recv: RecvStream {
+                    conn: conn.clone(),
+                    recv,
+                },
+            })
+        })
+    };
+    let uni = {
+        let conn = conn.clone();
+        uni_streams.map_ok(move |recv| {
+            conn.tickle();
+            Right(RecvStream {
+                conn: conn.clone(),
+                recv,
+            })
+        })
+    };
+    let inner = stream::select(bidi, uni).map_err(move |e| {
+        track.disconnect(&conn_id, CloseReason::ConnectionError);
+        Error::from(e)
+    });
+
+    IncomingStreams { conn, inner }
+}
+
+impl<S> Stream for IncomingStreams<S>
+where
+    S: Stream<Item = Result<Either<BidiStream, RecvStream>>> + Unpin,
+{
+    type Item = Result<Either<BidiStream, RecvStream>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl<S> RemoteAddr for IncomingStreams<S> {
+    type Addr = SocketAddr;
+
+    fn remote_addr(&self) -> Self::Addr {
+        self.conn.remote_addr()
+    }
+}
+
+impl<S> RemotePeer for IncomingStreams<S> {
+    fn remote_peer_id(&self) -> PeerId {
+        self.conn.remote_peer_id()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -33,7 +123,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub(super) fn new<'a>(
+    pub(super) fn new(
         remote_peer: PeerId,
         track: Conntrack,
         NewConnection {
@@ -42,56 +132,16 @@ impl Connection {
             uni_streams,
             ..
         }: NewConnection,
-    ) -> (Self, IncomingStreams<'a>) {
+    ) -> (
+        Self,
+        IncomingStreams<impl Stream<Item = Result<Either<BidiStream, RecvStream>>>>,
+    ) {
         let conn = Self {
             peer: remote_peer,
             conn: connection,
-            track: track.clone(),
+            track,
         };
-        let conn_id = conn.id();
-        let bidi = {
-            let conn = conn.clone();
-            let track = track.clone();
-            bi_streams
-                .map_ok(move |(send, recv)| {
-                    conn.tickle();
-                    BidiStream {
-                        conn: conn.clone(),
-                        send: SendStream {
-                            conn: conn.clone(),
-                            send,
-                        },
-                        recv: RecvStream {
-                            conn: conn.clone(),
-                            recv,
-                        },
-                    }
-                })
-                .map_err(move |e| {
-                    track.disconnect(&conn_id, CloseReason::ConnectionError);
-                    Error::from(e)
-                })
-        };
-        let uni = {
-            let conn = conn.clone();
-            uni_streams
-                .map_ok(move |recv| {
-                    conn.tickle();
-                    RecvStream {
-                        conn: conn.clone(),
-                        recv,
-                    }
-                })
-                .map_err(move |e| {
-                    track.disconnect(&conn_id, CloseReason::ConnectionError);
-                    Error::from(e)
-                })
-        };
-
-        let incoming = IncomingStreams {
-            bidi: Box::pin(bidi),
-            uni: Box::pin(uni),
-        };
+        let incoming = incoming_streams(conn.clone(), bi_streams, uni_streams);
 
         (conn, incoming)
     }


### PR DESCRIPTION
When switching from long-lived bidi- to ad-hoc uni-streams for gossip,
it was not properly considered that the partial view will not repair
itself in mostly-idle networks -- when there's nothing to send, and
nothing received, we need a cue from the connection driver and dispatch
that to the membership state machine. Note that this relies on PTO
expiration respectively delivery of CONNECTION_CLOSE frames from the
remote, and thus doesn't address any weird states due to "unclean"
reconnects within the PTO period.

Related-to: #575
Signed-off-by: Kim Altintop <kim@monadic.xyz>