### PR TITLE
net: move protocol state struct into its own module

### DIFF
--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -18,6 +18,7 @@ dyn-clone = "1.0"
 futures-timer = "3.0"
 globset = "0.4"
 governor = ">=0.3.2"
+indexmap = "1.6"
 lazy_static = "1"
 libc = "0.2"
 multibase = "0.9"
@@ -92,6 +93,10 @@ features = ["std", "derive"]
 version = "0.7"
 default-features = false
 features = ["tls-rustls"]
+
+[dependencies.radicle-data]
+path = "../data"
+features = ["minicbor"]
 
 [dependencies.radicle-git-ext]
 path = "../git-ext"

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -25,6 +25,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate radicle_macros;
 
+pub extern crate radicle_data as data;
 pub extern crate radicle_git_ext as git_ext;
 pub extern crate radicle_keystore as keystore;
 pub extern crate radicle_std_ext as std_ext;

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -7,7 +7,6 @@ use std::{
     fmt::Debug,
     future::Future,
     net::SocketAddr,
-    ops::Deref,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -16,12 +15,10 @@ use std::{
 
 use futures::{
     channel::mpsc,
-    future::{BoxFuture, FutureExt as _, TryFutureExt as _},
+    future::{BoxFuture, FutureExt as _},
     stream::StreamExt as _,
 };
-use governor::{Quota, RateLimiter};
 use nonempty::NonEmpty;
-use nonzero_ext::nonzero;
 use rand_pcg::Pcg64Mcg;
 use tracing::Instrument as _;
 
@@ -34,12 +31,9 @@ use super::{
 use crate::{
     git::{
         self,
-        p2p::{
-            server::GitServer,
-            transport::{GitStream, GitStreamFactory},
-        },
+        p2p::{server::GitServer, transport::GitStreamFactory},
         replication,
-        storage::{self, PoolError, PooledRef},
+        storage,
     },
     paths::Paths,
     signer::Signer,
@@ -66,6 +60,9 @@ mod tick;
 mod tincans;
 pub(super) use tincans::TinCans;
 pub use tincans::{Interrogation, RecvError};
+
+mod state;
+use state::{State, StateConfig, Storage};
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -266,147 +263,6 @@ pub trait ProtocolStorage<A>: broadcast::LocalStorage<A> + storage::Pooled + Sen
 impl<A, T> ProtocolStorage<A> for T where
     T: broadcast::LocalStorage<A> + storage::Pooled + Send + Sync
 {
-}
-
-type Limiter = governor::RateLimiter<
-    governor::state::direct::NotKeyed,
-    governor::state::InMemoryState,
-    governor::clock::DefaultClock,
->;
-
-#[derive(Clone)]
-struct Storage<S> {
-    inner: S,
-    limiter: Arc<Limiter>,
-}
-
-impl<S> From<S> for Storage<S> {
-    fn from(inner: S) -> Self {
-        Self {
-            inner,
-            limiter: Arc::new(RateLimiter::direct(Quota::per_second(
-                // TODO: make this an "advanced" config
-                nonzero!(5u32),
-            ))),
-        }
-    }
-}
-
-impl<S> Deref for Storage<S> {
-    type Target = S;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-#[async_trait]
-impl<A, S> broadcast::LocalStorage<A> for Storage<S>
-where
-    A: 'static,
-    S: broadcast::LocalStorage<A>,
-    S::Update: Send,
-{
-    type Update = S::Update;
-
-    async fn put<P>(&self, provider: P, has: Self::Update) -> broadcast::PutResult<Self::Update>
-    where
-        P: Into<(PeerId, Vec<A>)> + Send,
-    {
-        self.inner.put(provider, has).await
-    }
-
-    async fn ask(&self, want: Self::Update) -> bool {
-        self.inner.ask(want).await
-    }
-}
-
-impl<S> broadcast::ErrorRateLimited for Storage<S> {
-    fn is_error_rate_limit_breached(&self) -> bool {
-        self.limiter.check().is_err()
-    }
-}
-
-#[async_trait]
-impl<S> storage::Pooled for Storage<S>
-where
-    S: storage::Pooled + Send + Sync,
-{
-    async fn get(&self) -> Result<PooledRef, PoolError> {
-        self.inner.get().await
-    }
-}
-
-#[derive(Clone, Copy)]
-pub struct StateConfig {
-    pub replication: replication::Config,
-    pub fetch: config::Fetch,
-}
-
-#[derive(Clone)]
-struct State<S> {
-    local_id: PeerId,
-    endpoint: quic::Endpoint,
-    git: GitServer,
-    membership: membership::Hpv<Pcg64Mcg, SocketAddr>,
-    storage: Storage<S>,
-    phone: TinCans,
-    config: StateConfig,
-    nonces: nonce::NonceBag,
-    caches: cache::Caches,
-}
-
-#[async_trait]
-impl<S> GitStreamFactory for State<S>
-where
-    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + Clone + 'static,
-{
-    async fn open_stream(
-        &self,
-        to: &PeerId,
-        addr_hints: &[SocketAddr],
-    ) -> Option<Box<dyn GitStream>> {
-        let span = tracing::info_span!("open-git-stream", remote_id = %to);
-
-        let may_conn = match self.endpoint.get_connection(*to) {
-            Some(conn) => Some(conn),
-            None => {
-                let addr_hints = addr_hints.iter().copied().collect::<Vec<_>>();
-                io::connect(&self.endpoint, *to, addr_hints)
-                    .instrument(span.clone())
-                    .await
-                    .map(|(conn, ingress)| {
-                        tokio::spawn(
-                            io::streams::incoming(self.clone(), ingress).instrument(span.clone()),
-                        );
-                        conn
-                    })
-            },
-        };
-
-        match may_conn {
-            None => {
-                span.in_scope(|| tracing::error!("unable to obtain connection"));
-                None
-            },
-
-            Some(conn) => {
-                let stream = conn
-                    .open_bidi()
-                    .inspect_err(|e| tracing::error!(err = ?e, "unable to open stream"))
-                    .instrument(span.clone())
-                    .await
-                    .ok()?;
-                let upgraded = upgrade::upgrade(stream, upgrade::Git)
-                    .inspect_err(|e| tracing::error!(err = ?e, "unable to upgrade stream"))
-                    .instrument(span)
-                    .await
-                    .ok()?;
-
-                Some(Box::new(upgraded))
-            },
-        }
-    }
 }
 
 impl<R, A> broadcast::Membership for membership::Hpv<R, A>

--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -3,7 +3,7 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::net::SocketAddr;
+use std::{iter, net::SocketAddr};
 
 use futures::stream::{self, StreamExt as _};
 
@@ -71,7 +71,7 @@ where
                         origin: PeerInfo {
                             peer_id: state.local_id,
                             advertised_info: io::peer_advertisement(&state.endpoint),
-                            seen_addrs: Default::default(),
+                            seen_addrs: iter::empty().into(),
                         },
                         peers: sample,
                         ttl,

--- a/librad/src/net/protocol/broadcast.rs
+++ b/librad/src/net/protocol/broadcast.rs
@@ -14,10 +14,7 @@ mod storage;
 pub use storage::{LocalStorage, PutResult};
 
 #[derive(Clone, Debug, PartialEq, minicbor::Encode, minicbor::Decode)]
-pub enum Message<Addr, Payload>
-where
-    Addr: Clone + Ord,
-{
+pub enum Message<Addr, Payload> {
     #[n(0)]
     #[cbor(array)]
     Have {
@@ -49,7 +46,7 @@ pub(super) trait ErrorRateLimited {
 #[derive(Debug, Error)]
 pub enum Error<A, P>
 where
-    A: Clone + Debug + Ord,
+    A: Debug,
     P: Debug,
 {
     #[error("unsolicited message from {remote_id}")]
@@ -71,7 +68,7 @@ where
     M: Membership,
     S: LocalStorage<A, Update = P> + ErrorRateLimited,
     F: Fn() -> PeerInfo<A>,
-    A: Clone + Debug + Ord + Send + 'static,
+    A: Clone + Debug + Send + 'static,
     P: Clone + Debug,
 {
     use tick::Tock::*;

--- a/librad/src/net/protocol/control.rs
+++ b/librad/src/net/protocol/control.rs
@@ -3,7 +3,7 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::net::SocketAddr;
+use std::{iter, net::SocketAddr};
 
 use futures::stream::{self, StreamExt as _};
 use tracing::Instrument as _;
@@ -19,7 +19,7 @@ where
     let origin = PeerInfo {
         peer_id: state.local_id,
         advertised_info: io::peer_advertisement(&state.endpoint),
-        seen_addrs: Default::default(),
+        seen_addrs: iter::empty().into(),
     };
     // TODO: answer `Want`s from a provider cache
     let rpc = match evt {

--- a/librad/src/net/protocol/error/internal.rs
+++ b/librad/src/net/protocol/error/internal.rs
@@ -42,7 +42,7 @@ impl From<CborCodecError> for Gossip {
 }
 
 #[derive(Debug, Error)]
-pub enum Tock<A: Clone + Ord + Debug + 'static> {
+pub enum Tock<A: Debug + 'static> {
     #[error(transparent)]
     Reliable(#[from] ReliableSend<A>),
 
@@ -52,7 +52,7 @@ pub enum Tock<A: Clone + Ord + Debug + 'static> {
 
 #[derive(Debug, Error)]
 #[error("reliable send failed")]
-pub struct ReliableSend<A: Clone + Ord + Debug + 'static> {
+pub struct ReliableSend<A: Debug + 'static> {
     pub cont: Vec<membership::Tick<A>>,
     pub source: ReliableSendSource,
 }
@@ -67,7 +67,7 @@ pub enum ReliableSendSource {
 }
 
 #[derive(Debug, Error)]
-pub enum BestEffortSend<A: Clone + Ord + Debug + 'static> {
+pub enum BestEffortSend<A: Debug + 'static> {
     #[error("could not connect to {}", to.peer_id)]
     CouldNotConnect { to: PeerInfo<A> },
 

--- a/librad/src/net/protocol/event.rs
+++ b/librad/src/net/protocol/event.rs
@@ -101,10 +101,7 @@ pub mod upstream {
     }
 
     #[derive(Clone, Debug)]
-    pub enum Gossip<Addr, Payload>
-    where
-        Addr: Clone + Ord,
-    {
+    pub enum Gossip<Addr, Payload> {
         /// Triggered after applying a `Have` to [`broadcast::LocalStorage`].
         Put {
             /// The peer who announced the `Have`

--- a/librad/src/net/protocol/info.rs
+++ b/librad/src/net/protocol/info.rs
@@ -5,7 +5,9 @@
 
 use std::{collections::BTreeSet, convert::TryFrom, option::NoneError};
 
+use data::BoundedVec;
 use minicbor::{Decode, Encode};
+use typenum::U16;
 
 use crate::peer::PeerId;
 
@@ -19,10 +21,7 @@ pub enum Capability {
 pub type PeerInfo<Addr> = GenericPeerInfo<Addr, PeerAdvertisement<Addr>>;
 pub type PartialPeerInfo<Addr> = GenericPeerInfo<Addr, Option<PeerAdvertisement<Addr>>>;
 
-impl<Addr> PartialPeerInfo<Addr>
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> PartialPeerInfo<Addr> {
     pub fn sequence(self) -> Option<PeerInfo<Addr>> {
         let PartialPeerInfo {
             peer_id,
@@ -37,10 +36,7 @@ where
     }
 }
 
-impl<Addr> TryFrom<PartialPeerInfo<Addr>> for PeerInfo<Addr>
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> TryFrom<PartialPeerInfo<Addr>> for PeerInfo<Addr> {
     type Error = NoneError;
 
     fn try_from(part: PartialPeerInfo<Addr>) -> Result<Self, Self::Error> {
@@ -48,10 +44,7 @@ where
     }
 }
 
-impl<Addr> From<PeerInfo<Addr>> for PartialPeerInfo<Addr>
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> From<PeerInfo<Addr>> for PartialPeerInfo<Addr> {
     fn from(
         PeerInfo {
             peer_id,
@@ -67,10 +60,7 @@ where
     }
 }
 
-impl<Addr> From<PartialPeerInfo<Addr>> for (PeerId, Vec<Addr>)
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> From<PartialPeerInfo<Addr>> for (PeerId, Vec<Addr>) {
     fn from(info: PartialPeerInfo<Addr>) -> Self {
         (
             info.peer_id,
@@ -83,10 +73,7 @@ where
     }
 }
 
-impl<Addr> From<PeerInfo<Addr>> for (PeerId, Vec<Addr>)
-where
-    Addr: Clone + Ord,
-{
+impl<Addr> From<PeerInfo<Addr>> for (PeerId, Vec<Addr>) {
     fn from(info: PeerInfo<Addr>) -> Self {
         (
             info.peer_id,
@@ -99,12 +86,9 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Encode)]
 #[cbor(array)]
-pub struct GenericPeerInfo<Addr, T>
-where
-    Addr: Clone + Ord,
-{
+pub struct GenericPeerInfo<Addr, T> {
     #[n(0)]
     pub peer_id: PeerId,
 
@@ -112,29 +96,132 @@ where
     pub advertised_info: T,
 
     #[n(2)]
-    pub seen_addrs: BTreeSet<Addr>,
+    pub seen_addrs: BoundedVec<U16, Addr>,
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
-#[cbor(array)]
-pub struct PeerAdvertisement<Addr>
-where
-    Addr: Clone + Ord,
+// XXX: derive fails to add the trait bound on Addr
+impl<'__b777, Addr: minicbor::Decode<'__b777>, T: minicbor::Decode<'__b777>>
+    minicbor::Decode<'__b777> for GenericPeerInfo<Addr, T>
 {
+    fn decode(
+        __d777: &mut minicbor::Decoder<'__b777>,
+    ) -> Result<GenericPeerInfo<Addr, T>, minicbor::decode::Error> {
+        let mut peer_id: Option<PeerId> = None;
+        let mut advertised_info: Option<T> = None;
+        let mut seen_addrs: Option<BoundedVec<U16, Addr>> = None;
+        if let Some(__len777) = __d777.array()? {
+            for __i777 in 0..__len777 {
+                match __i777 {
+                    0 => peer_id = Some(minicbor::Decode::decode(__d777)?),
+                    1 => advertised_info = Some(minicbor::Decode::decode(__d777)?),
+                    2 => seen_addrs = Some(radicle_data::bounded::decode_truncate(__d777)?),
+                    _ => __d777.skip()?,
+                }
+            }
+        } else {
+            let mut __i777 = 0;
+            while minicbor::data::Type::Break != __d777.datatype()? {
+                match __i777 {
+                    0 => peer_id = Some(minicbor::Decode::decode(__d777)?),
+                    1 => advertised_info = Some(minicbor::Decode::decode(__d777)?),
+                    2 => seen_addrs = Some(radicle_data::bounded::decode_truncate(__d777)?),
+                    _ => __d777.skip()?,
+                }
+                __i777 += 1
+            }
+            __d777.skip()?
+        }
+        Ok(GenericPeerInfo {
+            peer_id: if let Some(x) = peer_id {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    0,
+                    "GenericPeerInfo::peer_id",
+                ));
+            },
+            advertised_info: if let Some(x) = advertised_info {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    1,
+                    "GenericPeerInfo::advertised_info",
+                ));
+            },
+            seen_addrs: if let Some(x) = seen_addrs {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    2,
+                    "GenericPeerInfo::seen_addrs",
+                ));
+            },
+        })
+    }
+}
+#[derive(Debug, Clone, PartialEq, Encode)]
+#[cbor(array)]
+pub struct PeerAdvertisement<Addr> {
     #[n(0)]
-    pub listen_addrs: BTreeSet<Addr>,
+    pub listen_addrs: BoundedVec<U16, Addr>,
 
     #[n(2)]
     pub capabilities: BTreeSet<Capability>,
 }
 
-impl<Addr> PeerAdvertisement<Addr>
-where
-    Addr: Clone + Ord,
+// XXX: derive fails to add the trait bound on Addr
+impl<'__b777, Addr: minicbor::Decode<'__b777>> minicbor::Decode<'__b777>
+    for PeerAdvertisement<Addr>
 {
+    fn decode(
+        __d777: &mut minicbor::Decoder<'__b777>,
+    ) -> Result<PeerAdvertisement<Addr>, minicbor::decode::Error> {
+        let mut listen_addrs: Option<BoundedVec<U16, Addr>> = None;
+        let mut capabilities: Option<BTreeSet<Capability>> = None;
+        if let Some(__len777) = __d777.array()? {
+            for __i777 in 0..__len777 {
+                match __i777 {
+                    0 => listen_addrs = Some(radicle_data::bounded::decode_truncate(__d777)?),
+                    2 => capabilities = Some(minicbor::Decode::decode(__d777)?),
+                    _ => __d777.skip()?,
+                }
+            }
+        } else {
+            let mut __i777 = 0;
+            while minicbor::data::Type::Break != __d777.datatype()? {
+                match __i777 {
+                    0 => listen_addrs = Some(radicle_data::bounded::decode_truncate(__d777)?),
+                    2 => capabilities = Some(minicbor::Decode::decode(__d777)?),
+                    _ => __d777.skip()?,
+                }
+                __i777 += 1
+            }
+            __d777.skip()?
+        }
+        Ok(PeerAdvertisement {
+            listen_addrs: if let Some(x) = listen_addrs {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    0,
+                    "PeerAdvertisement::listen_addrs",
+                ));
+            },
+            capabilities: if let Some(x) = capabilities {
+                x
+            } else {
+                return Err(minicbor::decode::Error::MissingValue(
+                    2,
+                    "PeerAdvertisement::capabilities",
+                ));
+            },
+        })
+    }
+}
+impl<Addr> PeerAdvertisement<Addr> {
     pub fn new(listen_addr: Addr) -> Self {
         Self {
-            listen_addrs: vec![listen_addr].into_iter().collect(),
+            listen_addrs: BoundedVec::singleton(listen_addr),
             capabilities: BTreeSet::default(),
         }
     }

--- a/librad/src/net/protocol/io/connections.rs
+++ b/librad/src/net/protocol/io/connections.rs
@@ -3,13 +3,14 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::{collections::BTreeSet, net::SocketAddr, panic};
+use std::{net::SocketAddr, panic};
 
 use either::Either;
 use futures::{
     future::{self, TryFutureExt as _},
     stream::{FuturesUnordered, Stream, StreamExt as _},
 };
+use indexmap::IndexSet;
 use tracing::Instrument as _;
 
 use crate::{
@@ -105,10 +106,9 @@ pub async fn connect_peer_info(
     >,
 )> {
     let addrs = peer_info
-        .advertised_info
-        .listen_addrs
+        .seen_addrs
         .into_iter()
-        .chain(peer_info.seen_addrs.into_iter());
+        .chain(peer_info.advertised_info.listen_addrs);
     connect(endpoint, peer_info.peer_id, addrs).await
 }
 
@@ -131,7 +131,7 @@ where
         !(ip.is_unspecified() || ip.is_documentation() || ip.is_multicast())
     }
 
-    let addrs = addrs.into_iter().filter(routable).collect::<BTreeSet<_>>();
+    let addrs = addrs.into_iter().filter(routable).collect::<IndexSet<_>>();
     if addrs.is_empty() {
         tracing::warn!("no routable addrs");
         None

--- a/librad/src/net/protocol/io/recv/gossip.rs
+++ b/librad/src/net/protocol/io/recv/gossip.rs
@@ -3,7 +3,7 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::net::SocketAddr;
+use std::{iter, net::SocketAddr};
 
 use futures::{
     io::AsyncRead,
@@ -57,7 +57,7 @@ pub(in crate::net::protocol) async fn gossip<S, T>(
                 let peer_info = || PeerInfo {
                     peer_id: state.local_id,
                     advertised_info: peer_advertisement(&state.endpoint),
-                    seen_addrs: Default::default(),
+                    seen_addrs: iter::empty().into(),
                 };
                 match broadcast::apply(
                     &state.membership,

--- a/librad/src/net/protocol/io/send/rpc.rs
+++ b/librad/src/net/protocol/io/send/rpc.rs
@@ -16,27 +16,18 @@ use crate::net::{
 };
 
 #[derive(Debug)]
-pub enum Rpc<A, P>
-where
-    A: Clone + Ord,
-{
+pub enum Rpc<A, P> {
     Membership(membership::Message<A>),
     Gossip(broadcast::Message<A, P>),
 }
 
-impl<A, P> From<membership::Message<A>> for Rpc<A, P>
-where
-    A: Clone + Ord,
-{
+impl<A, P> From<membership::Message<A>> for Rpc<A, P> {
     fn from(m: membership::Message<A>) -> Self {
         Self::Membership(m)
     }
 }
 
-impl<A, P> From<broadcast::Message<A, P>> for Rpc<A, P>
-where
-    A: Clone + Ord,
-{
+impl<A, P> From<broadcast::Message<A, P>> for Rpc<A, P> {
     fn from(m: broadcast::Message<A, P>) -> Self {
         Self::Gossip(m)
     }

--- a/librad/src/net/protocol/membership.rs
+++ b/librad/src/net/protocol/membership.rs
@@ -40,7 +40,7 @@ pub(super) fn apply<R, A, F, P>(
 ) -> Result<(Vec<Transition<A>>, Vec<Tock<A, P>>), Error>
 where
     R: rand::Rng + Clone,
-    A: Clone + Debug + Ord,
+    A: Clone + Debug + PartialEq,
     F: Fn() -> PeerAdvertisement<A>,
 {
     hpv.apply(remote_id, remote_addr, message)
@@ -58,7 +58,7 @@ where
 pub(super) fn collect_tocks<R, A, F, P>(hpv: &Hpv<R, A>, info: &F, tick: Tick<A>) -> Vec<Tock<A, P>>
 where
     R: rand::Rng + Clone,
-    A: Clone + Debug + Ord,
+    A: Clone + Debug + PartialEq,
     F: Fn() -> PeerAdvertisement<A>,
 {
     use Tick::*;

--- a/librad/src/net/protocol/membership/periodic.rs
+++ b/librad/src/net/protocol/membership/periodic.rs
@@ -20,10 +20,7 @@ use rand::Rng as _;
 use super::{Hpv, Shuffle};
 use crate::net::{protocol::info::PeerInfo, quic::MAX_IDLE_TIMEOUT};
 
-pub enum Periodic<A>
-where
-    A: Clone + Ord,
-{
+pub enum Periodic<A> {
     RandomPromotion { candidates: Vec<PeerInfo<A>> },
     Shuffle(Shuffle<A>),
     Tickle,
@@ -33,7 +30,7 @@ where
 pub(super) async fn periodic_tasks<Rng, Addr, T>(hpv: Hpv<Rng, Addr>, tx: T)
 where
     Rng: rand::Rng + Clone,
-    Addr: Clone + Debug + Ord + Send + Sync + 'static,
+    Addr: Clone + Debug + PartialEq + Send + Sync + 'static,
     T: futures::Sink<Periodic<Addr>>,
     T::Error: Display,
 {

--- a/librad/src/net/protocol/membership/rpc.rs
+++ b/librad/src/net/protocol/membership/rpc.rs
@@ -6,10 +6,7 @@
 use crate::net::protocol::info::{PeerAdvertisement, PeerInfo};
 
 #[derive(Debug, Clone, PartialEq, minicbor::Encode, minicbor::Decode)]
-pub enum Message<Addr>
-where
-    Addr: Clone + Ord,
-{
+pub enum Message<Addr> {
     #[n(0)]
     #[cbor(array)]
     Join {

--- a/librad/src/net/protocol/membership/tick.rs
+++ b/librad/src/net/protocol/membership/tick.rs
@@ -7,10 +7,7 @@ use super::{partial_view::Transition, rpc::Message};
 use crate::{net::protocol::info::PeerInfo, PeerId};
 
 #[derive(Debug)]
-pub enum Tick<Addr>
-where
-    Addr: Clone + Ord,
-{
+pub enum Tick<Addr> {
     /// Deliver `message` to all `recipients`.
     ///
     /// Failed recipients must be evicted from the active view.
@@ -43,10 +40,7 @@ where
     Forget { peer: PeerId },
 }
 
-impl<A> From<Transition<A>> for Option<Tick<A>>
-where
-    A: Clone + Ord,
-{
+impl<A> From<Transition<A>> for Option<Tick<A>> {
     fn from(t: Transition<A>) -> Self {
         use Tick::*;
         use Transition::*;

--- a/librad/src/net/protocol/state.rs
+++ b/librad/src/net/protocol/state.rs
@@ -1,0 +1,170 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{net::SocketAddr, ops::Deref, sync::Arc};
+
+use governor::{Quota, RateLimiter};
+use nonzero_ext::nonzero;
+use rand_pcg::Pcg64Mcg;
+use tracing::Instrument as _;
+
+use super::{broadcast, cache, config, gossip, io, membership, nonce, ProtocolStorage, TinCans};
+use crate::{
+    git::{
+        p2p::{
+            server::GitServer,
+            transport::{GitStream, GitStreamFactory},
+        },
+        replication,
+        storage::{self, PoolError, PooledRef},
+    },
+    net::{quic, upgrade},
+    PeerId,
+};
+use futures::future::TryFutureExt as _;
+
+#[derive(Clone, Copy)]
+pub(super) struct StateConfig {
+    pub replication: replication::Config,
+    pub fetch: config::Fetch,
+}
+
+/// Runtime state of a protocol instance.
+///
+/// You know, like `ReaderT (State s) IO`.
+#[derive(Clone)]
+pub(super) struct State<S> {
+    pub local_id: PeerId,
+    pub endpoint: quic::Endpoint,
+    pub git: GitServer,
+    pub membership: membership::Hpv<Pcg64Mcg, SocketAddr>,
+    pub storage: Storage<S>,
+    pub phone: TinCans,
+    pub config: StateConfig,
+    pub nonces: nonce::NonceBag,
+    pub caches: cache::Caches,
+}
+
+#[async_trait]
+impl<S> GitStreamFactory for State<S>
+where
+    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + Clone + 'static,
+{
+    async fn open_stream(
+        &self,
+        to: &PeerId,
+        addr_hints: &[SocketAddr],
+    ) -> Option<Box<dyn GitStream>> {
+        let span = tracing::info_span!("open-git-stream", remote_id = %to);
+
+        let may_conn = match self.endpoint.get_connection(*to) {
+            Some(conn) => Some(conn),
+            None => {
+                let addr_hints = addr_hints.iter().copied().collect::<Vec<_>>();
+                io::connect(&self.endpoint, *to, addr_hints)
+                    .instrument(span.clone())
+                    .await
+                    .map(|(conn, ingress)| {
+                        tokio::spawn(
+                            io::streams::incoming(self.clone(), ingress).instrument(span.clone()),
+                        );
+                        conn
+                    })
+            },
+        };
+
+        match may_conn {
+            None => {
+                span.in_scope(|| tracing::error!("unable to obtain connection"));
+                None
+            },
+
+            Some(conn) => {
+                let stream = conn
+                    .open_bidi()
+                    .inspect_err(|e| tracing::error!(err = ?e, "unable to open stream"))
+                    .instrument(span.clone())
+                    .await
+                    .ok()?;
+                let upgraded = upgrade::upgrade(stream, upgrade::Git)
+                    .inspect_err(|e| tracing::error!(err = ?e, "unable to upgrade stream"))
+                    .instrument(span)
+                    .await
+                    .ok()?;
+
+                Some(Box::new(upgraded))
+            },
+        }
+    }
+}
+
+type Limiter = governor::RateLimiter<
+    governor::state::direct::NotKeyed,
+    governor::state::InMemoryState,
+    governor::clock::DefaultClock,
+>;
+
+#[derive(Clone)]
+pub(super) struct Storage<S> {
+    inner: S,
+    limiter: Arc<Limiter>,
+}
+
+impl<S> From<S> for Storage<S> {
+    fn from(inner: S) -> Self {
+        Self {
+            inner,
+            limiter: Arc::new(RateLimiter::direct(Quota::per_second(
+                // TODO: make this an "advanced" config
+                nonzero!(5u32),
+            ))),
+        }
+    }
+}
+
+impl<S> Deref for Storage<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl<A, S> broadcast::LocalStorage<A> for Storage<S>
+where
+    A: 'static,
+    S: broadcast::LocalStorage<A>,
+    S::Update: Send,
+{
+    type Update = S::Update;
+
+    async fn put<P>(&self, provider: P, has: Self::Update) -> broadcast::PutResult<Self::Update>
+    where
+        P: Into<(PeerId, Vec<A>)> + Send,
+    {
+        self.inner.put(provider, has).await
+    }
+
+    async fn ask(&self, want: Self::Update) -> bool {
+        self.inner.ask(want).await
+    }
+}
+
+impl<S> broadcast::ErrorRateLimited for Storage<S> {
+    fn is_error_rate_limit_breached(&self) -> bool {
+        self.limiter.check().is_err()
+    }
+}
+
+#[async_trait]
+impl<S> storage::Pooled for Storage<S>
+where
+    S: storage::Pooled + Send + Sync,
+{
+    async fn get(&self) -> Result<PooledRef, PoolError> {
+        self.inner.get().await
+    }
+}

--- a/librad/src/net/protocol/tick.rs
+++ b/librad/src/net/protocol/tick.rs
@@ -15,10 +15,7 @@ use super::{error, gossip, io, membership, PeerInfo, ProtocolStorage, State};
 use crate::PeerId;
 
 #[derive(Debug)]
-pub(super) enum Tock<A, P>
-where
-    A: Clone + Ord,
-{
+pub(super) enum Tock<A, P> {
     /// Send to connected peer, or notify of connection loss
     SendConnected { to: PeerId, message: io::Rpc<A, P> },
 

--- a/librad/tests/smoke/interrogation.rs
+++ b/librad/tests/smoke/interrogation.rs
@@ -5,7 +5,7 @@
 
 use std::ops::Index as _;
 
-use librad::{identities::SomeUrn, net::protocol::PeerAdvertisement};
+use librad::{data::BoundedVec, identities::SomeUrn, net::protocol::PeerAdvertisement};
 use librad_test::{
     logging,
     rad::{identities::TestProject, testnet},
@@ -37,7 +37,10 @@ async fn responds() {
             requester.interrogate((responder.peer_id(), responder.listen_addrs().to_vec()));
         assert_eq!(
             PeerAdvertisement {
-                listen_addrs: responder.listen_addrs().iter().copied().collect(),
+                listen_addrs: BoundedVec::try_from_length(
+                    responder.listen_addrs().iter().copied().collect()
+                )
+                .unwrap(),
                 capabilities: Default::default(),
             },
             interrogation.peer_advertisement().await.unwrap()


### PR DESCRIPTION
This is a purely mechanical change, as part of continuously grooming the
scrolls.

Signed-off-by: Kim Altintop <kim@monadic.xyz>