### PR TITLE
p2p: allow any in upload-pack

### DIFF
--- a/librad/src/git/p2p/server.rs
+++ b/librad/src/git/p2p/server.rs
@@ -184,6 +184,8 @@ impl UploadPack {
     #[tracing::instrument(level = "debug", err)]
     fn upload_pack(repo_path: &Path) -> io::Result<Self> {
         let mut git = Command::new("git");
+        git.arg("-c").arg("uploadpack.allowanysha1inwant=true");
+
         git_tracing(&mut git);
         git.args(&[
             "upload-pack",


### PR DESCRIPTION
We allow `allowanysha1inwant`. This allows the server to request a
reference as a `want`, since one side might have updated its tips during
a mutual fetch.

Signed-off-by: Alexander Simmerl <a.simmerl@gmail.com>