### PR TITLE
librad: task cancellation

### DIFF
--- a/ci/build-test
+++ b/ci/build-test
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 echo '--- Build'
-cargo build --verbose --workspace --all-features
+cargo build --workspace --all-features
 
 echo '--- Test'
-GIT_TRACE2=1 RUST_LOG=librad=trace cargo test --workspace --all-features
+RUST_LOG=error cargo test --workspace --all-features

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -25,3 +25,4 @@ path = "../librad"
 
 [dependencies.tokio]
 version = "1.1"
+features = ["rt-multi-thread", "macros"]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -120,7 +120,11 @@ features = ["derive"]
 
 [dependencies.tokio]
 version = "1.1"
-features = ["full"]
+features = ["rt-multi-thread", "process", "net", "time"]
+
+[dependencies.tokio-stream]
+version = "0.1"
+features = ["sync"]
 
 [dependencies.tokio-util]
 version = "0.6"

--- a/librad/src/executor.rs
+++ b/librad/src/executor.rs
@@ -1,0 +1,285 @@
+// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    any::Any,
+    future::Future,
+    panic,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering::Relaxed},
+        Arc,
+    },
+    task::{Context, Poll},
+};
+
+use futures::{
+    channel::mpsc::{self, UnboundedReceiver, UnboundedSender},
+    stream::{FuturesUnordered, Stream as _},
+    FutureExt as _,
+};
+use thiserror::Error;
+use tracing::Instrument as _;
+
+/// Wrapper around an async runtime, which:
+///
+/// * Approximates a task scope
+/// * Commits to a semantics where mainstream runtimes disagree
+/// * Adds instrumentation to spawned tasks
+/// * May allow compile-time selection of the runtime implementation at some
+///   point (currently only `tokio` is supported)
+///
+/// When a [`Spawner`] is dropped, all tasks spawned through it are cancelled.
+/// Note, however, that mainstream runtimes **do not** guarantee that those
+/// tasks are cancelled _immediately_.
+pub struct Spawner {
+    scope: String,
+    inner: tokio::runtime::Handle,
+    detach: UnboundedSender<DetachedTask>,
+    pid1: tokio::task::JoinHandle<()>,
+
+    spawned: Arc<AtomicUsize>,
+    blocking: Arc<AtomicUsize>,
+}
+
+impl Spawner {
+    /// Create a new [`Spawner`] with a scope label.
+    ///
+    /// The scope label is for informational purposes (logging, tracing) only.
+    pub fn new<S: AsRef<str>>(scope: S) -> Self {
+        let rt = tokio::runtime::Handle::current();
+        let (tx_submit, rx_submit) = mpsc::unbounded();
+
+        let pid1 = rt.spawn(
+            Pid1 {
+                submit: rx_submit,
+                running: FuturesUnordered::new(),
+            }
+            .instrument(tracing::info_span!("pid1", scope = %scope.as_ref())),
+        );
+
+        Self {
+            scope: scope.as_ref().to_owned(),
+            inner: rt,
+            detach: tx_submit,
+            pid1,
+            spawned: Arc::new(AtomicUsize::new(0)),
+            blocking: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub fn spawn<T>(&self, task: T) -> JoinHandle<T::Output>
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static,
+    {
+        let counter = Arc::clone(&self.spawned);
+        JoinHandle {
+            detach: self.detach.clone(),
+            task: self.inner.spawn(
+                async move {
+                    counter.fetch_add(1, Relaxed);
+                    let res = task.await;
+                    counter.fetch_sub(1, Relaxed);
+                    res
+                }
+                .in_current_span(),
+            ),
+        }
+    }
+
+    pub fn spawn_blocking<F, T>(&self, f: F) -> JoinHandle<T>
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        let span = tracing::Span::current();
+        let counter = Arc::clone(&self.blocking);
+        JoinHandle {
+            detach: self.detach.clone(),
+            task: self.inner.spawn_blocking(move || {
+                counter.fetch_add(1, Relaxed);
+                let _guard = span.enter();
+                let res = f();
+                counter.fetch_sub(1, Relaxed);
+                res
+            }),
+        }
+    }
+
+    pub fn stats(&self) -> Stats {
+        Stats {
+            scope: &self.scope,
+            spawned: self.spawned.load(Relaxed),
+            blocking: self.blocking.load(Relaxed),
+        }
+    }
+}
+
+impl Drop for Spawner {
+    fn drop(&mut self) {
+        tracing::trace!(scope = %self.scope, "shutting down...");
+        self.pid1.abort();
+        tracing::trace!(scope = %self.scope, "shutdown complete")
+    }
+}
+
+/// Snapshot of the state of a [`Spawner`].
+pub struct Stats<'a> {
+    /// Scope label of the [`Spawner`].
+    pub scope: &'a str,
+    /// Number of tasks spawned using [`Spawner::spawn`] whose futures have not
+    /// resoved yet. Includes detached tasks.
+    pub spawned: usize,
+    /// Number of tasks spawned using [`Spawner::spawn_blocking`] whose futures
+    /// have not resolved yet. Includes detached tasks.
+    pub blocking: usize,
+}
+
+/// A handle to a task spawned via [`Spawner::spawn`] or
+/// [`Spawner::spawn_blocking`].
+///
+/// Dropping a [`JoinHandle`] will abort the task, ie. `spawn(task);` is a
+/// no-op. To continue running the task without polling the [`JoinHandle`]
+/// future, [`JoinHandle::detach`] can be used.
+///
+/// This is similar to `async-std`, but very unlike `tokio`.
+#[must_use = "spawned tasks must be awaited"]
+pub struct JoinHandle<T> {
+    detach: UnboundedSender<DetachedTask>,
+    task: tokio::task::JoinHandle<T>,
+}
+
+impl<T> JoinHandle<T> {
+    /// Abort the task corresponding to this [`JoinHandle`].
+    ///
+    /// The task will be dropped immediately and not polled again -- _unless_ it
+    /// is currently being polled, in which case the task can be considered
+    /// cancelled only after poll returns. Iow it is not guaranteed that the
+    /// task is cancelled when this function returns.
+    pub fn abort(&self) {
+        self.task.abort()
+    }
+}
+
+impl JoinHandle<()> {
+    /// If the underlying task does not yield any output, it can be "detached".
+    ///
+    /// A detached task will continue to run until the [`Spawner`] through which
+    /// it was created is dropped. When this happens, the task is aborted as
+    /// if [`JoinHandle::abort`] was called.
+    pub fn detach(self) {
+        if let Err(e) = self.detach.unbounded_send(DetachedTask(self.task)) {
+            tracing::warn!("detach queue closed, task will be cancelled");
+            drop(e.into_inner())
+        }
+    }
+}
+
+impl<T> Future for JoinHandle<T> {
+    type Output = Result<T, JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        self.task.poll_unpin(cx).map(|t| t.map_err(JoinError::from))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum JoinError {
+    #[error("task cancelled")]
+    Cancelled,
+    #[error("task panicked")]
+    Panicked(Box<dyn Any + Send + 'static>),
+}
+
+impl JoinError {
+    /// Test if [`JoinError::into_cancelled`] would panic.
+    pub fn is_panic(&self) -> bool {
+        match self {
+            Self::Cancelled => false,
+            Self::Panicked(_) => true,
+        }
+    }
+
+    /// If `self` is [`JoinError::Cancelled`], returns [`Cancelled`], otherwise
+    /// resumes the panic contained in [`JoinError::Panicked`].
+    pub fn into_cancelled(self) -> Cancelled {
+        match self {
+            Self::Cancelled => Cancelled,
+            Self::Panicked(panik) => panic::resume_unwind(panik),
+        }
+    }
+}
+
+impl From<tokio::task::JoinError> for JoinError {
+    fn from(e: tokio::task::JoinError) -> Self {
+        if e.is_cancelled() {
+            Self::Cancelled
+        } else if e.is_panic() {
+            Self::Panicked(e.into_panic())
+        } else {
+            unreachable!("unexpected join error: {:?}", e)
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("spawned task cancelled")]
+pub struct Cancelled;
+
+struct DetachedTask(tokio::task::JoinHandle<()>);
+
+impl Drop for DetachedTask {
+    fn drop(&mut self) {
+        self.0.abort()
+    }
+}
+
+impl Future for DetachedTask {
+    type Output = Result<(), JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        self.0.poll_unpin(cx).map(|t| t.map_err(JoinError::from))
+    }
+}
+
+/// Keeps track of [`DetachedTask`]s spawned through a particular [`Spawner`],
+/// dropping their handles once their futures resolve. When the [`Spawner`] is
+/// dropped, its [`Pid1`] is aborted, which in turn will drop all in-flight
+/// tasks.
+struct Pid1 {
+    submit: UnboundedReceiver<DetachedTask>,
+    running: FuturesUnordered<DetachedTask>,
+}
+
+impl Pid1 {
+    fn poll_submitted(&mut self, cx: &mut Context) {
+        while let Poll::Ready(Some(task)) = Pin::new(&mut self.submit).poll_next(cx) {
+            self.running.push(task)
+        }
+    }
+
+    fn poll_running(&mut self, cx: &mut Context) {
+        while let Poll::Ready(Some(result)) = Pin::new(&mut self.running).poll_next(cx) {
+            if let Err(JoinError::Panicked(panik)) = result {
+                tracing::error!(
+                    "detached task panicked: {:?}",
+                    panik.downcast_ref::<String>()
+                )
+            }
+        }
+    }
+}
+
+impl Future for Pid1 {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        self.poll_submitted(cx);
+        self.poll_running(cx);
+
+        Poll::Pending
+    }
+}

--- a/librad/src/git/fetch.rs
+++ b/librad/src/git/fetch.rs
@@ -16,7 +16,7 @@ pub use specs::Fetchspecs;
 pub const ONE_KB: usize = 1024;
 /// 5Mb for use in [`Limit`], specifically for the `peek` field, when we would
 /// like to fetch `rad/id` , `rad/self`, `rad/ids/*` references. This limit is
-/// based on the analysis in https://github.com/radicle-dev/radicle-upstream/issues/1795
+/// based on the analysis in <https://github.com/radicle-dev/radicle-upstream/issues/1795>
 pub const FIVE_MB: usize = ONE_KB * 5000;
 /// 5GB for use in [`Limit`], specifically for the `data` field, when we would
 /// like to fetch `rad/*` as well as `refs/heads/*` references.

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -50,3 +50,5 @@ extern crate futures_await_test;
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;
+
+pub(crate) mod executor;

--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -129,7 +129,7 @@ where
             },
 
             Ok(evt) => match evt {
-                Downstream::Gossip(gossip) => control::gossip(&state, gossip).await,
+                Downstream::Gossip(gossip) => control::gossip(&state, gossip, None).await,
                 Downstream::Info(info) => control::info(&state, info),
                 Downstream::Interrogation(inter) => {
                     control::interrogation(state.clone(), inter).await

--- a/librad/src/net/protocol/gossip.rs
+++ b/librad/src/net/protocol/gossip.rs
@@ -12,6 +12,18 @@ pub enum Rev {
     Git(git2::Oid),
 }
 
+impl From<git2::Oid> for Rev {
+    fn from(oid: git2::Oid) -> Self {
+        Self::Git(oid)
+    }
+}
+
+impl From<git_ext::Oid> for Rev {
+    fn from(oid: git_ext::Oid) -> Self {
+        Self::Git(oid.into())
+    }
+}
+
 impl Encode for Rev {
     fn encode<W: minicbor::encode::Write>(
         &self,

--- a/librad/src/net/protocol/io.rs
+++ b/librad/src/net/protocol/io.rs
@@ -7,7 +7,6 @@ use std::{iter, net::SocketAddr};
 
 use data::BoundedVec;
 use futures::stream::{self, StreamExt as _};
-use tracing::Instrument as _;
 
 use super::{
     gossip,
@@ -69,7 +68,10 @@ where
                         .await
                 }
 
-                tokio::spawn(streams::incoming(state.clone(), ingress).in_current_span());
+                state
+                    .spawner
+                    .spawn(streams::incoming(state.clone(), ingress))
+                    .detach();
             },
         }
     }

--- a/librad/src/net/protocol/tick.rs
+++ b/librad/src/net/protocol/tick.rs
@@ -9,7 +9,6 @@ use futures::{
     future::{BoxFuture, FutureExt as _, TryFutureExt as _},
     stream::{FuturesOrdered, StreamExt as _},
 };
-use tracing::Instrument as _;
 
 use super::{error, gossip, io, membership, PeerInfo, ProtocolStorage, State};
 use crate::PeerId;
@@ -105,7 +104,11 @@ where
                         let (conn, ingress) = io::connect_peer_info(&state.endpoint, to.clone())
                             .await
                             .ok_or(error::BestEffortSend::CouldNotConnect { to })?;
-                        tokio::spawn(io::streams::incoming(state, ingress).in_current_span());
+                        state
+                            .spawner
+                            .clone()
+                            .spawn(io::streams::incoming(state, ingress))
+                            .detach();
 
                         Ok(conn)
                     },

--- a/librad/src/net/quic/endpoint.rs
+++ b/librad/src/net/quic/endpoint.rs
@@ -17,10 +17,10 @@ use nonempty::NonEmpty;
 use parking_lot::RwLock;
 use quinn::{NewConnection, TransportConfig};
 use socket2::{Domain, Protocol, Socket, Type};
-use tracing::Instrument as _;
 
 use super::{BoxedIncomingStreams, Connection, Conntrack, Error, Result};
 use crate::{
+    executor,
     net::{
         connection::{CloseReason, LocalAddr, LocalPeer},
         tls,
@@ -65,6 +65,7 @@ pub struct Endpoint {
 impl Endpoint {
     pub async fn bind<'a, S>(
         signer: S,
+        spawner: &executor::Spawner,
         listen_addr: SocketAddr,
         advertised_addrs: Option<NonEmpty<SocketAddr>>,
         network: Network,
@@ -82,7 +83,7 @@ impl Endpoint {
             match advertised_addrs {
                 Some(addrs) => listen_addrs.write().extend(addrs),
                 None if listen_addr.ip().is_unspecified() => {
-                    ifwatch(listen_addr, Arc::downgrade(&listen_addrs)).await?
+                    ifwatch(spawner, listen_addr, Arc::downgrade(&listen_addrs)).await?
                 },
                 None => listen_addrs.write().extend(Some(listen_addr)),
             }
@@ -214,8 +215,9 @@ fn bind_socket(listen_addr: SocketAddr) -> Result<UdpSocket> {
     Ok(sock.into())
 }
 
-#[tracing::instrument(skip(listen_addrs))]
+#[tracing::instrument(skip(spawner, listen_addrs))]
 async fn ifwatch(
+    spawner: &executor::Spawner,
     bound_addr: SocketAddr,
     listen_addrs: Weak<RwLock<BTreeSet<SocketAddr>>>,
 ) -> io::Result<()> {
@@ -226,8 +228,8 @@ async fn ifwatch(
     }
 
     let mut watcher = IfWatcher::new().await?;
-    tokio::spawn(
-        async move {
+    spawner
+        .spawn(async move {
             loop {
                 match Pin::new(&mut watcher).await {
                     Err(e) => {
@@ -271,9 +273,8 @@ async fn ifwatch(
                     },
                 }
             }
-        }
-        .in_current_span(),
-    );
+        })
+        .detach();
 
     Ok(())
 }

--- a/librad/src/net/quic/error.rs
+++ b/librad/src/net/quic/error.rs
@@ -3,7 +3,7 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use crate::peer;
+use crate::{executor, peer};
 use std::io;
 use thiserror::Error;
 
@@ -38,6 +38,15 @@ pub enum Error {
 
     #[error(transparent)]
     Io(#[from] io::Error),
+
+    #[error(transparent)]
+    Task(executor::Cancelled),
+}
+
+impl From<executor::JoinError> for Error {
+    fn from(e: executor::JoinError) -> Self {
+        Self::Task(e.into_cancelled())
+    }
 }
 
 #[derive(Debug, Error)]

--- a/librad/tests/scenario/collaboration.rs
+++ b/librad/tests/scenario/collaboration.rs
@@ -24,12 +24,12 @@ fn config() -> testnet::Config {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn can_add_maintainer() {
+#[test]
+fn can_add_maintainer() {
     logging::init();
 
-    let net = testnet::run(config()).await.unwrap();
-    {
+    let net = testnet::run(config()).unwrap();
+    net.enter(async {
         let peer1 = net.peers().index(0);
         let peer2 = net.peers().index(1);
 
@@ -102,5 +102,5 @@ async fn can_add_maintainer() {
                 verified.unwrap().delegations().iter().direct().next()
             );
         }
-    }
+    })
 }

--- a/librad/tests/scenario/working_copy.rs
+++ b/librad/tests/scenario/working_copy.rs
@@ -66,12 +66,12 @@ fn config() -> testnet::Config {
 /// 7. peer2 creates an include file, based of the tracked users of the project
 /// i.e. peer1 8. peer2 includes this file in their working copy's config
 /// 9. peer2 fetches in the working copy and sees the commit
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn can_fetch() {
+#[test]
+fn can_fetch() {
     logging::init();
 
-    let net = testnet::run(config()).await.unwrap();
-    {
+    let net = testnet::run(config()).unwrap();
+    net.enter(async {
         let peer1 = net.peers().index(0);
         let peer2 = net.peers().index(1);
 
@@ -130,7 +130,7 @@ async fn can_fetch() {
             .unwrap();
             assert!(peer2_repo.find_commit(commit_id).is_ok());
         }
-    }
+    })
 }
 
 // Perform commit and push to working copy on peer1

--- a/librad/tests/smoke/clone.rs
+++ b/librad/tests/smoke/clone.rs
@@ -40,12 +40,12 @@ fn disconnected_config() -> testnet::Config {
 
 /// Fetching from a peer that does not have the identity should leave the
 /// `rad/*` refs intact.
-#[tokio::test]
-async fn not_present() {
+#[test]
+fn not_present() {
     logging::init();
 
-    let net = testnet::run(default_config()).await.unwrap();
-    {
+    let net = testnet::run(default_config()).unwrap();
+    net.enter(async {
         let maintainer = Host::init(net.peers().index(0)).await;
         let contributor = Leecher(net.peers().index(1));
         let voyeur = net.peers().index(2);
@@ -86,41 +86,41 @@ async fn not_present() {
             })
             .await
             .unwrap();
-    }
+    })
 }
 
-#[tokio::test]
-async fn when_connected() {
+#[test]
+fn when_connected() {
     logging::init();
 
-    let net = testnet::run(default_config()).await.unwrap();
-    {
+    let net = testnet::run(default_config()).unwrap();
+    net.enter(async {
         let host = Host::init(&net.peers()[0]).await;
         Leecher(&net.peers()[1]).clone_from(host, false).await
-    }
+    })
 }
 
-#[tokio::test]
-async fn when_disconnected() {
+#[test]
+fn when_disconnected() {
     logging::init();
 
-    let net = testnet::run(disconnected_config()).await.unwrap();
-    {
+    let net = testnet::run(disconnected_config()).unwrap();
+    net.enter(async {
         let host = Host::init(&net.peers()[0]).await;
         Leecher(&net.peers()[1]).clone_from(host, true).await
-    }
+    })
 }
 
-#[tokio::test]
+#[test]
 #[should_panic(expected = "git p2p transport: no connection to")]
-async fn when_disconnected_and_no_addr_hints() {
+fn when_disconnected_and_no_addr_hints() {
     logging::init();
 
-    let net = testnet::run(disconnected_config()).await.unwrap();
-    {
+    let net = testnet::run(disconnected_config()).unwrap();
+    net.enter(async {
         let host = Host::init(&net.peers()[0]).await;
         Leecher(&net.peers()[1]).clone_from(host, false).await
-    }
+    })
 }
 
 struct Host<'a> {

--- a/librad/tests/smoke/fetch_limit.rs
+++ b/librad/tests/smoke/fetch_limit.rs
@@ -14,8 +14,8 @@ use librad_test::{
 /// Stress test the limits that are set for fetching when using `replicate`.
 /// The `fetch::Limit` contains a base limit and should be scaled by the number
 /// of remotes that the fetcher is fetching from.
-#[tokio::test]
-async fn replication_does_not_exceed_limit() {
+#[test]
+fn replication_does_not_exceed_limit() {
     logging::init();
 
     let net = testnet::run(testnet::Config {
@@ -23,9 +23,8 @@ async fn replication_does_not_exceed_limit() {
         min_connected: 6,
         bootstrap: testnet::Bootstrap::from_env(),
     })
-    .await
     .unwrap();
-    {
+    net.enter(async {
         let peer1 = net.peers().index(0);
         let peer2 = net.peers().index(1);
         let peer3 = net.peers().index(2);
@@ -57,5 +56,5 @@ async fn replication_does_not_exceed_limit() {
             proj.pull(peer, peer1).await.ok().unwrap();
         }
         proj.pull(peer1, peer6).await.ok().unwrap();
-    }
+    })
 }

--- a/librad/tests/smoke/gossip.rs
+++ b/librad/tests/smoke/gossip.rs
@@ -49,12 +49,12 @@ fn config() -> testnet::Config {
 /// peer1. Then wait for peer2 to receive announcements for the project.
 /// Assert that peer2’s monorepo contains the commit, the branch and the tag
 /// from peer1.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn fetches_on_gossip_notify() {
+#[test]
+fn fetches_on_gossip_notify() {
     logging::init();
 
-    let net = testnet::run(config()).await.unwrap();
-    {
+    let net = testnet::run(config()).unwrap();
+    net.enter(async {
         let peer1 = net.peers().index(0);
         let peer2 = net.peers().index(1);
         let proj = peer1
@@ -175,7 +175,7 @@ async fn fetches_on_gossip_notify() {
             })
             .await
             .unwrap();
-    }
+    })
 }
 
 /// Given that a) a peer 1 holds a given URN and b) that same peer is a seed of
@@ -184,12 +184,12 @@ async fn fetches_on_gossip_notify() {
 ///
 /// Following that, verify that cloning from the returned PeerId means we have
 /// the URN in our monorepo.
-#[tokio::test]
-async fn ask_and_clone() {
+#[test]
+fn ask_and_clone() {
     logging::init();
 
-    let net = testnet::run(config()).await.unwrap();
-    {
+    let net = testnet::run(config()).unwrap();
+    net.enter(async {
         let peer1 = &net.peers()[0];
         let peer2 = &net.peers()[1];
         let proj = peer1
@@ -235,5 +235,5 @@ async fn ask_and_clone() {
             "expected peer2 to have URN {}",
             project_urn
         )
-    }
+    })
 }

--- a/librad/tests/smoke/graft.rs
+++ b/librad/tests/smoke/graft.rs
@@ -23,12 +23,12 @@ fn config() -> testnet::Config {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn mutual_fetch() {
+#[test]
+fn mutual_fetch() {
     logging::init();
 
-    let net = testnet::run(config()).await.unwrap();
-    {
+    let net = testnet::run(config()).unwrap();
+    net.enter(async {
         let alice = net.peers().index(0);
         let bob = net.peers().index(1);
         let project = alice
@@ -127,5 +127,5 @@ async fn mutual_fetch() {
 
         assert!(alice_has_bob, "alice is missing bob's commit");
         assert!(bob_has_alice, "bob is missing alice's commit");
-    }
+    })
 }

--- a/librad/tests/smoke/interrogation.rs
+++ b/librad/tests/smoke/interrogation.rs
@@ -19,12 +19,12 @@ fn config() -> testnet::Config {
     }
 }
 
-#[tokio::test]
-async fn responds() {
+#[test]
+fn responds() {
     logging::init();
 
-    let net = testnet::run(config()).await.unwrap();
-    {
+    let net = testnet::run(config()).unwrap();
+    net.enter(async {
         let responder = net.peers().index(0);
         let requester = net.peers().index(1);
         let TestProject { project, owner } = responder
@@ -53,5 +53,5 @@ async fn responds() {
         for urn in &[SomeUrn::Git(project.urn()), SomeUrn::Git(owner.urn())] {
             assert!(urns.contains(urn))
         }
-    }
+    })
 }

--- a/librad/tests/smoke/regression.rs
+++ b/librad/tests/smoke/regression.rs
@@ -16,8 +16,8 @@ use librad_test::{
 
 /// https://github.com/radicle-dev/radicle-link/issues/250
 /// Fixed in: 577e9943fa704895b47fe4e1c862bf0bd51d58a9
-#[tokio::test]
-async fn list_identities_returns_only_local_projects() {
+#[test]
+fn list_identities_returns_only_local_projects() {
     logging::init();
 
     let net = testnet::run(testnet::Config {
@@ -25,9 +25,8 @@ async fn list_identities_returns_only_local_projects() {
         min_connected: 3,
         bootstrap: testnet::Bootstrap::from_env(),
     })
-    .await
     .unwrap();
-    {
+    net.enter(async {
         let peer1 = net.peers().index(0);
         let peer2 = net.peers().index(1);
         let peer3 = net.peers().index(2);
@@ -49,5 +48,5 @@ async fn list_identities_returns_only_local_projects() {
             .unwrap();
 
         assert_eq!(2, all_identities.len());
-    }
+    })
 }

--- a/librad/tests/smoke/saturation.rs
+++ b/librad/tests/smoke/saturation.rs
@@ -28,14 +28,14 @@ fn config() -> testnet::Config {
     }
 }
 
-#[tokio::test]
-async fn saturate_a_peer_with_projects() {
+#[test]
+fn saturate_a_peer_with_projects() {
     logging::init();
 
     const NUM_PROJECTS: usize = 64;
 
-    let net = testnet::run(config()).await.unwrap();
-    {
+    let net = testnet::run(config()).unwrap();
+    net.enter(async {
         let peer1 = net.peers().index(0);
         let peer2 = net.peers().index(1);
 
@@ -111,5 +111,5 @@ async fn saturate_a_peer_with_projects() {
             .unwrap()
             .unwrap();
         assert_eq!(n_projects, NUM_PROJECTS);
-    }
+    })
 }


### PR DESCRIPTION
This is the (hopefully) last attempt to ensure orderly shutdown of
spawned tasks. It naturally touches a lot of files, but fret not: the
relevant pieces are mainly in `librad/src/executor.rs` and
`librad-test/src/rad/testnet.rs`.

Problem Overview
================

Task cancellation is ill-defined (ahem, an open problem) in contemporary
async Rust runtimes, particularly tokio: when the `JoinHandle` to a
spawned task is dropped, the task becomes detached and there is no way
to join or abort it.

The task itself does not get notified of runtime shutdown, so it needs
to ensure it stops by some other means -- by default, the runtime blocks
on the completion of any outstanding tasks when it shuts down.

Even if we manage to call `abort` on a `JoinHandle`, this will not
ensure prompt cancellation: the task could be currently scheduled to
run, and there's no way for the runtime to preempt it. That is, even
after aborting a task, we need to poll the `JoinHandle` at least once
more, or if the handle is lost wait for the entire runtime to terminate.

Lastly, aborting a task does not mean that any `JoinHandle`s the task is
`await`-ing will be aborted, too -- instead, they are going to become
detached.

All of this is arguably error-prone, but not so much of a problem for a
program with a single entry point, which shuts down whenever the "main
loop" it spawns terminates. It is a problem, however, when the program
wishes to restart such a main loop, but only after the previous instance
has fully released all resources.

Solution Overview
=================

We define a thin wrapper around the current runtime, `executor::Spawn`,
which shall be the single means of spawning tasks throughout the
library. This type is not publicly exported (we'll see why later).

`Spawn` adopts the `JoinHandle` semantics of `async-std`: when the
handle is dropped, the task gets aborted. It is possible to "detach" a
task, on which case `Spawn` internally keeps track of it. When
`Spawn::shutdown` is called, it is no longer possible to spawn new tasks
(detached or not), the outstanding detached tasks get aborted, and the
call blocks until the outstanding tasks have all terminated.

This does not present a user-visible task supervision framework, but
allows the stateful objects of the library to keep track of their own
tasks, and block on their completion when dropped. It is not necessary
for library maintainers to define their tasks in a particular
cancellation-aware way.

Subtleties
==========

We currently have two such stateful objects: one being the protocol
stack, and the other a handle to it (`net::Peer`). It is possible for
the handle to outlive the protocol stack (and continue to communicate
with it in case it gets restarted). The handle may, however, spawn tasks
itself, as it currently manages the storage pool. For these reasons, we allocate
independent `Spawn`s for each of them -- which means that this is all
internal state management, and the library user never gets to see any of
those `Spawn`ers.

For all of this to work, it is crucial that all `librad` code is
executed in an async context (ie. inside `Runtime::block_on`). This will
usually behave as expected in single-entry main() programs, but requires
to manage the runtime lifecycle in the multi-peer integration tests:
since they hold on to temporary files, it is advisable to wait on
_complete_ task shutdown (that is: runtime termination) before removing them.

Note that morally, these tests should allocate a separate runtime per
logical peer, in order to approximate the real-world multi-process
behaviour. This would, however, require considerable boilerplate for
test writers to ensure operations are scheduled onto the right peer's
event loop, so it was opted to use a single runtime peer test instead.

Collaterals
===========

2029473319c961e326d774683acda49d2106f274 is reverted in the process, as
this would subvert the task-tracking introduced here.

The logging verbosity of the test suite has been reduced in CI, as the
amount of log output has exceeded a useful volume.

Signed-off-by: Kim Altintop <kim@monadic.xyz>