### PR TITLE
net: run rere after serving the fetch

### DIFF
--- a/librad/tests/smoke/fetch_limit.rs
+++ b/librad/tests/smoke/fetch_limit.rs
@@ -52,8 +52,8 @@ fn replication_does_not_exceed_limit() {
             .unwrap();
 
         for &peer in &[peer2, peer3, peer4, peer5] {
-            proj.pull(peer1, peer).await.ok().unwrap();
-            proj.pull(peer, peer1).await.ok().unwrap();
+            proj.pull(peer1, peer).await.unwrap();
+            proj.pull(peer, peer1).await.unwrap();
         }
         proj.pull(peer1, peer6).await.ok().unwrap();
     })


### PR DESCRIPTION
Running both concurrently makes things harder to reason about. Better
opportunities for optimisation and interleaving may arise with git
protocol v2.

Signed-off-by: Kim Altintop <kim@monadic.xyz>