### PR TITLE
fetch: limit testing and increase

### DIFF
--- a/librad/src/git/fetch.rs
+++ b/librad/src/git/fetch.rs
@@ -41,7 +41,7 @@ use crate::{
 pub const ONE_KB: usize = 1024;
 /// 5KiB for use in [`Limit`], specifically for the `peek` field, when we would
 /// like to fetch `rad/id` , `rad/self`, `rad/ids/*` references.
-pub const FIVE_KB: usize = ONE_KB * 5;
+pub const TEN_KB: usize = ONE_KB * 10;
 /// 5GB for use in [`Limit`], specifically for the `data` field, when we would
 /// like to fetch `rad/*` as well as `refs/heads/*` references.
 pub const FIVE_GB: usize = ONE_KB * ONE_KB * ONE_KB * 5;
@@ -62,7 +62,7 @@ pub struct Limit {
 impl Default for Limit {
     fn default() -> Self {
         Self {
-            peek: FIVE_KB,
+            peek: TEN_KB,
             data: FIVE_GB,
         }
     }
@@ -591,7 +591,7 @@ impl<'a> DefaultFetcher<'a> {
                 let received_bytes = prog.received_bytes();
                 tracing::trace!("Fetch: received {} bytes", received_bytes);
                 if received_bytes > limit {
-                    tracing::error!("Fetch: exceeded {} bytes", limit);
+                    tracing::error!("Fetch: {} exceeded {} bytes", received_bytes, limit);
                     false
                 } else {
                     true

--- a/librad/tests/smoke/fetch_limit.rs
+++ b/librad/tests/smoke/fetch_limit.rs
@@ -1,0 +1,54 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use librad::git::tracking;
+use librad_test::{
+    logging,
+    rad::{identities::TestProject, testnet},
+};
+
+#[tokio::test]
+async fn replication_does_not_exceed_limit() {
+    logging::init();
+
+    const NUM_PEERS: usize = 6;
+
+    let peers = testnet::setup(NUM_PEERS).await.unwrap();
+    testnet::run_on_testnet(peers, NUM_PEERS, |mut peers| async move {
+        let peer1 = peers.pop().unwrap();
+        let peer2 = peers.pop().unwrap();
+        let peer3 = peers.pop().unwrap();
+        let peer4 = peers.pop().unwrap();
+        let peer5 = peers.pop().unwrap();
+        let peer6 = peers.pop().unwrap();
+
+        let proj = peer1
+            .using_storage({
+                let remotes = vec![
+                    peer2.peer_id(),
+                    peer3.peer_id(),
+                    peer4.peer_id(),
+                    peer5.peer_id(),
+                ];
+                move |storage| {
+                    let proj = TestProject::create(&storage)?;
+                    for remote in remotes.into_iter() {
+                        tracking::track(&storage, &proj.project.urn(), remote)?;
+                    }
+                    Ok::<_, anyhow::Error>(proj)
+                }
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        for peer in vec![peer2, peer3, peer4, peer5].iter() {
+            proj.pull(&peer1, peer).await.ok().unwrap();
+            proj.pull(peer, &peer1).await.ok().unwrap();
+        }
+        proj.pull(&peer1, &peer6).await.ok().unwrap();
+    })
+    .await;
+}

--- a/librad/tests/smoke/fetch_limit.rs
+++ b/librad/tests/smoke/fetch_limit.rs
@@ -9,6 +9,9 @@ use librad_test::{
     rad::{identities::TestProject, testnet},
 };
 
+/// Stress test the limits that are set for fetching when using `replicate`.
+/// The `fetch::Limit` contains a base limit and should be scaled by the number
+/// of remotes that the fetcher is fetching from.
 #[tokio::test]
 async fn replication_does_not_exceed_limit() {
     logging::init();

--- a/librad/tests/smoke/mod.rs
+++ b/librad/tests/smoke/mod.rs
@@ -4,5 +4,6 @@
 // Linking Exception. For full terms see the included LICENSE file.
 
 mod clone;
+mod fetch_limit;
 mod gossip;
 mod regression;


### PR DESCRIPTION
Adding a smoke test to show that a peer with 4 remotes will fail to replicate from another peer due to `PeekAll` exceeding the fetch limit. This pushes the limit up to 10kB but definitely isn't the fix. 

https://github.com/radicle-dev/radicle-link/pull/568 can partly address this since it doesn't use `PeekAll` anymore and works out the remotes it needs to peek at based on the provider, so it can scale the `Peek` in that case.

This increase will help with the replication issues that were noticed when testing Upstream.