### PR TITLE
net: Interrogation API (grafting pt. 2)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -203,8 +203,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/ctz/rustls",
     "https://github.com/meilisearch/madness",
-    "https://github.com/quinn-rs/quinn",
     "https://github.com/ZcashFoundation/ed25519-zebra",
 ]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -45,15 +45,18 @@ regex = "1.3"
 rustc-hash = "1.1"
 serde_bytes = "0.11"
 serde_json = "1.0"
+sized-vec = "0.3"
 tempfile = "3.1"
 thiserror = "1.0"
 time = "0.2"
 tracing = "0.1"
 tracing-attributes = "<0.12.0, ^0.1.13"
 tracing-futures = "0.2"
+typenum = "1.13"
 unicode-normalization = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 webpki = "0.21"
+xorf = "0.7"
 
 [dependencies.deadpool]
 version = "0.7"
@@ -147,6 +150,7 @@ log = "0.4"
 nonempty = "0.6"
 pretty_assertions = "0"
 proptest = "0"
+sha-1 = "0.9"
 tracing-subscriber = ">= 0.2"
 
 [dev-dependencies.librad-test]

--- a/librad/src/identities.rs
+++ b/librad/src/identities.rs
@@ -18,3 +18,15 @@ mod sealed;
 pub(crate) mod gen;
 
 pub use git::*;
+
+#[derive(Clone, Debug, minicbor::Encode, minicbor::Decode)]
+pub enum SomeUrn {
+    #[n(0)]
+    Git(#[n(0)] git::Urn),
+}
+
+impl From<git::Urn> for SomeUrn {
+    fn from(urn: git::Urn) -> Self {
+        Self::Git(urn)
+    }
+}

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -22,6 +22,7 @@ pub use super::protocol::{
         downstream::{MembershipInfo, Stats},
         Upstream as ProtocolEvent,
     },
+    Interrogation,
     PeerInfo,
 };
 pub use deadpool::managed::PoolError;
@@ -227,6 +228,10 @@ where
 
     pub async fn stats(&self) -> Stats {
         self.phone.stats().await
+    }
+
+    pub fn interrogate(&self, peer: impl Into<(PeerId, Vec<SocketAddr>)>) -> Interrogation {
+        self.phone.interrogate(peer)
     }
 
     pub fn subscribe(

--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -117,6 +117,9 @@ where
             Ok(evt) => match evt {
                 Downstream::Gossip(gossip) => control::gossip(&state, gossip).await,
                 Downstream::Info(info) => control::info(&state, info),
+                Downstream::Interrogation(inter) => {
+                    control::interrogation(state.clone(), inter).await
+                },
             },
         }
     }

--- a/librad/src/net/protocol/cache.rs
+++ b/librad/src/net/protocol/cache.rs
@@ -3,9 +3,9 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-mod clone;
-mod fetch_limit;
-mod gossip;
-mod graft;
-mod interrogation;
-mod regression;
+use super::io::recv::interrogation::Cache;
+
+#[derive(Clone, Default)]
+pub struct Caches {
+    pub interrogation: Cache,
+}

--- a/librad/src/net/protocol/error.rs
+++ b/librad/src/net/protocol/error.rs
@@ -7,7 +7,8 @@ use std::fmt::Debug;
 
 use thiserror::Error;
 
-use crate::{git::storage::pool::PoolError, net::quic};
+use super::interrogation;
+use crate::{git::storage::pool::PoolError, net::quic, PeerId};
 
 mod internal;
 pub(super) use internal::*;
@@ -20,4 +21,32 @@ pub enum Bootstrap {
 
     #[error(transparent)]
     Quic(#[from] quic::Error),
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Interrogation {
+    #[error("unable to obtain a connection to {0}")]
+    NoConnection(PeerId),
+
+    #[error("no response from {0}")]
+    NoResponse(PeerId),
+
+    #[error("error response: {0:?}")]
+    ErrorResponse(interrogation::Error),
+
+    #[error("invalid response")]
+    InvalidResponse,
+
+    #[error("network stack not available")]
+    Unavailable,
+
+    #[error(transparent)]
+    Rpc(#[from] Box<internal::Rpc<quic::BidiStream>>),
+}
+
+impl From<internal::Rpc<quic::BidiStream>> for Interrogation {
+    fn from(e: internal::Rpc<quic::BidiStream>) -> Self {
+        Self::Rpc(Box::new(e))
+    }
 }

--- a/librad/src/net/protocol/event.rs
+++ b/librad/src/net/protocol/event.rs
@@ -5,13 +5,14 @@
 
 use std::net::SocketAddr;
 
-use super::{broadcast, gossip, membership};
+use super::{broadcast, error, gossip, interrogation, membership};
 use crate::PeerId;
 
 #[derive(Clone)]
 pub enum Downstream {
     Gossip(downstream::Gossip),
     Info(downstream::Info),
+    Interrogation(downstream::Interrogation),
 }
 
 pub mod downstream {
@@ -58,6 +59,14 @@ pub mod downstream {
         pub connected_peers: usize,
         pub membership_active: usize,
         pub membership_passive: usize,
+    }
+
+    #[derive(Clone)]
+    pub struct Interrogation {
+        pub peer: (PeerId, Vec<SocketAddr>),
+        pub request: interrogation::Request,
+        pub reply:
+            Reply<Result<interrogation::Response<'static, SocketAddr>, error::Interrogation>>,
     }
 }
 

--- a/librad/src/net/protocol/interrogation.rs
+++ b/librad/src/net/protocol/interrogation.rs
@@ -3,9 +3,10 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-mod clone;
-mod fetch_limit;
-mod gossip;
-mod graft;
-mod interrogation;
-mod regression;
+use super::info::PeerAdvertisement;
+
+mod rpc;
+pub use rpc::{Error, Request, Response};
+
+pub mod xor;
+pub use xor::Xor;

--- a/librad/src/net/protocol/interrogation/rpc.rs
+++ b/librad/src/net/protocol/interrogation/rpc.rs
@@ -1,0 +1,115 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::borrow::Cow;
+
+use super::{xor, PeerAdvertisement};
+
+#[derive(Clone, Copy, Debug, minicbor::Encode, minicbor::Decode)]
+pub enum Request {
+    /// Request the remote peer's [`PeerAdvertisement`]
+    #[n(0)]
+    #[cbor(array)]
+    GetAdvertisement,
+
+    /// Ask the remote peer to tell us the network address it sees us as.
+    #[n(1)]
+    #[cbor(array)]
+    EchoAddr,
+
+    /// Request the complete list of URNs the remote peer has.
+    ///
+    /// The response is a compact representation with approximate membership
+    /// tests, see [`xor::Xor`].
+    #[n(2)]
+    #[cbor(array)]
+    GetUrns,
+}
+
+#[derive(minicbor::Encode, minicbor::Decode)]
+pub enum Response<'a, Addr>
+where
+    Addr: Clone + Ord,
+{
+    /// An application-level error occurred, which prevented the responder from
+    /// fulfilling the request.
+    #[n(0)]
+    #[cbor(array)]
+    Error(#[n(0)] Error),
+
+    /// Response to a [`Request::GetAdvertisement`].
+    #[n(1)]
+    #[cbor(array)]
+    Advertisement(#[n(0)] PeerAdvertisement<Addr>),
+
+    /// Response to a [`Request::EchoAddr`].
+    #[n(2)]
+    #[cbor(array)]
+    YourAddr(#[n(0)] Addr),
+
+    /// Response to a [`Request::GetUrns`].
+    ///
+    /// See [`xor::Xor`].
+    #[n(3)]
+    #[cbor(array)]
+    Urns(#[n(0)] Cow<'a, xor::Xor>),
+}
+
+/// Error response.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Some unspecified internal error occurred.
+    ///
+    /// The requester may try again at a later time, but an immediate retry is
+    /// more likely to fail again with the same error.
+    Internal,
+
+    /// The responder is busy with something.
+    ///
+    /// A retry after a small timeout is acceptable.
+    TemporarilyUnavailable,
+
+    /// Catch-all for unknown error codes (forwards-compatibility).
+    ///
+    /// This is for decoding, **do not** construct this variant.
+    Unknown(u8),
+}
+
+impl Error {
+    pub fn code(&self) -> u8 {
+        match self {
+            Error::Internal => 0,
+            Error::TemporarilyUnavailable => 1,
+            Error::Unknown(n) => *n,
+        }
+    }
+}
+
+impl From<u8> for Error {
+    fn from(n: u8) -> Self {
+        match n {
+            0 => Self::Internal,
+            1 => Self::TemporarilyUnavailable,
+            x => Self::Unknown(x),
+        }
+    }
+}
+
+impl minicbor::Encode for Error {
+    fn encode<W: minicbor::encode::Write>(
+        &self,
+        e: &mut minicbor::Encoder<W>,
+    ) -> Result<(), minicbor::encode::Error<W::Error>> {
+        e.u8(self.code())?;
+        Ok(())
+    }
+}
+
+impl<'b> minicbor::Decode<'b> for Error {
+    fn decode(d: &mut minicbor::Decoder<'b>) -> Result<Self, minicbor::decode::Error> {
+        d.u8().map(Self::from)
+    }
+}

--- a/librad/src/net/protocol/interrogation/xor.rs
+++ b/librad/src/net/protocol/interrogation/xor.rs
@@ -1,0 +1,233 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use sized_vec::Vec as SVec;
+use thiserror::Error;
+use typenum::{IsLessOrEqual, Unsigned, U10000};
+use xorf::{Filter as _, Xor16};
+
+use crate::identities::{SomeUrn, Urn};
+
+/// Maximum number of elements permitted in a single [`Xor`] filter.
+///
+/// Currently: 10,000
+pub type MaxElements = U10000;
+// approx. `MaxElements * 1.23`, but not exactly for all choices of
+// `MaxElements`
+const MAX_FINGERPRINTS: u64 = 12_330;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BuildError<E: std::error::Error + Send + Sync + 'static> {
+    #[error("too many elements")]
+    TooManyElements,
+
+    #[error(transparent)]
+    Inner(#[from] E),
+}
+
+/// Compact representation of a potentially large number of local [`Urn`]s, with
+/// approximate membership tests.
+///
+/// We use Lemire et.al.'s [Xor filter][xor] with 16-bit fingerprints, which
+/// gives a false positive rate of < 0.02. The number of elements in the filter
+/// is currently limited to 10,000, which makes for a total size of about 31KiB
+/// on the wire when fully loaded. This number may be adjusted in the
+/// future depending on real-world usage we see, or we may evolve the protocol
+/// such that large nodes announce their URN advertisement split over multiple
+/// Xor filters.
+///
+/// The choice of Xor filters is a tradeoff: their size is proportional to the
+/// number of elements (ie. no "unused" bits are transmitted), and generally
+/// smaller than both Bloom and Cuckoo filters. We also don't need to be careful
+/// about the load factor and resulting false positive rate. Membership tests
+/// appear to be on-par with all but the most query-optimised Bloom filters, and
+/// one order of magnitude faster than for Golomb-coded sets (which _may_ be
+/// even more space-efficient, trading false positive rate). On the downside,
+/// set intersection (which is ultimately what we're after) has to be computed
+/// element-wise. There is also a significant construction complexity (space +
+/// time), yet we can amortise this by caching, assuming the set of locally
+/// stored URNs will be relatively stable in most cases.
+///
+/// [xor]: https://arxiv.org/abs/1912.08258
+pub struct Xor {
+    inner: Xor16,
+}
+
+impl Xor {
+    pub fn contains(&self, urn: &SomeUrn) -> bool {
+        self.inner.contains(&xor_hash(urn))
+    }
+
+    pub fn try_from_iter<T, E>(iter: T) -> Result<Self, BuildError<E>>
+    where
+        T: IntoIterator<Item = Result<SomeUrn, E>>,
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let mut xs = Vec::with_capacity(MaxElements::USIZE);
+        for x in iter {
+            let urn = x?;
+            xs.push(xor_hash(&urn));
+            if xs.len() > MaxElements::USIZE {
+                return Err(BuildError::TooManyElements);
+            }
+        }
+
+        let inner = Xor16::from(xs);
+        Ok(Self { inner })
+    }
+}
+
+impl Clone for Xor {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Xor16 {
+                seed: self.inner.seed,
+                block_length: self.inner.block_length,
+                fingerprints: self.inner.fingerprints.clone(),
+            },
+        }
+    }
+}
+
+impl<N> From<&SVec<N, SomeUrn>> for Xor
+where
+    N: Unsigned + IsLessOrEqual<MaxElements>,
+{
+    fn from(svec: &SVec<N, SomeUrn>) -> Self {
+        let inner = Xor16::from(svec.iter().map(xor_hash).collect::<Vec<_>>());
+        Self { inner }
+    }
+}
+
+impl minicbor::Encode for Xor {
+    fn encode<W: minicbor::encode::Write>(
+        &self,
+        e: &mut minicbor::Encoder<W>,
+    ) -> Result<(), minicbor::encode::Error<W::Error>> {
+        Encode {
+            seed: self.inner.seed,
+            block_length: self.inner.block_length,
+            fingerprints: &self.inner.fingerprints,
+        }
+        .encode(e)
+    }
+}
+
+impl<'b> minicbor::Decode<'b> for Xor {
+    fn decode(d: &mut minicbor::Decoder) -> Result<Self, minicbor::decode::Error> {
+        let Decode {
+            seed,
+            block_length,
+            fingerprints,
+        } = minicbor::Decode::decode(d)?;
+        Ok(Self {
+            inner: Xor16 {
+                seed,
+                block_length,
+                fingerprints: fingerprints.into_boxed_slice(),
+            },
+        })
+    }
+}
+
+#[derive(minicbor::Encode)]
+struct Encode<'a> {
+    #[n(0)]
+    seed: u64,
+    #[n(1)]
+    block_length: usize,
+    #[n(2)]
+    fingerprints: &'a [u16],
+}
+
+#[derive(minicbor::Decode)]
+struct Decode {
+    #[n(0)]
+    seed: u64,
+    #[n(1)]
+    block_length: usize,
+    #[n(2)]
+    #[cbor(with = "bounded")]
+    fingerprints: Vec<u16>,
+}
+
+mod bounded {
+    use super::MAX_FINGERPRINTS;
+
+    pub fn decode(d: &mut minicbor::Decoder) -> Result<Vec<u16>, minicbor::decode::Error> {
+        use minicbor::decode::{Decode, Error::Message as Error};
+
+        match d.probe().array()? {
+            None => Err(Error("expected definite-length array")),
+            Some(len) => {
+                if len > MAX_FINGERPRINTS {
+                    Err(Error("max length exceeded"))
+                } else {
+                    Ok(Decode::decode(d)?)
+                }
+            },
+        }
+    }
+}
+
+fn xor_hash(urn: &SomeUrn) -> u64 {
+    let SomeUrn::Git(Urn { id, path: _ }) = urn;
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&id.as_bytes()[0..8]);
+    u64::from_be_bytes(buf)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use sha1::{Digest, Sha1};
+
+    struct BuildUrn {
+        hasher: Sha1,
+    }
+
+    impl BuildUrn {
+        fn new() -> Self {
+            Self {
+                hasher: Sha1::new(),
+            }
+        }
+
+        fn build(&mut self, v: &[u8]) -> SomeUrn {
+            self.hasher.update(v);
+            let digest = self.hasher.finalize_reset();
+            let oid = git2::Oid::from_bytes(&digest).unwrap();
+            SomeUrn::Git(Urn::new(oid.into()))
+        }
+    }
+
+    #[test]
+    fn false_negatives() {
+        let mut bob = BuildUrn::new();
+        let urns = SVec::<MaxElements, _>::fill(|i| bob.build(&i.to_be_bytes()));
+        let filter = Xor::from(&urns);
+
+        for urn in urns {
+            assert!(filter.contains(&urn))
+        }
+    }
+
+    #[test]
+    fn false_positives() {
+        let mut bob = BuildUrn::new();
+        let urns = SVec::<MaxElements, _>::fill(|i| bob.build(&i.to_be_bytes()));
+        let filter = Xor::from(&urns);
+
+        let false_positives =
+            SVec::<MaxElements, _>::fill(|_| bob.build(&rand::random::<usize>().to_be_bytes()))
+                .iter()
+                .filter(|urn| filter.contains(urn))
+                .count();
+        let rate: f64 = (false_positives * 100) as f64 / MaxElements::USIZE as f64;
+        assert!(rate < 0.02, "False positive rate is {:?}", rate);
+    }
+}

--- a/librad/src/net/protocol/io/recv.rs
+++ b/librad/src/net/protocol/io/recv.rs
@@ -9,5 +9,8 @@ pub(in crate::net::protocol) use git::git;
 mod gossip;
 pub(in crate::net::protocol) use gossip::gossip;
 
+pub(in crate::net::protocol) mod interrogation;
+pub(in crate::net::protocol) use interrogation::interrogation;
+
 mod membership;
 pub(in crate::net::protocol) use membership::{connection_lost, membership};

--- a/librad/src/net/protocol/io/recv/interrogation.rs
+++ b/librad/src/net/protocol/io/recv/interrogation.rs
@@ -1,0 +1,209 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    borrow::Cow,
+    net::SocketAddr,
+    panic,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use futures::{
+    io::{AsyncRead, AsyncWrite, AsyncWriteExt as _},
+    SinkExt as _,
+    StreamExt as _,
+};
+use futures_codec::FramedRead;
+use parking_lot::{
+    MappedRwLockReadGuard,
+    RwLock,
+    RwLockReadGuard,
+    RwLockUpgradableReadGuard,
+    RwLockWriteGuard,
+};
+use thiserror::Error;
+
+use crate::{
+    git::{identities, storage, Storage},
+    identities::SomeUrn,
+    net::{
+        connection::Duplex,
+        protocol::{
+            info::PeerAdvertisement,
+            interrogation::{self, xor, Request, Response, Xor},
+            io::{self, codec},
+            State,
+        },
+        quic,
+        upgrade::{self, Upgraded},
+    },
+};
+
+#[derive(Clone, Default)]
+pub struct Cache {
+    urns: Arc<RwLock<Option<(Instant, Xor)>>>,
+}
+
+#[derive(Debug, Error)]
+enum Error {
+    #[error("the cache is being rebuilt")]
+    Refreshing,
+
+    #[error(transparent)]
+    BuildUrns(#[from] Box<xor::BuildError<identities::Error>>),
+
+    #[error(transparent)]
+    Cbor(#[from] minicbor::encode::Error<std::io::Error>),
+}
+
+impl From<xor::BuildError<identities::Error>> for Error {
+    fn from(e: xor::BuildError<identities::Error>) -> Self {
+        Self::BuildUrns(Box::new(e))
+    }
+}
+
+lazy_static! {
+    static ref INTERNAL_ERROR: Vec<u8> =
+        encode(&Response::Error(interrogation::Error::Internal)).unwrap();
+    static ref UNAVAILABLE_ERROR: Vec<u8> = encode(&Response::Error(
+        interrogation::Error::TemporarilyUnavailable
+    ))
+    .unwrap();
+}
+
+pub(in crate::net::protocol) async fn interrogation<S, T>(
+    state: State<S>,
+    stream: Upgraded<upgrade::Interrogation, T>,
+) where
+    S: storage::Pooled + Send + 'static,
+    T: Duplex<Addr = SocketAddr>,
+    T::Read: AsyncRead + Unpin,
+    T::Write: AsyncWrite + Unpin,
+{
+    let remote_addr = stream.remote_addr();
+    let (recv, send) = stream.into_stream().split();
+    let mut recv = FramedRead::new(recv, codec::Codec::<interrogation::Request>::new());
+    if let Some(x) = recv.next().await {
+        match x {
+            Err(e) => tracing::warn!(err = ?e, "interrogation recv error"),
+            Ok(req) => {
+                let resp = match state.storage.get().await {
+                    Err(e) => {
+                        tracing::error!(err = ?e, "unable to borrow storage");
+                        Cow::from(&*INTERNAL_ERROR)
+                    },
+                    Ok(storage) => {
+                        let res = tokio::task::spawn_blocking(move || {
+                            handle_request(
+                                &state.endpoint,
+                                &storage,
+                                &state.caches.interrogation,
+                                remote_addr,
+                                req,
+                            )
+                            .map(Cow::from)
+                            .unwrap_or_else(|e| {
+                                tracing::error!(err = ?e, "error handling request");
+                                match e {
+                                    Error::Refreshing | Error::BuildUrns(_) => {
+                                        Cow::from(&*UNAVAILABLE_ERROR)
+                                    },
+                                    Error::Cbor(_) => Cow::from(&*INTERNAL_ERROR),
+                                }
+                            })
+                        })
+                        .await;
+                        match res {
+                            Err(e) => {
+                                if e.is_panic() {
+                                    panic::resume_unwind(e.into_panic())
+                                } else if e.is_cancelled() {
+                                    return;
+                                } else {
+                                    unreachable!("unexpected task error: {:?}", e)
+                                }
+                            },
+                            Ok(resp) => resp,
+                        }
+                    },
+                };
+
+                if let Err(e) = send.into_sink().send(resp).await {
+                    tracing::warn!(err = ?e, "interrogation send error")
+                }
+            },
+        }
+    }
+}
+
+fn handle_request(
+    endpoint: &quic::Endpoint,
+    storage: &Storage,
+    cache: &Cache,
+    remote_addr: SocketAddr,
+    req: interrogation::Request,
+) -> Result<Vec<u8>, Error> {
+    use either::Either::*;
+
+    match req {
+        Request::GetAdvertisement => Left(Response::Advertisement(peer_advertisement(endpoint))),
+        Request::EchoAddr => Left(Response::YourAddr(remote_addr)),
+        Request::GetUrns => {
+            let urns = urns(cache, storage)?;
+            Right(encode(&Response::<SocketAddr>::Urns(Cow::Borrowed(&urns))))
+        },
+    }
+    .right_or_else(|resp| encode(&resp))
+}
+
+fn peer_advertisement(endpoint: &quic::Endpoint) -> PeerAdvertisement<SocketAddr> {
+    io::peer_advertisement(endpoint)
+}
+
+fn urns<'a>(cache: &'a Cache, storage: &Storage) -> Result<MappedRwLockReadGuard<'a, Xor>, Error> {
+    // refresh the cache every couple of minutes, assuming we have the refs in
+    // memory anyways
+    //
+    // TODO: we should eventually have hooks to only refresh when the refs
+    // actually changed
+    const MAX_AGE: Duration = Duration::from_secs(300);
+
+    // fast path cache hit
+    {
+        let guard = cache.urns.read();
+        if let Some((updated, _)) = &*guard {
+            if updated.elapsed() < MAX_AGE {
+                return Ok(RwLockReadGuard::map(guard, |x| {
+                    x.as_ref().map(|(_, x)| x).unwrap()
+                }));
+            }
+        }
+    }
+
+    // take an upgradable read lock, exiting if another cache builder holds it
+    match cache.urns.try_upgradable_read() {
+        None => Err(Error::Refreshing),
+        Some(guard) => {
+            // I/O while only holding the read lock, other readers should be
+            // able to make progress
+            let xor = build_urns(storage)?;
+            let mut guard = RwLockUpgradableReadGuard::upgrade(guard);
+            *guard = Some((Instant::now(), xor));
+            Ok(RwLockReadGuard::map(
+                RwLockWriteGuard::downgrade(guard),
+                |x| x.as_ref().map(|(_, x)| x).unwrap(),
+            ))
+        },
+    }
+}
+
+fn build_urns(storage: &Storage) -> Result<Xor, xor::BuildError<identities::Error>> {
+    Xor::try_from_iter(identities::any::list_urns(storage)?.map(|res| res.map(SomeUrn::Git)))
+}
+
+fn encode(resp: &interrogation::Response<SocketAddr>) -> Result<Vec<u8>, Error> {
+    Ok(minicbor::to_vec(resp)?)
+}

--- a/librad/src/net/protocol/io/send.rs
+++ b/librad/src/net/protocol/io/send.rs
@@ -5,3 +5,6 @@
 
 pub mod rpc;
 pub use rpc::send_rpc;
+
+pub mod request_response;
+pub use request_response::request;

--- a/librad/src/net/protocol/io/send/request_response.rs
+++ b/librad/src/net/protocol/io/send/request_response.rs
@@ -1,0 +1,50 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::net::SocketAddr;
+
+use futures::{SinkExt as _, TryStreamExt as _};
+use futures_codec::Framed;
+
+use crate::net::{
+    codec::CborCodec,
+    connection::{RemoteAddr as _, RemotePeer as _},
+    protocol::{error, interrogation, quic, upgrade},
+};
+
+pub trait Request {
+    type Response;
+    type Upgrade: Into<upgrade::UpgradeRequest>;
+    const UPGRADE: Self::Upgrade;
+}
+
+impl Request for interrogation::Request {
+    type Response = interrogation::Response<'static, SocketAddr>;
+    type Upgrade = upgrade::Interrogation;
+    const UPGRADE: Self::Upgrade = upgrade::Interrogation;
+}
+
+#[tracing::instrument(
+    skip(conn, req),
+    fields(
+        remote_id = %conn.remote_peer_id(),
+        remote_addr = %conn.remote_addr()
+    ),
+    err
+)]
+pub async fn request<R>(
+    conn: &quic::Connection,
+    req: R,
+) -> Result<Option<R::Response>, error::Rpc<quic::BidiStream>>
+where
+    R: Request + minicbor::Encode,
+    for<'a> R::Response: minicbor::Decode<'a>,
+{
+    let stream = conn.open_bidi().await?;
+    let upgraded = upgrade::upgrade(stream, R::UPGRADE).await?;
+    let mut framing = Framed::new(upgraded.into_stream(), CborCodec::<R, R::Response>::new());
+    framing.send(req).await?;
+    Ok(framing.try_next().await?)
+}

--- a/librad/src/net/protocol/io/send/rpc.rs
+++ b/librad/src/net/protocol/io/send/rpc.rs
@@ -14,6 +14,7 @@ use crate::net::{
     quic,
     upgrade,
 };
+
 #[derive(Debug)]
 pub enum Rpc<A, P>
 where
@@ -50,7 +51,10 @@ where
     ),
     err
 )]
-pub async fn send_rpc<R, P>(conn: &quic::Connection, rpc: R) -> Result<(), error::SendGossip>
+pub async fn send_rpc<R, P>(
+    conn: &quic::Connection,
+    rpc: R,
+) -> Result<(), error::Rpc<quic::SendStream>>
 where
     R: Into<Rpc<SocketAddr, P>>,
     P: minicbor::Encode,
@@ -65,7 +69,6 @@ where
             FramedWrite::new(upgraded, codec::Membership::new())
                 .send(msg)
                 .await?;
-            Ok(())
         },
 
         Gossip(msg) => {
@@ -73,7 +76,8 @@ where
             FramedWrite::new(upgraded, codec::Gossip::new())
                 .send(msg)
                 .await?;
-            Ok(())
         },
     }
+
+    Ok(())
 }

--- a/librad/src/net/protocol/tincans.rs
+++ b/librad/src/net/protocol/tincans.rs
@@ -1,0 +1,237 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{net::SocketAddr, sync::Arc};
+
+use parking_lot::Mutex;
+pub use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::{broadcast as tincan, oneshot::Receiver};
+
+use super::{
+    error,
+    event::{self, Downstream},
+    gossip,
+    info::PeerAdvertisement,
+    interrogation,
+};
+use crate::PeerId;
+
+#[derive(Clone)]
+pub struct TinCans {
+    pub(super) downstream: tincan::Sender<event::Downstream>,
+    pub(super) upstream: tincan::Sender<event::Upstream>,
+}
+
+impl TinCans {
+    pub fn new() -> Self {
+        Self {
+            downstream: tincan::channel(16).0,
+            upstream: tincan::channel(16).0,
+        }
+    }
+
+    pub fn announce(&self, have: gossip::Payload) -> Result<(), gossip::Payload> {
+        use event::downstream::Gossip::Announce;
+
+        self.downstream
+            .send(Downstream::Gossip(Announce(have)))
+            .and(Ok(()))
+            .map_err(|tincan::error::SendError(e)| match e {
+                Downstream::Gossip(g) => g.payload(),
+                _ => unreachable!(),
+            })
+    }
+
+    pub fn query(&self, want: gossip::Payload) -> Result<(), gossip::Payload> {
+        use event::downstream::Gossip::Query;
+
+        self.downstream
+            .send(Downstream::Gossip(Query(want)))
+            .and(Ok(()))
+            .map_err(|tincan::error::SendError(e)| match e {
+                Downstream::Gossip(g) => g.payload(),
+                _ => unreachable!(),
+            })
+    }
+
+    pub async fn connected_peers(&self) -> Vec<PeerId> {
+        use event::downstream::Info::*;
+
+        let (tx, rx) = replier();
+        if let Err(tincan::error::SendError(e)) =
+            self.downstream.send(Downstream::Info(ConnectedPeers(tx)))
+        {
+            match e {
+                Downstream::Info(ConnectedPeers(reply)) => {
+                    reply
+                        .lock()
+                        .take()
+                        .expect("if chan send failed, there can't be another contender")
+                        .send(vec![])
+                        .ok();
+                },
+
+                _ => unreachable!(),
+            }
+        }
+
+        rx.await.unwrap_or_default()
+    }
+
+    pub async fn membership(&self) -> event::downstream::MembershipInfo {
+        use event::downstream::{Info::*, MembershipInfo};
+
+        let (tx, rx) = replier();
+        if let Err(tincan::error::SendError(e)) =
+            self.downstream.send(Downstream::Info(Membership(tx)))
+        {
+            match e {
+                Downstream::Info(Membership(reply)) => {
+                    reply
+                        .lock()
+                        .take()
+                        .expect("if chan send failed, there can't be another contender")
+                        .send(MembershipInfo::default())
+                        .ok();
+                },
+                _ => unreachable!(),
+            }
+        }
+
+        rx.await.unwrap_or_default()
+    }
+
+    pub async fn stats(&self) -> event::downstream::Stats {
+        use event::downstream::{Info::*, Stats};
+
+        let (tx, rx) = replier();
+        if let Err(tincan::error::SendError(e)) = self.downstream.send(Downstream::Info(Stats(tx)))
+        {
+            match e {
+                Downstream::Info(Stats(reply)) => {
+                    reply
+                        .lock()
+                        .take()
+                        .expect("if chan send failed, there can't be another contender")
+                        .send(Stats::default())
+                        .ok();
+                },
+
+                _ => unreachable!(),
+            }
+        }
+
+        rx.await.unwrap_or_default()
+    }
+
+    pub fn interrogate(&self, peer: impl Into<(PeerId, Vec<SocketAddr>)>) -> Interrogation {
+        Interrogation {
+            peer: peer.into(),
+            chan: self.downstream.clone(),
+        }
+    }
+
+    pub fn subscribe(&self) -> impl futures::Stream<Item = Result<event::Upstream, RecvError>> {
+        let mut r = self.upstream.subscribe();
+        async_stream::stream! { loop { yield r.recv().await } }
+    }
+
+    pub(super) fn emit(&self, evt: impl Into<event::Upstream>) {
+        self.upstream.send(evt.into()).ok();
+    }
+}
+
+impl Default for TinCans {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct Interrogation {
+    peer: (PeerId, Vec<SocketAddr>),
+    chan: tincan::Sender<event::Downstream>,
+}
+
+impl Interrogation {
+    /// Ask the interrogated peer to send its [`PeerAdvertisement`].
+    pub async fn peer_advertisement(
+        &self,
+    ) -> Result<PeerAdvertisement<SocketAddr>, error::Interrogation> {
+        use interrogation::{Request, Response};
+
+        self.request(Request::GetAdvertisement)
+            .await
+            .and_then(|resp| match resp {
+                Response::Advertisement(ad) => Ok(ad),
+                Response::Error(e) => Err(error::Interrogation::ErrorResponse(e)),
+                _ => Err(error::Interrogation::InvalidResponse),
+            })
+    }
+
+    /// Ask the interrogated peer to send back the [`SocketAddr`] the local peer
+    /// appears to have.
+    pub async fn echo_addr(&self) -> Result<SocketAddr, error::Interrogation> {
+        use interrogation::{Request, Response};
+
+        self.request(Request::EchoAddr)
+            .await
+            .and_then(|resp| match resp {
+                Response::YourAddr(ad) => Ok(ad),
+                Response::Error(e) => Err(error::Interrogation::ErrorResponse(e)),
+                _ => Err(error::Interrogation::InvalidResponse),
+            })
+    }
+
+    /// Ask the interrogated peer to send the complete list of URNs it has.
+    ///
+    /// The response is compactly encoded as an [`interrogation::Xor`] filter,
+    /// with a very small false positive probability.
+    pub async fn urns(&self) -> Result<interrogation::Xor, error::Interrogation> {
+        use interrogation::{Request, Response};
+
+        self.request(Request::GetUrns)
+            .await
+            .and_then(|resp| match resp {
+                Response::Urns(urns) => Ok(urns.into_owned()),
+                Response::Error(e) => Err(error::Interrogation::ErrorResponse(e)),
+                _ => Err(error::Interrogation::InvalidResponse),
+            })
+    }
+
+    async fn request(
+        &self,
+        request: interrogation::Request,
+    ) -> Result<interrogation::Response<'static, SocketAddr>, error::Interrogation> {
+        use event::downstream::Interrogation;
+
+        let (tx, rx) = replier();
+        let msg = Downstream::Interrogation(Interrogation {
+            peer: self.peer.clone(),
+            request,
+            reply: tx,
+        });
+        if let Err(tincan::error::SendError(e)) = self.chan.send(msg) {
+            match e {
+                Downstream::Interrogation(Interrogation { reply, .. }) => {
+                    reply
+                        .lock()
+                        .take()
+                        .expect("if chan send failed, there can't be another contender")
+                        .send(Err(error::Interrogation::Unavailable))
+                        .ok();
+                },
+
+                _ => unreachable!(),
+            }
+        }
+
+        rx.await.unwrap_or(Err(error::Interrogation::Unavailable))
+    }
+}
+
+fn replier<T>() -> (event::downstream::Reply<T>, Receiver<T>) {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    (Arc::new(Mutex::new(Some(tx))), rx)
+}

--- a/librad/tests/smoke/interrogation.rs
+++ b/librad/tests/smoke/interrogation.rs
@@ -1,0 +1,46 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use librad::{identities::SomeUrn, net::protocol::PeerAdvertisement};
+use librad_test::{
+    logging,
+    rad::{identities::TestProject, testnet},
+};
+
+#[tokio::test]
+async fn responds() {
+    logging::init();
+
+    let peers = testnet::setup(2).await.unwrap();
+    testnet::run_on_testnet(peers, 2, |mut peers| async move {
+        let responder = peers.pop().unwrap();
+        let requester = peers.pop().unwrap();
+
+        let TestProject { project, owner } = responder
+            .using_storage(move |s| TestProject::create(&s))
+            .await
+            .unwrap()
+            .unwrap();
+
+        let interrogation =
+            requester.interrogate((responder.peer_id(), responder.listen_addrs().to_vec()));
+        assert_eq!(
+            PeerAdvertisement {
+                listen_addrs: responder.listen_addrs().iter().copied().collect(),
+                capabilities: Default::default(),
+            },
+            interrogation.peer_advertisement().await.unwrap()
+        );
+        assert_eq!(
+            requester.listen_addrs()[0],
+            interrogation.echo_addr().await.unwrap()
+        );
+        let urns = interrogation.urns().await.unwrap();
+        for urn in &[SomeUrn::Git(project.urn()), SomeUrn::Git(owner.urn())] {
+            assert!(urns.contains(urn))
+        }
+    })
+    .await;
+}


### PR DESCRIPTION
In the second installment towards the grafting protocol, we introduce an
API and associated stream type to interrogate a known remote peer about
certain data. Of relevance for grafting is strictly speaking only the
RPC to ask for the complete list of URNs.

We use the Xor filter probabilistic datastructure for that, in order to
gain compact and bounded responses (see commentary inline). The work to
compute the set intersection will be on the requester, while the
responder recomputes the filter only when necessary (morally; we can't
currently intercept refs updates in the relevant places, so recompute
after an expiry timeout).

Signed-off-by: Kim Altintop <kim@monadic.xyz>