### PR TITLE
Allow configuring advertised address

### DIFF
--- a/e2e/src/bin/ephemeral-peer.rs
+++ b/e2e/src/bin/ephemeral-peer.rs
@@ -47,6 +47,7 @@ async fn main() {
             protocol: protocol::Config {
                 paths,
                 listen_addr: *LOCALHOST_ANY,
+                advertised_addrs: None,
                 membership: Default::default(),
                 network: Default::default(),
                 replication: Default::default(),

--- a/librad-test/src/rad/testnet.rs
+++ b/librad-test/src/rad/testnet.rs
@@ -111,6 +111,7 @@ where
     let protocol = protocol::Config {
         paths,
         listen_addr,
+        advertised_addrs: None,
         membership: Default::default(),
         network: Default::default(),
         replication: Default::default(),

--- a/librad/src/net/protocol/io.rs
+++ b/librad/src/net/protocol/io.rs
@@ -74,7 +74,7 @@ where
 
 pub(super) fn peer_advertisement(endpoint: &quic::Endpoint) -> PeerAdvertisement<SocketAddr> {
     let listen_addrs = endpoint
-        .listen_addrs()
+        .advertised_addrs()
         .expect("unable to obtain listen addrs")
         .into_iter()
         .collect();


### PR DESCRIPTION
In many configurations the address which can be seen by other nodes will
be completely different than the socket address used for listening. For
example a seed with address 0.0.0.0 will advertise localhost, all docker
interfaces, link-local ipv6 addresses, etc. but not the public address
it's unaware of.

This change introduces the minimal first step towards a better
advertisement. A static advertised address is exposed in configuration.

Future direction may include public address autodiscovery using STUN
endpoints, or asking other radicle nodes to report back the seen remote
address.

Fixes https://github.com/radicle-dev/radicle-link/issues/584