### PR TITLE
Remote helper signer can be configured

### DIFF
--- a/git-helpers/src/bin/remote/main.rs
+++ b/git-helpers/src/bin/remote/main.rs
@@ -6,5 +6,5 @@
 use radicle_git_helpers::remote_helper;
 
 fn main() -> anyhow::Result<()> {
-    remote_helper::run()
+    remote_helper::run(remote_helper::Config::default())
 }


### PR DESCRIPTION
Users of `radicle_git_helpers::remote_helper` can now configure the signer. This allows us to create integration tests with fast crypto [1].

[1]: https://github.com/radicle-dev/radicle-upstream/issues/1614