### PR TITLE
net: announce after rere

### DIFF
--- a/librad/tests/smoke/fetch_limit.rs
+++ b/librad/tests/smoke/fetch_limit.rs
@@ -20,7 +20,7 @@ fn replication_does_not_exceed_limit() {
 
     let net = testnet::run(testnet::Config {
         num_peers: nonzero!(6usize),
-        min_connected: 6,
+        min_connected: 3,
         bootstrap: testnet::Bootstrap::from_env(),
     })
     .unwrap();


### PR DESCRIPTION
The refs updated as a side-effect of rere shall be announced. This is a
prerequisite for grafting, which happens independent of gossip
membership.

Note that this will cause amplification while client-initiated announce
is still in effect.

Signed-off-by: Kim Altintop <kim@monadic.xyz>