### PR TITLE
replication: Account for missing refs prefix

### DIFF
--- a/git-ext/src/reference/name.rs
+++ b/git-ext/src/reference/name.rs
@@ -403,6 +403,8 @@ impl From<RefLike> for Qualified {
     fn from(RefLike(path): RefLike) -> Self {
         if path.starts_with("refs/") {
             Self(path)
+        } else if path.starts_with("heads/") || path.starts_with("tags/") {
+            Self(format!("refs/{}", path))
         } else {
             Self(format!("refs/heads/{}", path))
         }

--- a/librad/src/net/peer/storage.rs
+++ b/librad/src/net/peer/storage.rs
@@ -283,6 +283,13 @@ mod tests {
         }
 
         #[test]
+        fn missing_refs() {
+            let urn = Urn::new(*ZERO_OID).with_path(reflike!("heads/main"));
+            let ctx = urn_context(*LOCAL_PEER_ID, Left(urn.clone()));
+            assert_eq!(urn.with_path(reflike!("refs/heads/main")), ctx)
+        }
+
+        #[test]
         fn remote_empty() {
             let urn = Urn::new(*ZERO_OID);
             let ctx = urn_context(


### PR DESCRIPTION
When a peer announces without `refs` it would cause the logic to check
if the change is present locally to fail.

Signed-off-by: Alexander Simmerl <a.simmerl@gmail.com>