### PR TITLE
net: use stateless retry

### DIFF
--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -7,6 +7,8 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 nonempty = "0.6"
+thiserror = "1.0"
+typenum = "1.13"
 
 [dependencies.minicbor]
 version = ">= 0.6, 0"

--- a/data/src/bounded.rs
+++ b/data/src/bounded.rs
@@ -1,0 +1,393 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+#[cfg(any(feature = "serde", feature = "minicbor"))]
+use std::iter::FromIterator;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    marker::PhantomData,
+    ops::Deref,
+};
+
+use thiserror::Error;
+use typenum::{IsLessOrEqual, Unsigned, U0};
+
+/// Types which have a length.
+pub trait Length {
+    fn length(&self) -> usize;
+}
+
+impl<T> Length for Vec<T> {
+    fn length(&self) -> usize {
+        Vec::len(self)
+    }
+}
+
+impl<T> Length for BTreeSet<T> {
+    fn length(&self) -> usize {
+        BTreeSet::len(self)
+    }
+}
+
+impl<K, V> Length for BTreeMap<K, V> {
+    fn length(&self) -> usize {
+        BTreeMap::len(self)
+    }
+}
+
+impl<T, S> Length for HashSet<T, S> {
+    fn length(&self) -> usize {
+        HashSet::len(self)
+    }
+}
+
+impl<K, V, S> Length for HashMap<K, V, S> {
+    fn length(&self) -> usize {
+        HashMap::len(self)
+    }
+}
+
+impl Length for String {
+    fn length(&self) -> usize {
+        String::len(self)
+    }
+}
+
+impl Length for &str {
+    fn length(&self) -> usize {
+        str::len(self)
+    }
+}
+
+impl<T> Length for &[T] {
+    fn length(&self) -> usize {
+        (self as &[T]).len()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("minimum length {min} not reached: {len}")]
+    TooSmall { min: usize, len: usize },
+
+    #[error("maximum length {max} exceeded: {len}")]
+    TooLarge { max: usize, len: usize },
+}
+
+/// Newtype wrapper for types which have a [`Length`], witnessing that the
+/// length is within the inclusive range `[N, M]`.
+///
+/// Note that this type doesn't track the actual length on the type level, and
+/// so is immutable. Its main use is for validating untrusted input.
+pub struct Within<N, M, T> {
+    inner: T,
+    _min: PhantomData<N>,
+    _max: PhantomData<M>,
+}
+
+impl<N, M, T> Within<N, M, T> {
+    /// Construct a value whose [`Length`] is within `[N, M]`.
+    pub fn try_from_length(t: T) -> Result<Self, Error>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        T: Length,
+    {
+        let min = N::USIZE;
+        let max = M::USIZE;
+        let len = t.length();
+
+        if len < min {
+            Err(Error::TooSmall { min, len })
+        } else if len > max {
+            Err(Error::TooLarge { max, len })
+        } else {
+            Ok(Self {
+                inner: t,
+                _min: PhantomData,
+                _max: PhantomData,
+            })
+        }
+    }
+
+    /// Consumes the [`Within`], returning the wrapped value.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<N, M, T> Deref for Within<N, M, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Alias for types which might be empty (have a [`Length`] of zero), and a
+/// _maximum_ [`Length`] of `N`.
+pub type Bounded<N, T> = Within<U0, N, T>;
+
+/// Alias for a [`Bounded`] [`Vec`].
+pub type BoundedVec<N, T> = Bounded<N, Vec<T>>;
+
+/// Alias for a [`Bounded`] [`BTreeSet`].
+pub type BoundedOrderedSet<N, T> = Bounded<N, BTreeSet<T>>;
+
+/// Alias for a [`Bounded`] [`HashSet`].
+pub type BoundedHashSet<N, T, S> = Bounded<N, HashSet<T, S>>;
+
+/// Alias for a [`Bounded`] [`BTreeMap`].
+pub type BoundedOrderedMap<N, K, V> = Bounded<N, BTreeMap<K, V>>;
+
+/// Alias for a [`Bounded`] [`HashMap`].
+pub type BoundedHashMap<N, K, V, S> = Bounded<N, HashMap<K, V, S>>;
+
+/// Instead of returning an error when the deserialized value exceeds the
+/// maximum length, truncate it to the maximum length.
+///
+/// Note that this will deserialize the whole structure into memory before
+/// truncating it.
+///
+/// This function is only available when the `serde` feature is enabled.
+///
+/// # Example
+///
+/// ```no_run
+/// use radicle_data::BoundedVec;
+/// use typenum::U10;
+///
+/// #[derive(serde::Deserialize)]
+/// struct MyStruct {
+///     #[serde(deserialize_with = "radicle_data::bounded::deserialize_truncate")]
+///     just_ten: BoundedVec<U10, u8>,
+/// }
+/// ```
+#[cfg(feature = "serde")]
+pub fn deserialize_truncate<'de, N, T, D>(d: D) -> Result<Bounded<N, T>, D::Error>
+where
+    N: Unsigned,
+    T: serde::Deserialize<'de> + IntoIterator + FromIterator<T::Item>,
+    D: serde::Deserializer<'de>,
+{
+    let inner = T::deserialize(d)?.into_iter().take(N::USIZE).collect::<T>();
+    Ok(Bounded {
+        inner,
+        _min: PhantomData,
+        _max: PhantomData,
+    })
+}
+
+/// Instead of returning an error when the decoded value exceeds the maximum
+/// length, truncate it to the maximum length.
+///
+/// Note that this will decode the whole structure into memory before truncating
+/// it.
+///
+/// This function is only available when the `minicbor` feature is enabled.
+///
+/// # Example
+///
+/// ```no_run
+/// use radicle_data::BoundedVec;
+/// use typenum::U10;
+///
+/// #[derive(minicbor::Decode)]
+/// struct MyStruct {
+///     #[n(0)]
+///     #[cbor(decode_with = "radicle_data::bounded::decode_truncate")]
+///     just_ten: BoundedVec<U10, u8>,
+/// }
+/// ```
+#[cfg(feature = "minicbor")]
+pub fn decode_truncate<'de, N, T>(
+    d: &mut minicbor::Decoder<'de>,
+) -> Result<Bounded<N, T>, minicbor::decode::Error>
+where
+    N: Unsigned,
+    T: minicbor::Decode<'de> + IntoIterator + FromIterator<T::Item>,
+{
+    let inner = T::decode(d)?.into_iter().take(N::USIZE).collect::<T>();
+    Ok(Bounded {
+        inner,
+        _min: PhantomData,
+        _max: PhantomData,
+    })
+}
+
+#[cfg(feature = "serde")]
+mod serde_impls {
+    use super::*;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl<N, M, T> Serialize for Within<N, M, T>
+    where
+        T: Serialize,
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.inner.serialize(serializer)
+        }
+    }
+
+    impl<'de, N, M, T> Deserialize<'de> for Within<N, M, T>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        T: Deserialize<'de> + Length,
+    {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            use serde::de::Error as _;
+
+            let inner = T::deserialize(deserializer)?;
+            Within::try_from_length(inner).map_err(D::Error::custom)
+        }
+    }
+}
+
+#[cfg(feature = "minicbor")]
+mod minicbor_impls {
+    use super::*;
+    use std::{collections::hash_map::RandomState, hash::Hash};
+
+    use minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
+
+    impl<N, M, T> Encode for Within<N, M, T>
+    where
+        T: Encode,
+    {
+        fn encode<W: encode::Write>(
+            &self,
+            e: &mut Encoder<W>,
+        ) -> Result<(), encode::Error<W::Error>> {
+            self.inner.encode(e)
+        }
+    }
+
+    impl<'de, N, M, T> Decode<'de> for Within<N, M, Vec<T>>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        T: Decode<'de>,
+    {
+        fn decode(d: &mut Decoder<'de>) -> Result<Self, decode::Error> {
+            decode_array(d)
+        }
+    }
+
+    impl<'de, N, M, T> Decode<'de> for Within<N, M, BTreeSet<T>>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        T: Ord + Decode<'de>,
+    {
+        fn decode(d: &mut Decoder<'de>) -> Result<Self, decode::Error> {
+            decode_array(d)
+        }
+    }
+
+    impl<'de, N, M, K, V> Decode<'de> for Within<N, M, BTreeMap<K, V>>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        K: Ord + Decode<'de>,
+        V: Decode<'de>,
+    {
+        fn decode(d: &mut Decoder<'de>) -> Result<Self, decode::Error> {
+            decode_map(d)
+        }
+    }
+
+    impl<'de, N, M, T> Decode<'de> for Within<N, M, HashSet<T, RandomState>>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        T: Eq + Hash + Decode<'de>,
+    {
+        fn decode(d: &mut Decoder<'de>) -> Result<Self, decode::Error> {
+            decode_array(d)
+        }
+    }
+
+    impl<'de, N, M, K, V> Decode<'de> for Within<N, M, HashMap<K, V, RandomState>>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        K: Eq + Hash + Decode<'de>,
+        V: Decode<'de>,
+    {
+        fn decode(d: &mut Decoder<'de>) -> Result<Self, decode::Error> {
+            decode_map(d)
+        }
+    }
+
+    impl<'de, N, M> Decode<'de> for Within<N, M, String>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+    {
+        fn decode(d: &mut Decoder<'de>) -> Result<Self, decode::Error> {
+            decode_any(d)
+        }
+    }
+
+    fn decode_array<'de, N, M, T>(d: &mut Decoder<'de>) -> Result<Within<N, M, T>, decode::Error>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        T: Decode<'de> + Length,
+    {
+        use decode::Error::Message;
+
+        match d.probe().array()? {
+            Some(len) if len < N::U64 => Err(Message("min length not reached")),
+            Some(len) if len > M::U64 => Err(Message("max length exceeded")),
+            None | Some(_) => decode_any(d),
+        }
+    }
+
+    fn decode_map<'de, N, M, T>(d: &mut Decoder<'de>) -> Result<Within<N, M, T>, decode::Error>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        T: Decode<'de> + Length,
+    {
+        use decode::Error::Message;
+
+        match d.probe().map()? {
+            Some(len) if len < N::U64 => Err(Message("min length not reached")),
+            Some(len) if len > M::U64 => Err(Message("max length exceeded")),
+            None | Some(_) => decode_any(d),
+        }
+    }
+
+    fn decode_any<'de, N, M, T>(d: &mut Decoder<'de>) -> Result<Within<N, M, T>, decode::Error>
+    where
+        N: Unsigned + IsLessOrEqual<M>,
+        M: Unsigned,
+        T: Decode<'de> + Length,
+    {
+        use decode::Error::Message;
+
+        let inner = T::decode(d)?;
+        if inner.length() < N::USIZE {
+            Err(Message("min length not reached"))
+        } else if inner.length() > M::USIZE {
+            Err(Message("max length exceeded"))
+        } else {
+            Ok(Within {
+                inner,
+                _min: PhantomData,
+                _max: PhantomData,
+            })
+        }
+    }
+}

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -3,6 +3,17 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
+pub mod bounded;
+pub use crate::bounded::{
+    Bounded,
+    BoundedHashMap,
+    BoundedHashSet,
+    BoundedOrderedMap,
+    BoundedOrderedSet,
+    BoundedVec,
+    Within,
+};
+
 pub mod nonempty;
 pub use crate::nonempty::{
     NonEmpty,

--- a/data/src/nonempty.rs
+++ b/data/src/nonempty.rs
@@ -209,6 +209,7 @@ impl<T> NonEmpty<T> {
         container.insert(v);
         Self(container)
     }
+
     /// Construct a [`NonEmpty`] from a possibly empty type.
     ///
     /// If the argument is empty, ie. [`MaybeEmpty::is_empty`] evaluates to

--- a/e2e/compose.yaml
+++ b/e2e/compose.yaml
@@ -44,7 +44,7 @@ services:
         --listen 0.0.0.0:12345
         --graphite graphite:9109
     environment:
-    - RUST_LOG=debug
+    - 'RUST_LOG=${RUST_LOG:-debug}'
     deploy:
       replicas: 1
 
@@ -61,7 +61,7 @@ services:
         --bootstrap hyne66jefcpkobg91qzdy6ysetr8fn3p3d6myce61uwf7s67g3i79e@bootstrap:12345
         --graphite graphite:9109
     environment:
-    - RUST_LOG=debug
+    - 'RUST_LOG=${RUST_LOG:-debug}'
     deploy:
       replicas: 3
 

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -240,6 +240,8 @@ where
         self.phone.subscribe()
     }
 
+    /// Borrow a [`git::storage::Storage`] from the pool, and run a blocking
+    /// computation on it.
     pub async fn using_storage<F, A>(&self, blocking: F) -> Result<A, StorageError>
     where
         F: FnOnce(&git::storage::Storage) -> A + Send + 'static,
@@ -260,6 +262,19 @@ where
         }
     }
 
+    /// Borrow a [`git::storage::Storage`] from the pool directly.
+    ///
+    /// # WARNING
+    ///
+    /// Operations on [`git::storage::Storage`] are ususally blocking, and thus
+    /// require to be spawned to a dedicated thread pool in an async
+    /// context. [`Self::using_storage`] takes care of that, while the
+    /// consumer of this method's return value is responsible for spawning
+    /// themselves.
+    ///
+    /// Also note that the consumer is responsible for dropping the returned
+    /// value in a timely fashion after it is no longer needed, in order to
+    /// return the [`git::storage::Storage`] to the pool.
     pub async fn storage(
         &self,
     ) -> Result<impl AsRef<git::storage::Storage>, PoolError<git::storage::Error>> {

--- a/librad/src/net/quic/endpoint.rs
+++ b/librad/src/net/quic/endpoint.rs
@@ -307,6 +307,13 @@ where
     let mut quic_config = quinn::ServerConfigBuilder::default().build();
     quic_config.crypto = Arc::new(tls_config);
     quic_config.transport = Arc::new(transport_config);
+    quic_config
+        // https://tools.ietf.org/html/draft-ietf-quic-transport-11#section-6.5
+        .use_stateless_retry(true)
+        // below are quinn defaults
+        .retry_token_lifetime(15_000_000) // microseconds
+        .migration(true)
+        .concurrent_connections(100_000);
 
     Ok(quic_config)
 }


### PR DESCRIPTION
Popped off the reading list: QUIC stateless retry is essentially a
defense against UDP reflection attacks, adding one (small) roundtrip to
the handshake.

Signed-off-by: Kim Altintop <kim@monadic.xyz>