### PR TITLE
replication: Prevent fetch of non-existing repo 

### DIFF
--- a/librad/src/git/fetch.rs
+++ b/librad/src/git/fetch.rs
@@ -547,7 +547,7 @@ impl<'a> DefaultFetcher<'a> {
             .to_string(),
         )?;
         remote.connect(git2::Direction::Fetch)?;
-        let remote_heads = remote
+        let remote_heads: RemoteHeads = remote
             .list()?
             .iter()
             .filter_map(|remote_head| match remote_head.symref_target() {
@@ -620,7 +620,7 @@ impl<'a> DefaultFetcher<'a> {
                 &refspecs,
                 Some(
                     git2::FetchOptions::new()
-                        .prune(git2::FetchPrune::On)
+                        .prune(git2::FetchPrune::Off)
                         .update_fetchhead(false)
                         .download_tags(git2::AutotagOption::None)
                         .remote_callbacks(callbacks),


### PR DESCRIPTION
Up until fetches would go through even if the project doesn't exist on
the server. Due to the use of pruning during the fetch this would leave
remotes in a broken state with a tree looking like:

```
 └── hyygmx7fm9zaneg64d7gjuohwwmo1obduwk4s6jku3yau9k8y3dgjs
    ├── heads
    │   └── main
    └── rad
        └── ids
```