### PR TITLE
fetch: do not force signed_refs

### DIFF
--- a/librad/src/git/fetch/specs.rs
+++ b/librad/src/git/fetch/specs.rs
@@ -362,7 +362,7 @@ pub mod refspecs {
                     Refspec {
                         src,
                         dst,
-                        force: Force::True,
+                        force: Force::False,
                     }
                     .into_fetchspec()
                 })
@@ -599,17 +599,17 @@ mod tests {
             [
                 // First, lolek + bolek's heads (forced)
                 format!(
-                    "+{}:{}",
+                    "{}:{}",
                     PROJECT_NAMESPACE.join(reflike!("refs/remotes/bolek/heads/mister")),
                     PROJECT_NAMESPACE.join(reflike!("refs/remotes/bolek/heads/mister"))
                 ),
                 format!(
-                    "+{}:{}",
+                    "{}:{}",
                     PROJECT_NAMESPACE.join(reflike!("refs/remotes/bolek/heads/next")),
                     PROJECT_NAMESPACE.join(reflike!("refs/remotes/bolek/heads/next"))
                 ),
                 format!(
-                    "+{}:{}",
+                    "{}:{}",
                     PROJECT_NAMESPACE.join(reflike!("refs/remotes/lolek/heads/mister")),
                     PROJECT_NAMESPACE.join(reflike!("refs/remotes/lolek/heads/mister"))
                 ),


### PR DESCRIPTION
We don't want to force the update of any of these references (despite
force not necessarily being respected
https://github.com/radicle-dev/radicle-link/issues/645).

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>