### PR TITLE
e2e: expose container ports on the host

### DIFF
--- a/e2e/Procfile
+++ b/e2e/Procfile
@@ -1,2 +1,2 @@
-bootstrap: cargo run --bin ephemeral-peer -- --secret-key hIfobTmxKMemyXPOC8EmUNdufwi2MsKucEB9EikOyDE --listen 127.0.0.1:12345
-peer: sleep 5; cargo run --bin ephemeral-peer -- --bootstrap hyne66jefcpkobg91qzdy6ysetr8fn3p3d6myce61uwf7s67g3i79e@127.0.0.1:12345
+bootstrap: cargo run --bin ephemeral-peer -- --secret-key hIfobTmxKMemyXPOC8EmUNdufwi2MsKucEB9EikOyDE --listen 127.0.0.1:54321
+peer: sleep 5; cargo run --bin ephemeral-peer -- --bootstrap hyne66jefcpkobg91qzdy6ysetr8fn3p3d6myce61uwf7s67g3i79e@127.0.0.1:54321

--- a/e2e/compose.yaml
+++ b/e2e/compose.yaml
@@ -36,6 +36,8 @@ services:
       dockerfile: e2e/ephemeral-peer.dockerfile
     image: ephemeral-peer
     init: true
+    ports:
+    - '12345:12345/udp'
     command: |
       ephemeral-peer
         --secret-key hIfobTmxKMemyXPOC8EmUNdufwi2MsKucEB9EikOyDE
@@ -51,8 +53,11 @@ services:
     - 'bootstrap-peer'
     image: ephemeral-peer
     init: true
+    ports:
+    - '12346/udp'
     command: |
       ephemeral-peer
+        --listen 0.0.0.0:12346
         --bootstrap hyne66jefcpkobg91qzdy6ysetr8fn3p3d6myce61uwf7s67g3i79e@bootstrap:12345
         --graphite graphite:9109
     environment:


### PR DESCRIPTION
Allows to bootstrap a peer on the host against the bootstrap container.
Note that the network indeed converges.

To prevent conflicts, a different port for the Procfile bootstrap node
is chosen.

Signed-off-by: Kim Altintop <kim@monadic.xyz>