### PR TITLE
Connect to discovered peers concurrently

### DIFF
--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -28,7 +28,7 @@ where
     D: futures::Stream<Item = (PeerId, Vec<SocketAddr>)>,
 {
     disco
-        .for_each(|(peer, addrs)| {
+        .for_each_concurrent(10, |(peer, addrs)| {
             let state = state.clone();
             async move { io::discovered(state, peer, addrs).await }
         })


### PR DESCRIPTION
Before, connecting to a discovered peer would block the connecting to the peer discovered next. This would cause particular problems when we tried to connect to a peer that isn’t reachable and the connection would result in a timeout.