### PR TITLE
seed: migrate Rust code back

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -204,4 +204,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
     "https://github.com/ZcashFoundation/ed25519-zebra",
+    "https://github.com/radicle-dev/radicle-avatar",
 ]

--- a/seed/Cargo.toml
+++ b/seed/Cargo.toml
@@ -6,10 +6,20 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [dependencies]
+argh = "0.1"
 async-trait = "0.1"
 futures = "0.3"
 librad = { path = "../librad" }
+num_cpus = "1"
 radicle-keystore = "0"
+serde = "1"
 thiserror = "1"
 tokio = { version = "1.1", features = ["time"] }
+tokio-stream = "0.1"
 tracing = "0.1"
+tracing-subscriber = "0.2"
+warp = { version = "0.3", default-features = false }
+
+[dependencies.radicle-avatar]
+git = "https://github.com/radicle-dev/radicle-avatar"
+branch = "main"

--- a/seed/src/cli.rs
+++ b/seed/src/cli.rs
@@ -1,0 +1,7 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+pub mod args;
+pub mod main;

--- a/seed/src/cli/args.rs
+++ b/seed/src/cli/args.rs
@@ -1,0 +1,105 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{net, path::PathBuf};
+
+use argh::FromArgs;
+
+use librad::{git::Urn, net::protocol::membership, peer::PeerId};
+
+/// A set of peers to track
+#[derive(FromArgs)]
+#[argh(subcommand, name = "track-peers")]
+pub struct Peers {
+    /// track the specified peer only
+    #[argh(option, long = "peer")]
+    pub peers: Vec<PeerId>,
+}
+
+/// A set of URNs to track
+#[derive(FromArgs)]
+#[argh(subcommand, name = "track-urns")]
+pub struct Urns {
+    /// track the specified URN only
+    #[argh(option, long = "urn")]
+    pub urns: Vec<Urn>,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+pub enum Track {
+    Urns(Urns),
+    Peers(Peers),
+}
+
+#[derive(FromArgs)]
+/// Radicle Seed.
+pub struct Options {
+    /// track the specified peer only
+    #[argh(subcommand)]
+    pub track: Option<Track>,
+
+    /// listen on the following address for peer connections
+    #[argh(option)]
+    pub peer_listen: Option<net::SocketAddr>,
+
+    /// listen on the following address for HTTP connections (default:
+    /// 127.0.0.1:8888)
+    #[argh(option, default = "std::net::SocketAddr::from(([127, 0, 0, 1], 8888))")]
+    pub http_listen: net::SocketAddr,
+
+    /// log level (default: info)
+    #[argh(option, default = "tracing::Level::INFO")]
+    pub log: tracing::Level,
+
+    /// radicle root path, for key and git storage
+    #[argh(option)]
+    pub root: Option<PathBuf>,
+
+    /// path to UI assets directory
+    #[argh(option, default = "PathBuf::from(\"ui/public\")")]
+    pub assets_path: PathBuf,
+
+    /// name of this seed, displayed to users
+    #[argh(option)]
+    pub name: Option<String>,
+
+    /// description of this seed, displayed to users as HTML
+    #[argh(option)]
+    pub description: Option<String>,
+
+    /// public address of this seed node, eg. 'seedling.radicle.xyz:12345'
+    #[argh(option)]
+    pub public_addr: Option<String>,
+
+    /// list of bootstrap peers, eg.
+    /// 'f00...@seed1.example.com:12345,bad...@seed2.example.com:12345'
+    #[argh(option)]
+    pub bootstrap: Option<String>,
+
+    /// number of [`librad::git::storage::Storage`] instancess to pool for
+    /// consumers.
+    #[argh(option, default = "num_cpus::get_physical()")]
+    pub user_size: usize,
+
+    /// number of [`librad::git::storage::Storage`] instancess to pool for the
+    /// protocol.
+    #[argh(option, default = "num_cpus::get_physical()")]
+    pub protocol_size: usize,
+
+    /// max number of active members to set in [`membership::Params`].
+    #[argh(option, default = "membership::Params::default().max_active")]
+    pub membership_max_active: usize,
+
+    /// max number of passive members to set in [`membership::Params`].
+    #[argh(option, default = "membership::Params::default().max_passive")]
+    pub membership_max_passive: usize,
+}
+
+impl Options {
+    pub fn from_env() -> Self {
+        argh::from_env()
+    }
+}

--- a/seed/src/cli/main.rs
+++ b/seed/src/cli/main.rs
@@ -1,0 +1,137 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    env,
+    net::{SocketAddr, ToSocketAddrs},
+    str::FromStr,
+};
+
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+use librad::{
+    git::replication,
+    net::{
+        peer,
+        protocol::{self, membership},
+        Network,
+    },
+    paths,
+    peer::PeerId,
+    profile,
+};
+
+use crate::{cli::args, frontend, Mode, Node, NodeConfig, Signer};
+
+fn parse_peer_address(address: &str) -> SocketAddr {
+    address
+        .to_socket_addrs()
+        .map(|mut a| a.next())
+        .expect("peer address could not be parsed")
+        .expect("peer address could not be resolved")
+}
+
+fn parse_peer_list(option: String) -> Vec<(PeerId, SocketAddr)> {
+    option
+        .split(',')
+        .map(|entry| entry.splitn(2, '@').collect())
+        .into_iter()
+        .map(|parts: Vec<&str>| {
+            (
+                PeerId::from_str(parts[0]).expect("peer id could not be parsed"),
+                parse_peer_address(parts[1]),
+            )
+        })
+        .collect()
+}
+
+pub async fn main() {
+    let opts = args::Options::from_env();
+    let subscriber = FmtSubscriber::builder();
+    if env::var("RUST_LOG").is_ok() {
+        let subscriber = subscriber
+            .with_env_filter(EnvFilter::from_default_env())
+            .finish();
+
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("setting tracing subscriber should succeed");
+    } else {
+        let subscriber = subscriber.with_max_level(opts.log).finish();
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("setting tracing subscriber should succeed");
+    };
+
+    let signer = match Signer::new(std::io::stdin()) {
+        Ok(signer) => signer,
+        Err(err) => panic!("invalid key was supplied to stdin: {}", err),
+    };
+    let paths = if let Some(root) = &opts.root {
+        paths::Paths::from_root(root).expect("failed to configure paths")
+    } else {
+        profile::Profile::load()
+            .expect("failed to load profile")
+            .paths()
+            .to_owned()
+    };
+
+    let storage = peer::config::Storage {
+        user: peer::config::UserStorage {
+            pool_size: opts.user_size,
+        },
+        protocol: peer::config::ProtocolStorage {
+            pool_size: opts.protocol_size,
+            ..peer::config::ProtocolStorage::default()
+        },
+    };
+    let membership = membership::Params {
+        max_active: opts.membership_max_active,
+        max_passive: opts.membership_max_passive,
+        ..membership::Params::default()
+    };
+    let listen_addr = opts.peer_listen.unwrap_or_else(|| ([0, 0, 0, 0], 0).into());
+
+    let config = NodeConfig {
+        mode: match opts.track {
+            Some(args::Track::Peers(args::Peers { peers })) => {
+                Mode::TrackPeers(peers.into_iter().collect())
+            },
+            Some(args::Track::Urns(args::Urns { urns })) => {
+                Mode::TrackUrns(urns.into_iter().collect())
+            },
+            None => Mode::TrackEverything,
+        },
+        bootstrap: opts.bootstrap.map_or_else(Vec::new, parse_peer_list),
+    };
+    let peer_config = peer::Config {
+        signer: signer.clone(),
+        protocol: protocol::Config {
+            paths,
+            listen_addr,
+            advertised_addrs: None,
+            membership,
+            network: Network::default(),
+            replication: replication::Config::default(),
+            fetch: protocol::config::Fetch::default(),
+        },
+        storage,
+    };
+    let node = Node::new().unwrap();
+    let handle = node.handle();
+    let peer_id = PeerId::from(signer);
+    let (tx, rx) = futures::channel::mpsc::channel(1);
+
+    tokio::spawn(frontend::run(
+        opts.name,
+        opts.description,
+        opts.http_listen,
+        opts.public_addr,
+        opts.assets_path,
+        peer_id,
+        handle,
+        rx,
+    ));
+
+    node.run(config, peer_config, tx).await.unwrap();
+}

--- a/seed/src/frontend.rs
+++ b/seed/src/frontend.rs
@@ -1,0 +1,333 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    net,
+    path::PathBuf,
+    sync::Arc,
+    time::{self, SystemTime},
+};
+
+use futures::{channel::mpsc as chan, StreamExt as _};
+use serde::Serialize;
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use warp::Filter as _;
+
+use librad::{git::Urn, net::protocol::event::downstream, peer::PeerId};
+use radicle_avatar::{self as avatar, Avatar};
+
+use crate as seed;
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Info {
+    name: Option<String>,
+    peer_id: PeerId,
+    public_addr: Option<String>,
+    description: Option<String>,
+    peers: usize,
+    projects: usize,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MembershipInfo {
+    active: Vec<PeerId>,
+    passive: Vec<PeerId>,
+}
+
+impl From<downstream::MembershipInfo> for MembershipInfo {
+    fn from(i: downstream::MembershipInfo) -> Self {
+        Self {
+            active: i.active,
+            passive: i.passive,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Event {
+    ProjectTracked(Project),
+    #[serde(rename_all = "camelCase")]
+    Snapshot {
+        projects: Vec<Project>,
+        peers: Vec<Peer>,
+        info: Info,
+    },
+}
+
+#[derive(Debug)]
+struct State {
+    name: Option<String>,
+    description: Option<String>,
+    public_addr: Option<String>,
+    peer_id: PeerId,
+    projects: HashMap<Urn, Project>,
+    peers: HashMap<PeerId, Peer>,
+    subs: Vec<tokio::sync::mpsc::UnboundedSender<Event>>,
+}
+
+impl State {
+    fn info(&self) -> Info {
+        Info {
+            name: self.name.clone(),
+            public_addr: self.public_addr.clone(),
+            peer_id: self.peer_id,
+            description: self.description.clone(),
+            projects: self.projects.len(),
+            peers: self.peers.values().filter(|p| p.is_connected()).count(),
+        }
+    }
+
+    fn broadcast(&mut self, event: Event) {
+        self.subs.retain(|sub| sub.send(event.clone()).is_ok());
+    }
+
+    fn project_tracked(&mut self, mut proj: seed::Project) {
+        // We don't want any path in this URN, just the project id.
+        proj.urn = proj.urn.with_path(None);
+
+        let tracked = time::SystemTime::now();
+
+        match self.projects.entry(proj.urn.clone()) {
+            Entry::Vacant(v) => {
+                let proj = Project::from((proj, Some(tracked)));
+                v.insert(proj.clone());
+                self.broadcast(Event::ProjectTracked(proj));
+            },
+            Entry::Occupied(_) => {},
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Peer {
+    pub peer_id: PeerId,
+    pub user: Option<User>,
+    pub state: PeerState,
+}
+
+impl Peer {
+    fn is_connected(&self) -> bool {
+        matches!(self.state, PeerState::Connected { .. })
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum PeerState {
+    #[serde(rename_all = "camelCase")]
+    Connected,
+    #[serde(rename_all = "camelCase")]
+    Disconnected { since: time::SystemTime },
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct User {
+    urn: Urn,
+    avatar: Avatar,
+    name: Option<String>,
+}
+
+impl From<Urn> for User {
+    fn from(urn: Urn) -> Self {
+        let avatar = Avatar::from(&urn.to_string(), avatar::Usage::Identity);
+
+        Self {
+            avatar,
+            urn,
+            name: None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Project {
+    pub urn: Urn,
+    pub name: String,
+    pub description: Option<String>,
+    pub maintainers: Vec<User>,
+    pub tracked: Option<SystemTime>,
+}
+
+impl From<(seed::Project, Option<SystemTime>)> for Project {
+    fn from((other, tracked): (seed::Project, Option<SystemTime>)) -> Self {
+        Self {
+            urn: other.urn,
+            name: other.name,
+            description: other.description,
+            maintainers: other.maintainers.into_iter().map(User::from).collect(),
+            tracked,
+        }
+    }
+}
+
+async fn fanout(state: Arc<Mutex<State>>, mut events: chan::Receiver<seed::Event>) {
+    while let Some(e) = events.next().await {
+        tracing::info!("{:?}", e);
+
+        let mut state = state.lock().await;
+
+        match e {
+            seed::Event::ProjectTracked(proj, _) => {
+                state.project_tracked(proj);
+            },
+            // FIXME: potential to report the status of the seed
+            seed::Event::Disconnected => {},
+            seed::Event::Listening(_) => {},
+        };
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run<A: Into<net::SocketAddr>>(
+    name: Option<String>,
+    description: Option<String>,
+    addr: A,
+    public_addr: Option<String>,
+    assets_path: PathBuf,
+    peer_id: PeerId,
+    mut handle: seed::NodeHandle,
+    events: chan::Receiver<seed::Event>,
+) {
+    let public = warp::fs::dir(assets_path);
+    let projects = handle.get_projects().await.unwrap();
+    let state = Arc::new(Mutex::new(State {
+        name,
+        description,
+        peer_id,
+        public_addr,
+        projects: projects
+            .into_iter()
+            .map(|p| (p.urn.clone(), Project::from((p, None))))
+            .collect(),
+        peers: HashMap::new(),
+        subs: Vec::new(),
+    }));
+
+    tokio::task::spawn(fanout(state.clone(), events));
+
+    let handle = Arc::new(Mutex::new(handle));
+
+    let membership = {
+        let handle = handle.clone();
+        warp::path("membership")
+            .map(move || handle.clone())
+            .and_then(membership_handler)
+    };
+
+    let projects = warp::path("projects")
+        .map({
+            let state = state.clone();
+            move || state.clone()
+        })
+        .and_then(projects_handler);
+
+    let peers = warp::path("peers")
+        .map(move || handle.clone())
+        .and_then(peers_handler);
+
+    let info = warp::path("info")
+        .map({
+            let state = state.clone();
+            move || state.clone()
+        })
+        .and_then(info_handler);
+
+    let app = warp::path("events")
+        .and(warp::get())
+        .map(move || state.clone())
+        .and_then(events_handler);
+
+    warp::serve(
+        app.or(public)
+            .or(membership)
+            .or(projects)
+            .or(peers)
+            .or(info),
+    )
+    .run(addr)
+    .await;
+}
+
+async fn membership_handler(
+    handle: Arc<Mutex<seed::NodeHandle>>,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let mut handle = handle.lock().await;
+    let info = handle
+        .get_membership()
+        .await
+        .expect("failed to get membership");
+
+    Ok(warp::reply::json(&MembershipInfo::from(info)))
+}
+
+async fn info_handler(state: Arc<Mutex<State>>) -> Result<impl warp::Reply, warp::Rejection> {
+    let state = state.lock().await;
+
+    Ok(warp::reply::json(&state.info()))
+}
+
+async fn peers_handler(
+    handle: Arc<Mutex<seed::NodeHandle>>,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let mut handle = handle.lock().await;
+    let peers = handle
+        .get_peers()
+        .await
+        .expect("failed to get peer list")
+        .into_iter()
+        .map(|peer_id| Peer {
+            peer_id,
+            user: None,
+            state: PeerState::Connected,
+        })
+        .collect::<Vec<_>>();
+
+    Ok(warp::reply::json(&peers))
+}
+
+async fn projects_handler(state: Arc<Mutex<State>>) -> Result<impl warp::Reply, warp::Rejection> {
+    let state = state.lock().await;
+    let projs = state.projects.clone();
+
+    Ok(warp::reply::json(
+        &projs
+            .values()
+            .cloned()
+            .map(Project::from)
+            .collect::<Vec<_>>(),
+    ))
+}
+
+async fn events_handler(state: Arc<Mutex<State>>) -> Result<impl warp::Reply, warp::Rejection> {
+    let receiver = {
+        let mut state = state.lock().await;
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let projects = state.projects.values().cloned().collect();
+        let peers = state.peers.values().cloned().collect();
+        let info = state.info();
+
+        tx.send(Event::Snapshot {
+            projects,
+            peers,
+            info,
+        })
+        .unwrap();
+        state.subs.push(tx);
+
+        rx
+    };
+
+    Ok(warp::sse::reply(warp::sse::keep_alive().stream(
+        UnboundedReceiverStream::new(receiver).map(|e| warp::sse::Event::default().json_data(e)),
+    )))
+}

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -7,7 +7,9 @@
 #[macro_use]
 extern crate async_trait;
 
+pub mod cli;
 pub mod event;
+pub mod frontend;
 pub mod handle;
 pub mod project;
 pub mod signer;


### PR DESCRIPTION
Some Rust code was living in radicle-bins which made churn in some
librad components annoying to iterate on. This patch migrates that
code back here as the first step.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>