### PR TITLE
net: promote periodic membership tickle

### DIFF
--- a/librad/src/net/protocol/membership/periodic.rs
+++ b/librad/src/net/protocol/membership/periodic.rs
@@ -18,7 +18,7 @@ use futures_timer::Delay;
 use rand::Rng as _;
 
 use super::{Hpv, Shuffle};
-use crate::net::protocol::info::PeerInfo;
+use crate::net::{protocol::info::PeerInfo, quic::MAX_IDLE_TIMEOUT};
 
 pub enum Periodic<A>
 where
@@ -26,6 +26,7 @@ where
 {
     RandomPromotion { candidates: Vec<PeerInfo<A>> },
     Shuffle(Shuffle<A>),
+    Tickle,
 }
 
 #[tracing::instrument(skip(hpv, tx))]
@@ -38,7 +39,7 @@ where
 {
     let params = hpv.params();
 
-    let shuffle = Interval::new(params.shuffle_interval, Duration::from_secs(5)).filter_map(|()| {
+    let shuffle = Interval::new(params.shuffle_interval, Duration::from_secs(5)).filter_map(|_| {
         let p = hpv.shuffle().map(Periodic::Shuffle);
         if p.is_none() {
             tracing::warn!("nothing to shuffle");
@@ -46,7 +47,7 @@ where
         future::ready(p)
     });
 
-    let promote = Interval::new(params.promote_interval, Duration::from_secs(5)).filter_map(|()| {
+    let promote = Interval::new(params.promote_interval, Duration::from_secs(5)).filter_map(|_| {
         let candidates = hpv.choose_passive_to_promote();
         if candidates.is_empty() {
             tracing::warn!("nothing to promote");
@@ -56,7 +57,17 @@ where
         }
     });
 
-    if let Err(e) = stream::select(shuffle, promote).map(Ok).forward(tx).await {
+    let tickle = Interval::new(MAX_IDLE_TIMEOUT.div_f32(2.0), Duration::from_secs(5))
+        .filter_map(|_| future::ready(Some(Periodic::Tickle)));
+
+    // Wrapping the `select` calls is the most effective to combine the three
+    // interval streams into one. All other means (select macro, select_all)
+    // incur significant overhead.
+    if let Err(e) = stream::select(stream::select(promote, shuffle), tickle)
+        .map(Ok)
+        .forward(tx)
+        .await
+    {
         tracing::warn!(err = %e, "periodic tasks error");
     }
     tracing::info!("shutting down")

--- a/librad/src/net/quic.rs
+++ b/librad/src/net/quic.rs
@@ -32,7 +32,7 @@ const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
 ///
 /// Only has an effect for responders (servers), which we configure to not send
 /// keep alive probes. Should tolerate the loss of 1-2 keep-alive probes.
-const MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(65);
+pub(in crate::net) const MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(65);
 
 /// Maximum number of connections to a single peer.
 const MAX_PEER_CONNECTIONS: usize = 5;


### PR DESCRIPTION
To avoid connections being gc'ed when idling, there was a mechanism to
tickle all active ones in the current partial view. So far that was
placed after the await point of the stream processing, so it would not
be executed. To remedy the change tries to be barry algebraic by
introducing a new variant explicitely for the tickler. It does the job
but doesn't quite hit the mark as the current accept::periodic
implementation is very much tailored to the tick tocking - Likely
warrants a bit of a rework.

Signed-off-by: Alexander Simmerl <a.simmerl@gmail.com>