### PR TITLE
daemon: basic support for listing tagged patches

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -53,6 +53,7 @@ pub mod convert;
 pub mod keystore;
 pub mod peer;
 pub use peer::{Control as PeerControl, Event as PeerEvent, Peer, RunConfig, Status as PeerStatus};
+pub mod patch;
 pub mod project;
 pub mod request;
 pub mod state;

--- a/daemon/src/patch.rs
+++ b/daemon/src/patch.rs
@@ -1,0 +1,169 @@
+//! [`list`] all the [`Patch`]es for project.
+
+use either::Either;
+use librad::{
+    git::types::{namespace::Namespace, Reference, RefsCategory},
+    peer::PeerId,
+    signer::BoxedSigner,
+};
+use radicle_git_ext::RefspecPattern;
+
+use crate::{
+    project::{self, peer},
+    state, Person,
+};
+
+const TAG_PREFIX: &str = "radicle-patch/";
+
+/// A patch is a change set that a user wants the maintainer to merge into a projects default
+/// branch.
+///
+/// A patch is represented by an annotated tag, prefixed with `radicle-patch/`.
+#[derive(Debug, Clone)]
+pub struct Patch {
+    /// ID of a patch. This is the portion of the tag name followin the `radicle-patch/` prefix.
+    pub id: String,
+    /// Peer that the patch originated from
+    pub peer: project::Peer<peer::Status<Person>>,
+    /// Message attached to the patch. This is the message of the annotated tag.
+    pub message: Option<String>,
+    /// Head commit that this
+    pub commit: git2::Oid,
+    /// The merge base of [`Patch::commit`] and the head commit of the first maintainers default
+    /// branch.
+    pub merge_base: Option<git2::Oid>,
+}
+
+impl Patch {
+    /// Returns true if [`Patch::commit`] is contained in the base branch history. This is the case
+    /// when [`Patch::commit`] is the same as [`Patch::merge_base`].
+    #[must_use]
+    pub fn merged(&self) -> bool {
+        self.merge_base == Some(self.commit)
+    }
+}
+
+/// List all patches for the given project.
+///
+/// # Errors
+/// * Cannot access the monorepo
+/// * Cannot find references within the monorepo
+pub async fn list(
+    peer: &crate::net::peer::Peer<BoxedSigner>,
+    project_urn: crate::Urn,
+) -> Result<Vec<Patch>, state::Error> {
+    let mut patches = Vec::new();
+    let monorepo_path = state::monorepo(peer);
+    let monorepo = git2::Repository::open(monorepo_path)?;
+    let namespace = Namespace::from(project_urn.clone());
+    let default_branch_head_commit = {
+        let project = state::get_project(peer, project_urn.clone())
+            .await?
+            .ok_or_else(|| state::Error::ProjectNotFound(project_urn.clone()))?;
+        let maintainer = project
+            .delegations()
+            .iter()
+            .flat_map(|either| match either {
+                Either::Left(pk) => Either::Left(std::iter::once(PeerId::from(*pk))),
+                Either::Right(indirect) => {
+                    Either::Right(indirect.delegations().iter().map(|pk| PeerId::from(*pk)))
+                },
+            })
+            .next()
+            .expect("missing delegation");
+        // the `remote` for `get_branch` is set to the first maintainer, if the current `peer`
+        // is that maintainer, `get_branch` will catch that and search the local peers directories.
+        // The `branch` is set to `None` as `get_branch` will then fall back to the default branch.
+        let default_branch =
+            state::get_branch(peer, project_urn.clone(), Some(maintainer), None).await?;
+        monorepo
+            .find_reference(&default_branch.to_string())?
+            .peel_to_commit()?
+            .id()
+    };
+
+    for project_peer in state::list_project_peers(peer, project_urn.clone()).await? {
+        let remote = match project_peer {
+            project::Peer::Local { .. } => None,
+            project::Peer::Remote { peer_id, .. } => Some(peer_id),
+        };
+        let ref_pattern = Reference {
+            remote,
+            category: RefsCategory::Tags,
+            name: format!("{}*", TAG_PREFIX)
+                .parse::<RefspecPattern>()
+                .expect("invalid refspec pattern"),
+            namespace: Some(namespace.clone()),
+        };
+        let refs = ref_pattern.references(&monorepo)?;
+        for r in refs {
+            let r = r?;
+            match patch_from_ref(
+                &monorepo,
+                default_branch_head_commit,
+                project_peer.clone(),
+                &r,
+            ) {
+                Ok(patch) => patches.push(patch),
+                Err(err) => {
+                    log::warn!("failed to get patch from ref: {:?}", err);
+                },
+            }
+        }
+    }
+    Ok(patches)
+}
+
+#[derive(thiserror::Error, Debug)]
+enum PatchExtractError {
+    #[error("cannot peel reference to tag")]
+    PeelToTagFailed(#[source] git2::Error),
+    #[error("failed to determine merge base")]
+    FailedToDetermineMergeBase(#[source] git2::Error),
+    #[error("tag target object is not a commit")]
+    InvalidObjectType,
+    #[error("tag name is not valid UTF-8")]
+    InvalidName(#[source] std::str::Utf8Error),
+}
+
+fn patch_from_ref<'repo>(
+    monorepo: &'repo git2::Repository,
+    default_branch_head_commit: git2::Oid,
+    peer: project::Peer<peer::Status<Person>>,
+    reference: &git2::Reference<'repo>,
+) -> Result<Patch, PatchExtractError> {
+    let tag = reference
+        .peel_to_tag()
+        .map_err(PatchExtractError::PeelToTagFailed)?;
+    let commit = tag.target_id();
+
+    let merge_base = match monorepo.merge_base(commit, default_branch_head_commit) {
+        Ok(merge_base) => Some(merge_base),
+        Err(err) => {
+            if err.code() == git2::ErrorCode::NotFound {
+                None
+            } else {
+                return Err(PatchExtractError::FailedToDetermineMergeBase(err));
+            }
+        },
+    };
+
+    let tag_name = std::str::from_utf8(tag.name_bytes()).map_err(PatchExtractError::InvalidName)?;
+
+    let id = tag_name
+        .strip_prefix(TAG_PREFIX)
+        // This can only fail if our ref pattern is wrong
+        .expect("invalid prefix");
+
+    if tag.target_type() != Some(git2::ObjectType::Commit) {
+        return Err(PatchExtractError::InvalidObjectType);
+    }
+
+    Ok(Patch {
+        id: id.to_owned(),
+        peer,
+        message: tag.message().map(String::from),
+        commit,
+        merge_base,
+    })
+}

--- a/daemon/src/patch.rs
+++ b/daemon/src/patch.rs
@@ -1,3 +1,8 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
 //! [`list`] all the [`Patch`]es for project.
 
 use either::Either;
@@ -10,18 +15,20 @@ use radicle_git_ext::RefspecPattern;
 
 use crate::{
     project::{self, peer},
-    state, Person,
+    state,
+    Person,
 };
 
 const TAG_PREFIX: &str = "radicle-patch/";
 
-/// A patch is a change set that a user wants the maintainer to merge into a projects default
-/// branch.
+/// A patch is a change set that a user wants the maintainer to merge into a
+/// projects default branch.
 ///
 /// A patch is represented by an annotated tag, prefixed with `radicle-patch/`.
 #[derive(Debug, Clone)]
 pub struct Patch {
-    /// ID of a patch. This is the portion of the tag name followin the `radicle-patch/` prefix.
+    /// ID of a patch. This is the portion of the tag name followin the
+    /// `radicle-patch/` prefix.
     pub id: String,
     /// Peer that the patch originated from
     pub peer: project::Peer<peer::Status<Person>>,
@@ -29,14 +36,15 @@ pub struct Patch {
     pub message: Option<String>,
     /// Head commit that this
     pub commit: git2::Oid,
-    /// The merge base of [`Patch::commit`] and the head commit of the first maintainers default
-    /// branch.
+    /// The merge base of [`Patch::commit`] and the head commit of the first
+    /// maintainers default branch.
     pub merge_base: Option<git2::Oid>,
 }
 
 impl Patch {
-    /// Returns true if [`Patch::commit`] is contained in the base branch history. This is the case
-    /// when [`Patch::commit`] is the same as [`Patch::merge_base`].
+    /// Returns true if [`Patch::commit`] is contained in the base branch
+    /// history. This is the case when [`Patch::commit`] is the same as
+    /// [`Patch::merge_base`].
     #[must_use]
     pub fn merged(&self) -> bool {
         self.merge_base == Some(self.commit)
@@ -71,9 +79,10 @@ pub async fn list(
             })
             .next()
             .expect("missing delegation");
-        // the `remote` for `get_branch` is set to the first maintainer, if the current `peer`
-        // is that maintainer, `get_branch` will catch that and search the local peers directories.
-        // The `branch` is set to `None` as `get_branch` will then fall back to the default branch.
+        // the `remote` for `get_branch` is set to the first maintainer, if the current
+        // `peer` is that maintainer, `get_branch` will catch that and search
+        // the local peers directories. The `branch` is set to `None` as
+        // `get_branch` will then fall back to the default branch.
         let default_branch =
             state::get_branch(peer, project_urn.clone(), Some(maintainer), None).await?;
         monorepo

--- a/daemon/tests/patch.rs
+++ b/daemon/tests/patch.rs
@@ -1,3 +1,8 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
 use std::convert::TryFrom;
 
 use librad::git::{

--- a/daemon/tests/patch.rs
+++ b/daemon/tests/patch.rs
@@ -1,0 +1,250 @@
+use std::convert::TryFrom;
+
+use librad::git::{
+    local::url::LocalUrl,
+    types::{remote::LocalPushspec, Fetchspec, Force, Remote},
+};
+use radicle_git_ext::RefspecPattern;
+
+use radicle_daemon::{identities::payload::Person, state, RunConfig};
+
+#[macro_use]
+mod common;
+use common::{build_peer, init_logging, shia_le_pathbuf, started};
+
+/// Given two peers Alice and Bob
+/// Alice creates a project
+/// Bob clones the project from alice and checks it out
+/// Alice tracks Bob
+/// Bob creates a new commit and patch tag in the working copy
+/// Bob pushes the patch tag to the `rad` remote
+/// Alice fetches from Bob
+/// Alice sees the patch in `radicle_daemon::patch::list`
+#[tokio::test]
+async fn patch_replication() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+
+    let alice_tmp_dir = tempfile::tempdir()?;
+    let alice_repo_path = alice_tmp_dir.path().join("radicle");
+    let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
+    let (alice_peer, alice_addrs) = {
+        let peer = alice_peer.peer.clone();
+        let events = alice_peer.subscribe();
+        let mut peer_control = alice_peer.control();
+        tokio::task::spawn(alice_peer.run());
+        started(events).await?;
+        let alice_addrs = peer_control.listen_addrs().await;
+        (peer, alice_addrs)
+    };
+    let alice = state::init_owner(
+        &alice_peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
+
+    let bob_tmp_dir = tempfile::tempdir()?;
+    let bob_peer = build_peer(&bob_tmp_dir, RunConfig::default()).await?;
+    let (bob_peer, bob_addrs) = {
+        let peer = bob_peer.peer.clone();
+        let events = bob_peer.subscribe();
+        let mut peer_control = bob_peer.control();
+        tokio::task::spawn(bob_peer.run());
+        started(events).await?;
+        let bob_addrs = peer_control.listen_addrs().await;
+        (peer, bob_addrs)
+    };
+    let _bob = state::init_owner(&bob_peer, Person { name: "bob".into() }).await?;
+
+    let project = state::init_project(
+        &alice_peer,
+        &alice,
+        shia_le_pathbuf(alice_repo_path.clone()),
+    )
+    .await?;
+
+    state::clone_project(
+        &bob_peer,
+        project.urn(),
+        alice_peer.peer_id(),
+        alice_addrs.clone(),
+        None,
+    )
+    .await?;
+
+    let bob_repo_path = bob_tmp_dir.path().join("radicle");
+    state::checkout(
+        &bob_peer,
+        project.urn(),
+        alice_peer.peer_id(),
+        bob_repo_path.clone(),
+    )
+    .await
+    .unwrap();
+
+    state::track(&alice_peer, project.urn(), bob_peer.peer_id())
+        .await
+        .unwrap();
+
+    let bob_signature = git2::Signature::now("bob", "bob@example.com")?;
+    let repo = git2::Repository::open(bob_repo_path.join(project.subject().name.to_string()))?;
+    let default_branch = project.subject().default_branch.clone().unwrap();
+
+    let default_branch_head = repo
+        .find_reference(&format!("refs/heads/{}", default_branch))?
+        .peel_to_commit()
+        .unwrap();
+
+    let _tag_id = repo
+        .tag(
+            "radicle-patch/BOBS-PATCH",
+            &default_branch_head.as_object(),
+            &bob_signature,
+            "MESSAGE",
+            false,
+        )
+        .unwrap();
+
+    let mut rad =
+        Remote::<LocalUrl>::rad_remote::<_, Fetchspec>(LocalUrl::from(project.urn()), None);
+    let _ = rad.push(
+        state::settings(&bob_peer),
+        &repo,
+        LocalPushspec::Matching {
+            pattern: RefspecPattern::try_from("refs/tags/*").unwrap(),
+            force: Force::False,
+        },
+    )?;
+
+    state::fetch(
+        &alice_peer,
+        project.urn(),
+        bob_peer.peer_id(),
+        bob_addrs,
+        None,
+    )
+    .await
+    .unwrap();
+    let alice_patches = radicle_daemon::patch::list(&alice_peer, project.urn())
+        .await
+        .unwrap();
+    assert_eq!(alice_patches.len(), 1);
+    assert_eq!(alice_patches[0].id, "BOBS-PATCH",);
+
+    state::fetch(
+        &bob_peer,
+        project.urn(),
+        alice_peer.peer_id(),
+        alice_addrs,
+        None,
+    )
+    .await
+    .unwrap();
+    let bob_patches = radicle_daemon::patch::list(&bob_peer, project.urn())
+        .await
+        .unwrap();
+    assert_eq!(bob_patches.len(), 1);
+    assert_eq!(bob_patches[0].id, "BOBS-PATCH",);
+
+    Ok(())
+}
+
+/// Alice creates a patch using Git. We check that all fields in `Patch` have
+/// the correct values.
+#[tokio::test]
+async fn patch_struct() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+
+    let alice_tmp_dir = tempfile::tempdir()?;
+    let alice_repo_path = alice_tmp_dir.path().join("radicle");
+    let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
+    let alice_peer = {
+        let peer = alice_peer.peer.clone();
+        let events = alice_peer.subscribe();
+        tokio::task::spawn(alice_peer.run());
+        started(events).await?;
+        peer
+    };
+    let alice = state::init_owner(
+        &alice_peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
+    let alice_signature =
+        git2::Signature::now(&alice.subject().name.to_string(), "alice@example.com")?;
+
+    let project = state::init_project(
+        &alice_peer,
+        &alice,
+        shia_le_pathbuf(alice_repo_path.clone()),
+    )
+    .await?;
+
+    let repo = git2::Repository::open(alice_repo_path.join(project.subject().name.to_string()))?;
+    let default_branch = project.subject().default_branch.clone().unwrap();
+    let default_branch_ref = format!("refs/heads/{}", default_branch);
+
+    let original_default_branch_head = repo
+        .find_reference(&default_branch_ref)?
+        .peel_to_commit()
+        .unwrap();
+
+    // Create a new commit and update the default branch
+    repo.commit(
+        Some(&default_branch_ref),
+        &alice_signature,
+        &alice_signature,
+        "",
+        &original_default_branch_head.tree().unwrap(),
+        &[&original_default_branch_head],
+    )
+    .unwrap();
+
+    let patch_head_id = repo
+        .commit(
+            None,
+            &alice_signature,
+            &alice_signature,
+            "",
+            &original_default_branch_head.tree().unwrap(),
+            &[&original_default_branch_head],
+        )
+        .unwrap();
+    let patch_head = repo.find_commit(patch_head_id).unwrap();
+
+    let _tag_id = repo
+        .tag(
+            "radicle-patch/ALICES-PATCH",
+            &patch_head.as_object(),
+            &alice_signature,
+            "MESSAGE",
+            false,
+        )
+        .unwrap();
+
+    let mut rad =
+        Remote::<LocalUrl>::rad_remote::<_, Fetchspec>(LocalUrl::from(project.urn()), None);
+    let _ = rad.push(
+        state::settings(&alice_peer),
+        &repo,
+        LocalPushspec::Matching {
+            pattern: RefspecPattern::try_from("refs/tags/*").unwrap(),
+            force: Force::False,
+        },
+    )?;
+
+    let patches = radicle_daemon::patch::list(&alice_peer, project.urn())
+        .await
+        .unwrap();
+    let patch = &patches[0];
+    assert_eq!(patch.id, "ALICES-PATCH",);
+    assert_eq!(patch.merge_base, Some(original_default_branch_head.id()));
+    assert_eq!(patch.commit, patch_head_id);
+    assert_eq!(patch.message, Some("MESSAGE".to_string()));
+    assert_eq!(patch.merged(), false);
+
+    Ok(())
+}


### PR DESCRIPTION
We’re adding basic support for listing patches based on Git tags with a special prefix.

I’d love to get some feedback on how much of this can be extracted and moved to other parts of the codebase