### PR TITLE
data: add a way to extend bounded types

### DIFF
--- a/data/src/bounded.rs
+++ b/data/src/bounded.rs
@@ -123,6 +123,21 @@ impl<N, M, T> Within<N, M, T> {
         iter::once(v).into()
     }
 
+    /// Extend the inner collection with the values of an iterator.
+    ///
+    /// To maintain the upper bound `M`, the given iterator may not be consumed
+    /// fully.
+    pub fn extend_fill<I, V>(&mut self, iter: I)
+    where
+        M: Unsigned,
+        I: IntoIterator<Item = V>,
+        T: Length + Extend<V>,
+    {
+        let len = self.inner.length();
+        let max = M::USIZE;
+        self.inner.extend(iter.into_iter().take(max - len));
+    }
+
     /// Consumes the [`Within`], returning the wrapped value.
     pub fn into_inner(self) -> T {
         self.inner


### PR DESCRIPTION
As the Extend trait promises to consume the iterator, we make it clear
that this may leave unconsumed elements in the iterator.

Signed-off-by: Kim Altintop <kim@monadic.xyz>