### PR TITLE
net: use a bounded vec for propagated address info

### DIFF
--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -18,6 +18,7 @@ dyn-clone = "1.0"
 futures-timer = "3.0"
 globset = "0.4"
 governor = ">=0.3.2"
+indexmap = "1.6"
 lazy_static = "1"
 libc = "0.2"
 multibase = "0.9"
@@ -92,6 +93,10 @@ features = ["std", "derive"]
 version = "0.7"
 default-features = false
 features = ["tls-rustls"]
+
+[dependencies.radicle-data]
+path = "../data"
+features = ["minicbor"]
 
 [dependencies.radicle-git-ext]
 path = "../git-ext"

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -25,6 +25,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate radicle_macros;
 
+pub extern crate radicle_data as data;
 pub extern crate radicle_git_ext as git_ext;
 pub extern crate radicle_keystore as keystore;
 pub extern crate radicle_std_ext as std_ext;

--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -3,7 +3,7 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::net::SocketAddr;
+use std::{iter, net::SocketAddr};
 
 use futures::stream::{self, StreamExt as _};
 
@@ -71,7 +71,7 @@ where
                         origin: PeerInfo {
                             peer_id: state.local_id,
                             advertised_info: io::peer_advertisement(&state.endpoint),
-                            seen_addrs: Default::default(),
+                            seen_addrs: iter::empty().into(),
                         },
                         peers: sample,
                         ttl,

--- a/librad/src/net/protocol/broadcast.rs
+++ b/librad/src/net/protocol/broadcast.rs
@@ -14,10 +14,7 @@ mod storage;
 pub use storage::{LocalStorage, PutResult};
 
 #[derive(Clone, Debug, PartialEq, minicbor::Encode, minicbor::Decode)]
-pub enum Message<Addr, Payload>
-where
-    Addr: Clone + Ord,
-{
+pub enum Message<Addr, Payload> {
     #[n(0)]
     #[cbor(array)]
     Have {
@@ -49,7 +46,7 @@ pub(super) trait ErrorRateLimited {
 #[derive(Debug, Error)]
 pub enum Error<A, P>
 where
-    A: Clone + Debug + Ord,
+    A: Debug,
     P: Debug,
 {
     #[error("unsolicited message from {remote_id}")]
@@ -71,7 +68,7 @@ where
     M: Membership,
     S: LocalStorage<A, Update = P> + ErrorRateLimited,
     F: Fn() -> PeerInfo<A>,
-    A: Clone + Debug + Ord + Send + 'static,
+    A: Clone + Debug + Send + 'static,
     P: Clone + Debug,
 {
     use tick::Tock::*;

--- a/librad/src/net/protocol/control.rs
+++ b/librad/src/net/protocol/control.rs
@@ -3,7 +3,7 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::net::SocketAddr;
+use std::{iter, net::SocketAddr};
 
 use futures::stream::{self, StreamExt as _};
 use tracing::Instrument as _;
@@ -19,7 +19,7 @@ where
     let origin = PeerInfo {
         peer_id: state.local_id,
         advertised_info: io::peer_advertisement(&state.endpoint),
-        seen_addrs: Default::default(),
+        seen_addrs: iter::empty().into(),
     };
     // TODO: answer `Want`s from a provider cache
     let rpc = match evt {

--- a/librad/src/net/protocol/error/internal.rs
+++ b/librad/src/net/protocol/error/internal.rs
@@ -42,7 +42,7 @@ impl From<CborCodecError> for Gossip {
 }
 
 #[derive(Debug, Error)]
-pub enum Tock<A: Clone + Ord + Debug + 'static> {
+pub enum Tock<A: Debug + 'static> {
     #[error(transparent)]
     Reliable(#[from] ReliableSend<A>),
 
@@ -52,7 +52,7 @@ pub enum Tock<A: Clone + Ord + Debug + 'static> {
 
 #[derive(Debug, Error)]
 #[error("reliable send failed")]
-pub struct ReliableSend<A: Clone + Ord + Debug + 'static> {
+pub struct ReliableSend<A: Debug + 'static> {
     pub cont: Vec<membership::Tick<A>>,
     pub source: ReliableSendSource,
 }
@@ -67,7 +67,7 @@ pub enum ReliableSendSource {
 }
 
 #[derive(Debug, Error)]
-pub enum BestEffortSend<A: Clone + Ord + Debug + 'static> {
+pub enum BestEffortSend<A: Debug + 'static> {
     #[error("could not connect to {}", to.peer_id)]
     CouldNotConnect { to: PeerInfo<A> },
 

--- a/librad/src/net/protocol/event.rs
+++ b/librad/src/net/protocol/event.rs
@@ -101,10 +101,7 @@ pub mod upstream {
     }
 
     #[derive(Clone, Debug)]
-    pub enum Gossip<Addr, Payload>
-    where
-        Addr: Clone + Ord,
-    {
+    pub enum Gossip<Addr, Payload> {
         /// Triggered after applying a `Have` to [`broadcast::LocalStorage`].
         Put {
             /// The peer who announced the `Have`

--- a/librad/src/net/protocol/info.rs
+++ b/librad/src/net/protocol/info.rs
@@ -5,7 +5,9 @@
 
 use std::{collections::BTreeSet, convert::TryFrom, option::NoneError};
 
+use data::BoundedVec;
 use minicbor::{Decode, Encode};
+use typenum::U16;
 
 use crate::peer::PeerId;
 
@@ -19,10 +21,7 @@ pub enum Capability {
 pub type PeerInfo<Addr> = GenericPeerInfo<Addr, PeerAdvertisement<Addr>>;
 pub type PartialPeerInfo<Addr> = GenericPeerInfo<Addr, Option<PeerAdvertisement<Addr>>>;
 
-impl<Addr> PartialPeerInfo<Addr>
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> PartialPeerInfo<Addr> {
     pub fn sequence(self) -> Option<PeerInfo<Addr>> {
         let PartialPeerInfo {
             peer_id,
@@ -37,10 +36,7 @@ where
     }
 }
 
-impl<Addr> TryFrom<PartialPeerInfo<Addr>> for PeerInfo<Addr>
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> TryFrom<PartialPeerInfo<Addr>> for PeerInfo<Addr> {
     type Error = NoneError;
 
     fn try_from(part: PartialPeerInfo<Addr>) -> Result<Self, Self::Error> {
@@ -48,10 +44,7 @@ where
     }
 }
 
-impl<Addr> From<PeerInfo<Addr>> for PartialPeerInfo<Addr>
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> From<PeerInfo<Addr>> for PartialPeerInfo<Addr> {
     fn from(
         PeerInfo {
             peer_id,
@@ -67,10 +60,7 @@ where
     }
 }
 
-impl<Addr> From<PartialPeerInfo<Addr>> for (PeerId, Vec<Addr>)
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> From<PartialPeerInfo<Addr>> for (PeerId, Vec<Addr>) {
     fn from(info: PartialPeerInfo<Addr>) -> Self {
         (
             info.peer_id,
@@ -83,10 +73,7 @@ where
     }
 }
 
-impl<Addr> From<PeerInfo<Addr>> for (PeerId, Vec<Addr>)
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> From<PeerInfo<Addr>> for (PeerId, Vec<Addr>) {
     fn from(info: PeerInfo<Addr>) -> Self {
         (
             info.peer_id,
@@ -99,12 +86,9 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Encode)]
 #[cbor(array)]
-pub struct GenericPeerInfo<Addr, T>
-where
-    Addr: Clone + Ord,
-{
+pub struct GenericPeerInfo<Addr, T> {
     #[n(0)]
     pub peer_id: PeerId,
 
@@ -112,29 +96,132 @@ where
     pub advertised_info: T,
 
     #[n(2)]
-    pub seen_addrs: BTreeSet<Addr>,
+    pub seen_addrs: BoundedVec<U16, Addr>,
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
-#[cbor(array)]
-pub struct PeerAdvertisement<Addr>
-where
-    Addr: Clone + Ord,
+// XXX: derive fails to add the trait bound on Addr
+impl<'__b777, Addr: minicbor::Decode<'__b777>, T: minicbor::Decode<'__b777>>
+    minicbor::Decode<'__b777> for GenericPeerInfo<Addr, T>
 {
+    fn decode(
+        __d777: &mut minicbor::Decoder<'__b777>,
+    ) -> Result<GenericPeerInfo<Addr, T>, minicbor::decode::Error> {
+        let mut peer_id: Option<PeerId> = None;
+        let mut advertised_info: Option<T> = None;
+        let mut seen_addrs: Option<BoundedVec<U16, Addr>> = None;
+        if let Some(__len777) = __d777.array()? {
+            for __i777 in 0..__len777 {
+                match __i777 {
+                    0 => peer_id = Some(minicbor::Decode::decode(__d777)?),
+                    1 => advertised_info = Some(minicbor::Decode::decode(__d777)?),
+                    2 => seen_addrs = Some(radicle_data::bounded::decode_truncate(__d777)?),
+                    _ => __d777.skip()?,
+                }
+            }
+        } else {
+            let mut __i777 = 0;
+            while minicbor::data::Type::Break != __d777.datatype()? {
+                match __i777 {
+                    0 => peer_id = Some(minicbor::Decode::decode(__d777)?),
+                    1 => advertised_info = Some(minicbor::Decode::decode(__d777)?),
+                    2 => seen_addrs = Some(radicle_data::bounded::decode_truncate(__d777)?),
+                    _ => __d777.skip()?,
+                }
+                __i777 += 1
+            }
+            __d777.skip()?
+        }
+        Ok(GenericPeerInfo {
+            peer_id: if let Some(x) = peer_id {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    0,
+                    "GenericPeerInfo::peer_id",
+                ));
+            },
+            advertised_info: if let Some(x) = advertised_info {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    1,
+                    "GenericPeerInfo::advertised_info",
+                ));
+            },
+            seen_addrs: if let Some(x) = seen_addrs {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    2,
+                    "GenericPeerInfo::seen_addrs",
+                ));
+            },
+        })
+    }
+}
+#[derive(Debug, Clone, PartialEq, Encode)]
+#[cbor(array)]
+pub struct PeerAdvertisement<Addr> {
     #[n(0)]
-    pub listen_addrs: BTreeSet<Addr>,
+    pub listen_addrs: BoundedVec<U16, Addr>,
 
     #[n(2)]
     pub capabilities: BTreeSet<Capability>,
 }
 
-impl<Addr> PeerAdvertisement<Addr>
-where
-    Addr: Clone + Ord,
+// XXX: derive fails to add the trait bound on Addr
+impl<'__b777, Addr: minicbor::Decode<'__b777>> minicbor::Decode<'__b777>
+    for PeerAdvertisement<Addr>
 {
+    fn decode(
+        __d777: &mut minicbor::Decoder<'__b777>,
+    ) -> Result<PeerAdvertisement<Addr>, minicbor::decode::Error> {
+        let mut listen_addrs: Option<BoundedVec<U16, Addr>> = None;
+        let mut capabilities: Option<BTreeSet<Capability>> = None;
+        if let Some(__len777) = __d777.array()? {
+            for __i777 in 0..__len777 {
+                match __i777 {
+                    0 => listen_addrs = Some(radicle_data::bounded::decode_truncate(__d777)?),
+                    2 => capabilities = Some(minicbor::Decode::decode(__d777)?),
+                    _ => __d777.skip()?,
+                }
+            }
+        } else {
+            let mut __i777 = 0;
+            while minicbor::data::Type::Break != __d777.datatype()? {
+                match __i777 {
+                    0 => listen_addrs = Some(radicle_data::bounded::decode_truncate(__d777)?),
+                    2 => capabilities = Some(minicbor::Decode::decode(__d777)?),
+                    _ => __d777.skip()?,
+                }
+                __i777 += 1
+            }
+            __d777.skip()?
+        }
+        Ok(PeerAdvertisement {
+            listen_addrs: if let Some(x) = listen_addrs {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    0,
+                    "PeerAdvertisement::listen_addrs",
+                ));
+            },
+            capabilities: if let Some(x) = capabilities {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    2,
+                    "PeerAdvertisement::capabilities",
+                ));
+            },
+        })
+    }
+}
+impl<Addr> PeerAdvertisement<Addr> {
     pub fn new(listen_addr: Addr) -> Self {
         Self {
-            listen_addrs: vec![listen_addr].into_iter().collect(),
+            listen_addrs: BoundedVec::singleton(listen_addr),
             capabilities: BTreeSet::default(),
         }
     }

--- a/librad/src/net/protocol/io/connections.rs
+++ b/librad/src/net/protocol/io/connections.rs
@@ -3,13 +3,14 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::{collections::BTreeSet, net::SocketAddr, panic};
+use std::{net::SocketAddr, panic};
 
 use either::Either;
 use futures::{
     future::{self, TryFutureExt as _},
     stream::{FuturesUnordered, Stream, StreamExt as _},
 };
+use indexmap::IndexSet;
 use tracing::Instrument as _;
 
 use crate::{
@@ -105,10 +106,9 @@ pub async fn connect_peer_info(
     >,
 )> {
     let addrs = peer_info
-        .advertised_info
-        .listen_addrs
+        .seen_addrs
         .into_iter()
-        .chain(peer_info.seen_addrs.into_iter());
+        .chain(peer_info.advertised_info.listen_addrs);
     connect(endpoint, peer_info.peer_id, addrs).await
 }
 
@@ -131,7 +131,7 @@ where
         !(ip.is_unspecified() || ip.is_documentation() || ip.is_multicast())
     }
 
-    let addrs = addrs.into_iter().filter(routable).collect::<BTreeSet<_>>();
+    let addrs = addrs.into_iter().filter(routable).collect::<IndexSet<_>>();
     if addrs.is_empty() {
         tracing::warn!("no routable addrs");
         None

--- a/librad/src/net/protocol/io/recv/gossip.rs
+++ b/librad/src/net/protocol/io/recv/gossip.rs
@@ -3,7 +3,7 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::net::SocketAddr;
+use std::{iter, net::SocketAddr};
 
 use futures::{
     io::AsyncRead,
@@ -57,7 +57,7 @@ pub(in crate::net::protocol) async fn gossip<S, T>(
                 let peer_info = || PeerInfo {
                     peer_id: state.local_id,
                     advertised_info: peer_advertisement(&state.endpoint),
-                    seen_addrs: Default::default(),
+                    seen_addrs: iter::empty().into(),
                 };
                 match broadcast::apply(
                     &state.membership,

--- a/librad/src/net/protocol/io/send/rpc.rs
+++ b/librad/src/net/protocol/io/send/rpc.rs
@@ -16,27 +16,18 @@ use crate::net::{
 };
 
 #[derive(Debug)]
-pub enum Rpc<A, P>
-where
-    A: Clone + Ord,
-{
+pub enum Rpc<A, P> {
     Membership(membership::Message<A>),
     Gossip(broadcast::Message<A, P>),
 }
 
-impl<A, P> From<membership::Message<A>> for Rpc<A, P>
-where
-    A: Clone + Ord,
-{
+impl<A, P> From<membership::Message<A>> for Rpc<A, P> {
     fn from(m: membership::Message<A>) -> Self {
         Self::Membership(m)
     }
 }
 
-impl<A, P> From<broadcast::Message<A, P>> for Rpc<A, P>
-where
-    A: Clone + Ord,
-{
+impl<A, P> From<broadcast::Message<A, P>> for Rpc<A, P> {
     fn from(m: broadcast::Message<A, P>) -> Self {
         Self::Gossip(m)
     }

--- a/librad/src/net/protocol/membership.rs
+++ b/librad/src/net/protocol/membership.rs
@@ -40,7 +40,7 @@ pub(super) fn apply<R, A, F, P>(
 ) -> Result<(Vec<Transition<A>>, Vec<Tock<A, P>>), Error>
 where
     R: rand::Rng + Clone,
-    A: Clone + Debug + Ord,
+    A: Clone + Debug + PartialEq,
     F: Fn() -> PeerAdvertisement<A>,
 {
     hpv.apply(remote_id, remote_addr, message)
@@ -58,7 +58,7 @@ where
 pub(super) fn collect_tocks<R, A, F, P>(hpv: &Hpv<R, A>, info: &F, tick: Tick<A>) -> Vec<Tock<A, P>>
 where
     R: rand::Rng + Clone,
-    A: Clone + Debug + Ord,
+    A: Clone + Debug + PartialEq,
     F: Fn() -> PeerAdvertisement<A>,
 {
     use Tick::*;

--- a/librad/src/net/protocol/membership/periodic.rs
+++ b/librad/src/net/protocol/membership/periodic.rs
@@ -20,10 +20,7 @@ use rand::Rng as _;
 use super::{Hpv, Shuffle};
 use crate::net::{protocol::info::PeerInfo, quic::MAX_IDLE_TIMEOUT};
 
-pub enum Periodic<A>
-where
-    A: Clone + Ord,
-{
+pub enum Periodic<A> {
     RandomPromotion { candidates: Vec<PeerInfo<A>> },
     Shuffle(Shuffle<A>),
     Tickle,
@@ -33,7 +30,7 @@ where
 pub(super) async fn periodic_tasks<Rng, Addr, T>(hpv: Hpv<Rng, Addr>, tx: T)
 where
     Rng: rand::Rng + Clone,
-    Addr: Clone + Debug + Ord + Send + Sync + 'static,
+    Addr: Clone + Debug + PartialEq + Send + Sync + 'static,
     T: futures::Sink<Periodic<Addr>>,
     T::Error: Display,
 {

--- a/librad/src/net/protocol/membership/rpc.rs
+++ b/librad/src/net/protocol/membership/rpc.rs
@@ -6,10 +6,7 @@
 use crate::net::protocol::info::{PeerAdvertisement, PeerInfo};
 
 #[derive(Debug, Clone, PartialEq, minicbor::Encode, minicbor::Decode)]
-pub enum Message<Addr>
-where
-    Addr: Clone + Ord,
-{
+pub enum Message<Addr> {
     #[n(0)]
     #[cbor(array)]
     Join {

--- a/librad/src/net/protocol/membership/tick.rs
+++ b/librad/src/net/protocol/membership/tick.rs
@@ -7,10 +7,7 @@ use super::{partial_view::Transition, rpc::Message};
 use crate::{net::protocol::info::PeerInfo, PeerId};
 
 #[derive(Debug)]
-pub enum Tick<Addr>
-where
-    Addr: Clone + Ord,
-{
+pub enum Tick<Addr> {
     /// Deliver `message` to all `recipients`.
     ///
     /// Failed recipients must be evicted from the active view.
@@ -43,10 +40,7 @@ where
     Forget { peer: PeerId },
 }
 
-impl<A> From<Transition<A>> for Option<Tick<A>>
-where
-    A: Clone + Ord,
-{
+impl<A> From<Transition<A>> for Option<Tick<A>> {
     fn from(t: Transition<A>) -> Self {
         use Tick::*;
         use Transition::*;

--- a/librad/src/net/protocol/tick.rs
+++ b/librad/src/net/protocol/tick.rs
@@ -15,10 +15,7 @@ use super::{error, gossip, io, membership, PeerInfo, ProtocolStorage, State};
 use crate::PeerId;
 
 #[derive(Debug)]
-pub(super) enum Tock<A, P>
-where
-    A: Clone + Ord,
-{
+pub(super) enum Tock<A, P> {
     /// Send to connected peer, or notify of connection loss
     SendConnected { to: PeerId, message: io::Rpc<A, P> },
 

--- a/librad/tests/smoke/interrogation.rs
+++ b/librad/tests/smoke/interrogation.rs
@@ -5,7 +5,7 @@
 
 use std::ops::Index as _;
 
-use librad::{identities::SomeUrn, net::protocol::PeerAdvertisement};
+use librad::{data::BoundedVec, identities::SomeUrn, net::protocol::PeerAdvertisement};
 use librad_test::{
     logging,
     rad::{identities::TestProject, testnet},
@@ -37,7 +37,10 @@ async fn responds() {
             requester.interrogate((responder.peer_id(), responder.listen_addrs().to_vec()));
         assert_eq!(
             PeerAdvertisement {
-                listen_addrs: responder.listen_addrs().iter().copied().collect(),
+                listen_addrs: BoundedVec::try_from_length(
+                    responder.listen_addrs().iter().copied().collect()
+                )
+                .unwrap(),
                 capabilities: Default::default(),
             },
             interrogation.peer_advertisement().await.unwrap()


### PR DESCRIPTION
This is a long-standing open issue: we need to make sure that collection
types are always bounded on the wire.

Note that, while morally a set, set semantics were not captured
precisely:

1. For establishing a connection, we take the union of the seen and
   advertised addresses, with a bias towards the former.
2. For maintaining the seen addresses, we bias towards the more recent
   information.

1. needs to be computed at runtime anyways, while 2. is much simpler to
maintain using a (small) Vec instead of a specialised insertion-ordered
set type. We thus spare ourselves the nuisance of having to thread
through an Ord or Hash constraint on the datatype level.

Signed-off-by: Kim Altintop <kim@monadic.xyz>