### PR TITLE
librad: introduce prop feature flag

### DIFF
--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["The Radicle Team <dev@radicle.xyz>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
 
+[features]
+prop = [ "proptest" ]
+
 [dependencies]
 async-stream = "0.3"
 async-trait = "0.1"
@@ -35,7 +38,7 @@ picky-asn1-x509 = "0.4"
 pnet_datalink = "0.27"
 priority-queue = "1.0"
 radicle-keystore = "0"
-rand = "0.7"
+rand = { version = "0.7", features = [ "small_rng" ] }
 rand_pcg = "0.2"
 regex = "1.3"
 rustc-hash = "1.1"
@@ -88,6 +91,10 @@ features = []
 [dependencies.minicbor]
 version = ">= 0.6, 0"
 features = ["std", "derive"]
+
+[dependencies.proptest]
+version = "0"
+optional = true
 
 [dependencies.quinn]
 version = "0.7"

--- a/librad/src/identities.rs
+++ b/librad/src/identities.rs
@@ -14,8 +14,8 @@ pub use urn::Urn;
 
 mod sealed;
 
-#[cfg(test)]
-pub(crate) mod gen;
+#[cfg(any(test, feature = "prop"))]
+pub mod gen;
 
 pub use git::*;
 

--- a/librad/src/identities/delegation/direct.rs
+++ b/librad/src/identities/delegation/direct.rs
@@ -59,7 +59,7 @@ impl From<Direct> for BTreeSet<PublicKey> {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "prop"))]
 impl From<BTreeSet<PublicKey>> for Direct {
     fn from(set: BTreeSet<PublicKey>) -> Self {
         Self(set)

--- a/librad/src/identities/delegation/indirect.rs
+++ b/librad/src/identities/delegation/indirect.rs
@@ -58,7 +58,7 @@ pub struct Indirect<T, R, C> {
 // also not a hard guarantee the `Identity` invariants are maintained (namely
 // the content hashes). So, let's keep this impl to tests, and assume `root` and
 // `revision` identify the stored `IndirectlyDelegating`.
-#[cfg(test)]
+#[cfg(any(test, feature = "prop"))]
 impl<T, R, C> PartialEq for Indirect<T, R, C>
 where
     R: Ord,

--- a/librad/src/identities/gen.rs
+++ b/librad/src/identities/gen.rs
@@ -3,10 +3,189 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use git_ext::Oid;
+use std::convert::TryFrom as _;
+
+use either::Either;
 use proptest::prelude::*;
+use url::Url;
+
+use git_ext::{Oid, RefLike};
+
+use crate::{internal::canonical::Cstring, keys::gen::gen_public_key};
+
+use super::{
+    payload::{
+        HasNamespace,
+        KeyOrUrn,
+        Person,
+        PersonDelegations,
+        PersonPayload,
+        Project,
+        ProjectDelegations,
+        ProjectPayload,
+        SomePayload,
+    },
+    Urn,
+};
+
+impl Arbitrary for Person {
+    type Parameters = ();
+    type Strategy = prop::strategy::Map<<Cstring as Arbitrary>::Strategy, fn(Cstring) -> Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any::<Cstring>().prop_map(|name| Person { name })
+    }
+}
+
+impl Arbitrary for Project {
+    type Parameters = ();
+    // Silly clippy: this _is_ a type definition
+    #[allow(clippy::type_complexity)]
+    type Strategy = prop::strategy::Map<
+        (
+            <Cstring as Arbitrary>::Strategy,
+            <Option<Cstring> as Arbitrary>::Strategy,
+            <Option<Cstring> as Arbitrary>::Strategy,
+        ),
+        fn((Cstring, Option<Cstring>, Option<Cstring>)) -> Self,
+    >;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        Strategy::prop_map(
+            (
+                any::<Cstring>(),
+                any::<Option<Cstring>>(),
+                any::<Option<Cstring>>(),
+            ),
+            |(name, description, default_branch)| Project {
+                name,
+                description,
+                default_branch,
+            },
+        )
+    }
+}
 
 pub fn gen_oid(kind: git2::ObjectType) -> impl Strategy<Value = Oid> {
     any::<Vec<u8>>()
         .prop_map(move |bytes| git2::Oid::hash_object(kind, &bytes).map(Oid::from).unwrap())
+}
+
+pub fn gen_urn() -> impl Strategy<Value = Urn<Oid>> {
+    (
+        gen_oid(git2::ObjectType::Tree),
+        prop::option::of(prop::collection::vec("[a-z0-9]+", 1..3)),
+    )
+        .prop_map(|(id, path)| {
+            let path = path.map(|elems| {
+                RefLike::try_from(elems.join("/")).unwrap_or_else(|e| {
+                    panic!(
+                        "Unexpected error generating a RefLike from `{}`: {}",
+                        elems.join("/"),
+                        e
+                    )
+                })
+            });
+            Urn { id, path }
+        })
+}
+
+lazy_static! {
+    static ref UPSTREAM_USER_NAMESPACE: Url =
+        Url::parse("https://radicle.xyz/upstream/user/v1").unwrap();
+    static ref UPSTREAM_PROJECT_NAMESPACE: Url =
+        Url::parse("https://radicle.xyz/upstream/project/v1").unwrap();
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct UpstreamUser {
+    #[serde(rename = "radicle-registry-name")]
+    pub registered_as: Cstring,
+}
+
+impl Arbitrary for UpstreamUser {
+    type Parameters = ();
+    type Strategy = prop::strategy::Map<<Cstring as Arbitrary>::Strategy, fn(Cstring) -> Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any::<Cstring>().prop_map(|registered_as| Self { registered_as })
+    }
+}
+
+impl HasNamespace for UpstreamUser {
+    fn namespace() -> &'static Url {
+        &UPSTREAM_USER_NAMESPACE
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct UpstreamProject {
+    #[serde(rename = "radicle-registry-name")]
+    pub registered_as: Cstring,
+}
+
+impl Arbitrary for UpstreamProject {
+    type Parameters = ();
+    type Strategy = prop::strategy::Map<<Cstring as Arbitrary>::Strategy, fn(Cstring) -> Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any::<Cstring>().prop_map(|registered_as| Self { registered_as })
+    }
+}
+
+impl HasNamespace for UpstreamProject {
+    fn namespace() -> &'static Url {
+        &UPSTREAM_PROJECT_NAMESPACE
+    }
+}
+
+pub fn gen_person_payload() -> impl Strategy<Value = PersonPayload> {
+    (any::<Person>(), proptest::option::of(any::<UpstreamUser>())).prop_map(|(person, up)| {
+        let mut p = PersonPayload::new(person);
+        if let Some(up) = up {
+            p.set_ext(up).unwrap();
+        }
+        p
+    })
+}
+
+pub fn gen_project_payload() -> impl Strategy<Value = ProjectPayload> {
+    (
+        any::<Project>(),
+        proptest::option::of(any::<UpstreamProject>()),
+    )
+        .prop_map(|(project, up)| {
+            let mut p = ProjectPayload::new(project);
+            if let Some(up) = up {
+                p.set_ext(up).unwrap();
+            }
+            p
+        })
+}
+
+pub fn gen_payload() -> impl Strategy<Value = SomePayload> {
+    prop_oneof![
+        gen_person_payload().prop_map(SomePayload::Person),
+        gen_project_payload().prop_map(SomePayload::Project)
+    ]
+}
+
+pub fn gen_person_delegations() -> impl Strategy<Value = PersonDelegations> {
+    proptest::collection::btree_set(gen_public_key(), 1..32).prop_map(PersonDelegations)
+}
+
+pub fn gen_key_or_urn() -> impl Strategy<Value = KeyOrUrn<Oid>> {
+    prop_oneof![
+        gen_public_key().prop_map(|pk| KeyOrUrn {
+            inner: Either::Left(pk)
+        }),
+        gen_oid(git2::ObjectType::Tree).prop_map(|oid| KeyOrUrn {
+            inner: Either::Right(Urn::new(oid))
+        })
+    ]
+}
+
+pub fn gen_project_delegations() -> impl Strategy<Value = ProjectDelegations<Oid>> {
+    proptest::collection::btree_set(gen_key_or_urn(), 1..64)
+        .prop_map(|inner| ProjectDelegations { inner })
 }

--- a/librad/src/identities/generic.rs
+++ b/librad/src/identities/generic.rs
@@ -17,8 +17,8 @@ use super::{delegation::Delegations, payload::Payload, sealed, sign::Signatures,
 
 pub mod error;
 
-#[cfg(test)]
-pub(crate) mod gen;
+#[cfg(any(test, feature = "prop"))]
+pub mod gen;
 #[cfg(test)]
 pub(crate) mod tests;
 

--- a/librad/src/identities/urn.rs
+++ b/librad/src/identities/urn.rs
@@ -378,11 +378,10 @@ where
 pub(crate) mod tests {
     use super::*;
 
-    use git_ext::Oid;
     use librad_test::roundtrip::*;
     use proptest::prelude::*;
 
-    use crate::identities::gen::gen_oid;
+    use crate::identities::gen::gen_urn;
 
     /// Fake `id` of a `Urn<FakeId>`.
     ///
@@ -412,25 +411,6 @@ pub(crate) mod tests {
         fn from(id: &FakeId) -> Self {
             multihash::wrap(multihash::Code::Identity, &id.0.to_be_bytes())
         }
-    }
-
-    fn gen_urn() -> impl Strategy<Value = Urn<Oid>> {
-        (
-            gen_oid(git2::ObjectType::Tree),
-            prop::option::of(prop::collection::vec("[a-z0-9]+", 1..3)),
-        )
-            .prop_map(|(id, path)| {
-                let path = path.map(|elems| {
-                    ext::RefLike::try_from(elems.join("/")).unwrap_or_else(|e| {
-                        panic!(
-                            "Unexpected error generating a RefLike from `{}`: {}",
-                            elems.join("/"),
-                            e
-                        )
-                    })
-                });
-                Urn { id, path }
-            })
     }
 
     /// All serialisation roundtrips [`Urn`] must pass

--- a/librad/src/internal/canonical.rs
+++ b/librad/src/internal/canonical.rs
@@ -145,7 +145,7 @@ where
 #[serde(transparent)]
 pub struct Cstring(String);
 
-#[cfg(test)]
+#[cfg(any(test, feature = "prop"))]
 impl Arbitrary for Cstring {
     type Parameters = ();
     type Strategy = prop::strategy::Map<&'static str, fn(String) -> Self>;

--- a/librad/src/internal/canonical.rs
+++ b/librad/src/internal/canonical.rs
@@ -14,7 +14,7 @@ use serde_bytes::ByteBuf;
 use thiserror::Error;
 use unicode_normalization::UnicodeNormalization;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "prop"))]
 use proptest::prelude::*;
 
 pub mod formatter;

--- a/librad/src/keys.rs
+++ b/librad/src/keys.rs
@@ -22,6 +22,10 @@ use keystore::{sign, SecretKeyExt};
 pub const PUBLICKEYBYTES: usize = std::mem::size_of::<ed25519::VerificationKeyBytes>();
 pub use keystore::SecStr;
 
+#[cfg(any(test, feature = "prop"))]
+pub mod gen;
+pub mod risky;
+
 /// Version of the signature scheme in use
 ///
 /// This is used for future-proofing serialisation. For ergonomics reasons, we
@@ -67,7 +71,6 @@ impl SecretKey {
         Self(sk)
     }
 
-    #[cfg(test)]
     pub fn from_seed(seed: [u8; 32]) -> Self {
         Self(ed25519::SigningKey::from(seed))
     }
@@ -432,17 +435,8 @@ pub mod tests {
     use super::*;
 
     use librad_test::roundtrip::*;
-    use proptest::prelude::*;
 
     const DATA_TO_SIGN: &[u8] = b"alors monsieur";
-
-    pub fn gen_secret_key() -> impl Strategy<Value = SecretKey> {
-        any::<[u8; 32]>().prop_map(SecretKey::from_seed)
-    }
-
-    pub fn gen_public_key() -> impl Strategy<Value = PublicKey> {
-        gen_secret_key().prop_map(|sk| sk.public())
-    }
 
     #[test]
     fn test_sign_verify_via_signature() {

--- a/librad/src/keys/gen.rs
+++ b/librad/src/keys/gen.rs
@@ -1,0 +1,16 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use proptest::prelude::*;
+
+use super::{risky::RESKey, PublicKey};
+
+pub fn gen_secret_key() -> impl Strategy<Value = RESKey> {
+    any::<()>().prop_map(|()| RESKey::new())
+}
+
+pub fn gen_public_key() -> impl Strategy<Value = PublicKey> {
+    gen_secret_key().prop_map(|sk| sk.public())
+}

--- a/librad/src/keys/risky.rs
+++ b/librad/src/keys/risky.rs
@@ -1,0 +1,77 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{fmt, ops::Deref};
+
+use rand::{rngs::SmallRng, Rng as _, SeedableRng as _};
+use zeroize::Zeroize;
+
+use super::SecretKey;
+
+use crate::peer::PeerId;
+
+/// A Reduced Entropy SecretKey a.k.a a Risky SecretKey.
+#[derive(Clone, Zeroize)]
+#[zeroize(drop)]
+pub struct RESKey {
+    key: SecretKey,
+    seed: [u8; 32],
+}
+
+impl RESKey {
+    /// Produce a `RESKey` using [`SmallRng`]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let mut rng = SmallRng::from_entropy();
+        let seed = rng.gen();
+        Self::from_seed(seed)
+    }
+
+    pub fn from_seed(seed: [u8; 32]) -> Self {
+        let key = SecretKey::from_seed(seed);
+        Self { key, seed }
+    }
+}
+
+impl fmt::Debug for RESKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RESKey")
+            .field("key", &"***".to_string())
+            .field("seed", &self.seed)
+            .finish()
+    }
+}
+
+impl fmt::Display for RESKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.key)
+    }
+}
+
+impl Deref for RESKey {
+    type Target = SecretKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.key
+    }
+}
+
+impl AsRef<SecretKey> for RESKey {
+    fn as_ref(&self) -> &SecretKey {
+        &self.key
+    }
+}
+
+impl From<&RESKey> for PeerId {
+    fn from(risky: &RESKey) -> Self {
+        PeerId::from(risky.key.clone())
+    }
+}
+
+impl From<RESKey> for PeerId {
+    fn from(risky: RESKey) -> Self {
+        PeerId::from(risky.key.clone())
+    }
+}

--- a/librad/src/keys/unsafe.rs
+++ b/librad/src/keys/unsafe.rs
@@ -1,0 +1,35 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+/// A Reduced Entropy SecretKey a.k.a a Risky SecretKey.
+#[derive(Clone, Zeroize)]
+#[zeroize(drop)]
+pub struct RESKey {
+    key: SecretKey,
+    seed: [u8; 32],
+}
+
+impl fmt::Debug for RESKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RESKey")
+            .field("key", &"***".to_string())
+            .field("seed", &self.seed)
+            .finish()
+    }
+}
+
+impl fmt::Display for RESKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.key)
+    }
+}
+
+impl Deref for RESKey {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.key
+    }
+}

--- a/librad/src/net/protocol/membership/partial_view.rs
+++ b/librad/src/net/protocol/membership/partial_view.rs
@@ -207,7 +207,7 @@ mod test {
 
     use crate::{
         net::protocol::info::PeerAdvertisement,
-        peer::{tests::gen_peer_id, PeerId},
+        peer::{gen::gen_peer_id, PeerId},
     };
 
     fn gen_peers() -> impl Strategy<Value = (PeerId, Vec<PeerId>)> {

--- a/librad/src/peer.rs
+++ b/librad/src/peer.rs
@@ -228,19 +228,24 @@ impl<'a, T> From<&'a Originates<T>> for OriginatesRef<'a, T> {
     }
 }
 
-#[cfg(test)]
-pub mod tests {
+#[cfg(any(test, feature = "prop"))]
+pub mod gen {
     use proptest::prelude::Strategy;
 
-    use super::*;
+    use crate::keys::gen::gen_secret_key;
 
-    use crate::keys::tests::gen_secret_key;
-
-    use librad_test::roundtrip::*;
+    use super::PeerId;
 
     pub fn gen_peer_id() -> impl Strategy<Value = PeerId> {
         gen_secret_key().prop_map(PeerId::from)
     }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    use librad_test::roundtrip::*;
 
     #[test]
     fn test_default_encoding_roundtrip() {


### PR DESCRIPTION
We introduce a prop feature flag so that we can expose proptest
strategies, outside of tests, in other workspace packages.

This includes adding a new secret key mascot RESKey the risky key. It
uses SmallRng from the rand package for quicker testing.

We move all Arbitrary instances and gen_* functions in to `gen` modules
and make them public under the "prop" flag.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>