### PR TITLE
daemon: run all async tests on the multi-threaded runtime

### DIFF
--- a/daemon/src/seed.rs
+++ b/daemon/src/seed.rs
@@ -94,7 +94,7 @@ mod tests {
 
     use pretty_assertions::assert_eq;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_resolve_seeds() -> Result<(), super::Error> {
         let seeds = super::resolve(&[
             "hydsst3z3d5bc6pxq4gz1g4cu6sgbx38czwf3bmmk3ouz4ibjbbtds@localhost:9999",

--- a/daemon/src/state.rs
+++ b/daemon/src/state.rs
@@ -974,7 +974,7 @@ pub mod test {
         ]
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn can_create_user() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         let key = SecretKey::new();
@@ -988,7 +988,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn can_init_owner() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         let key = SecretKey::new();
@@ -1018,7 +1018,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn can_update_owner_payload() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         let key = SecretKey::new();
@@ -1048,7 +1048,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn can_create_project() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         env::set_var("RAD_HOME", tmp_dir.path());
@@ -1073,7 +1073,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn can_create_project_for_existing_repo() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         let repo_path = tmp_dir.path().join("radicle");
@@ -1099,7 +1099,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn list_projects() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
 
@@ -1141,7 +1141,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn list_users() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         let key = SecretKey::new();

--- a/daemon/tests/internal.rs
+++ b/daemon/tests/internal.rs
@@ -14,7 +14,7 @@ use radicle_daemon::{PeerEvent, RunConfig};
 mod common;
 use common::*;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn can_observe_timers() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
 

--- a/daemon/tests/replication.rs
+++ b/daemon/tests/replication.rs
@@ -39,7 +39,7 @@ use common::{
     started,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn can_clone_project() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
 
@@ -122,7 +122,7 @@ async fn can_clone_project() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn can_clone_user() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
 
@@ -175,7 +175,7 @@ async fn can_clone_user() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn can_fetch_project_changes() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
 
@@ -318,7 +318,7 @@ async fn can_fetch_project_changes() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn can_sync_on_startup() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
 
@@ -387,7 +387,7 @@ async fn can_sync_on_startup() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn can_create_working_copy_of_peer() -> Result<(), Box<dyn std::error::Error + 'static>> {
     init_logging();
 
@@ -534,7 +534,7 @@ async fn can_create_working_copy_of_peer() -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn track_peer() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
     let alice_tmp_dir = tempfile::tempdir()?;

--- a/daemon/tests/working_copy.rs
+++ b/daemon/tests/working_copy.rs
@@ -17,7 +17,7 @@ use pretty_assertions::assert_eq;
 mod common;
 use common::{build_peer, init_logging, shia_le_pathbuf};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn upstream_for_default() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
 
@@ -53,7 +53,7 @@ async fn upstream_for_default() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn checkout_twice_fails() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
 


### PR DESCRIPTION
In conjunction with #650, we see async tests intermittently hanging
indefinitely when the per-test runtime shuts down. This may have to do
with some blocking operations in `daemon` not being properly
`spawn_blocking`-ed (and thus blocking the single runtime thread), or
some mysterious interaction with threads spawned from within the async
program.

In any case, using the multi-threaded runtime appears to fix it.

Signed-off-by: Kim Altintop <kim@monadic.xyz>