### PR TITLE
identities: ensure (eligible) delegations cannot be empty

### DIFF
--- a/librad/src/identities/delegation/direct.rs
+++ b/librad/src/identities/delegation/direct.rs
@@ -4,7 +4,6 @@
 // Linking Exception. For full terms see the included LICENSE file.
 
 use std::{
-    cmp,
     collections::{btree_set, BTreeSet},
     iter::FromIterator,
 };
@@ -42,7 +41,7 @@ impl Delegations for Direct {
     }
 
     fn quorum_threshold(&self) -> usize {
-        cmp::max(1, self.0.len() / 2)
+        self.0.len() / 2
     }
 }
 

--- a/librad/src/identities/delegation/indirect.rs
+++ b/librad/src/identities/delegation/indirect.rs
@@ -4,7 +4,6 @@
 // Linking Exception. For full terms see the included LICENSE file.
 
 use std::{
-    cmp,
     collections::{
         btree_map::{self, Entry},
         BTreeMap,
@@ -329,7 +328,7 @@ impl<T, R, C> Delegations for Indirect<T, R, C> {
             .count();
         let indirect = self.identities.len();
 
-        cmp::max(1, (direct + indirect) / 2)
+        (direct + indirect) / 2
     }
 }
 

--- a/librad/src/identities/generic.rs
+++ b/librad/src/identities/generic.rs
@@ -383,7 +383,7 @@ impl<T, R, C> Verifying<Identity<T, R, C>, Signed> {
             .map_err(error::Verify::eligibility)?
             .len();
 
-        if eligible > self.doc.quorum_threshold() {
+        if eligible > 0 && eligible > self.doc.quorum_threshold() {
             Ok(self.coerce())
         } else {
             Err(error::Verify::Quorum)
@@ -449,7 +449,7 @@ impl<T, R, C> Verifying<Identity<T, R, C>, Quorum> {
                         .map_err(error::Verify::eligibility)?
                         .len();
 
-                    if votes > parent.doc.quorum_threshold() {
+                    if votes > 0 && votes > parent.doc.quorum_threshold() {
                         Ok(self.coerce())
                     } else {
                         Err(error::Verify::ParentQuorum)


### PR DESCRIPTION
Fixes the previous attempt of requiring the quorum threshold to be at
least 1, which would still require this check. Perhaps a future patch
should reject empty delegations at parse time.

Signed-off-by: Kim Altintop <kim@monadic.xyz>