### PR TITLE
net: send disconnect on unsolicited broadcast

### DIFF
--- a/librad/src/net/protocol/io/recv/gossip.rs
+++ b/librad/src/net/protocol/io/recv/gossip.rs
@@ -11,19 +11,23 @@ use futures::{
 };
 use futures_codec::FramedRead;
 
-use crate::net::{
-    connection::RemotePeer,
-    protocol::{
-        broadcast,
-        gossip,
-        info::PeerInfo,
-        io::{codec, peer_advertisement},
-        membership,
-        tick,
-        ProtocolStorage,
-        State,
+use crate::{
+    net::{
+        connection::RemotePeer,
+        protocol::{
+            broadcast,
+            event,
+            gossip,
+            info::PeerInfo,
+            io::{codec, peer_advertisement},
+            membership,
+            tick,
+            ProtocolStorage,
+            State,
+        },
+        upgrade::{self, Upgraded},
     },
-    upgrade::{self, Upgraded},
+    PeerId,
 };
 
 pub(in crate::net::protocol) async fn gossip<S, T>(
@@ -40,15 +44,10 @@ pub(in crate::net::protocol) async fn gossip<S, T>(
         match x {
             Err(e) => {
                 tracing::warn!(err = ?e, "gossip recv error");
-                let info = || peer_advertisement(&state.endpoint);
-
                 let membership::TnT { trans, ticks } = state.membership.connection_lost(remote_id);
-                trans.into_iter().for_each(|evt| state.phone.emit(evt));
-                for tick in ticks {
-                    stream::iter(membership::collect_tocks(&state.membership, &info, tick))
-                        .for_each(|tock| tick::tock(state.clone(), tock))
-                        .await
-                }
+                let tocks = membership_tocks(&state, ticks.into_iter());
+                eval_events(&state, trans);
+                eval_tocks(state.clone(), tocks).await;
 
                 break;
             },
@@ -68,22 +67,68 @@ pub(in crate::net::protocol) async fn gossip<S, T>(
                 )
                 .await
                 {
-                    Err(e) => {
-                        tracing::warn!(err = ?e, "gossip error");
+                    // Partial view states diverge apparently, and the stream is
+                    // (assumed to be) unidirectional. Thus, send a DISCONNECT
+                    // to sync states.
+                    Err(broadcast::Error::Unsolicited { remote_id, .. }) => {
+                        tracing::warn!(
+                            remote_id = %remote_id,
+                            "unsolicited broadcast message, sending disconnect"
+                        );
+                        let tocks =
+                            membership_tocks(&state, Some(disconnect(remote_id)).into_iter());
+                        eval_tocks(state.clone(), tocks).await;
+
                         break;
                     },
 
                     Ok((may_event, tocks)) => {
-                        if let Some(event) = may_event {
-                            state.phone.emit(event)
-                        }
-
-                        stream::iter(tocks)
-                            .for_each(|tock| tick::tock(state.clone(), tock))
-                            .await
+                        eval_events(&state, may_event);
+                        eval_tocks(state.clone(), tocks).await
                     },
                 }
             },
         }
+    }
+}
+
+fn membership_tocks<'a, S, I>(
+    state: &'a State<S>,
+    ticks: I,
+) -> impl Iterator<Item = tick::Tock<SocketAddr, gossip::Payload>> + 'a
+where
+    I: Iterator<Item = membership::Tick<SocketAddr>> + 'a,
+{
+    let info = {
+        let endpoint = state.endpoint.clone();
+        move || peer_advertisement(&endpoint)
+    };
+    ticks.flat_map(move |tick| membership::collect_tocks(&state.membership, &info, tick))
+}
+
+async fn eval_tocks<S, I>(state: State<S>, tocks: I)
+where
+    S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + Clone + 'static,
+    I: IntoIterator<Item = tick::Tock<SocketAddr, gossip::Payload>>,
+{
+    stream::iter(tocks)
+        .for_each(|tock| tick::tock(state.clone(), tock))
+        .await
+}
+
+fn eval_events<S, I, E>(state: &State<S>, evts: I)
+where
+    I: IntoIterator<Item = E>,
+    E: Into<event::Upstream>,
+{
+    for evt in evts {
+        state.phone.emit(evt)
+    }
+}
+
+fn disconnect<A>(remote_id: PeerId) -> membership::Tick<A> {
+    membership::Tick::Reply {
+        to: remote_id,
+        message: membership::Message::Disconnect,
     }
 }


### PR DESCRIPTION
Another oversight when switching to unidirectional streams: the
unsolicited state occurs when partial view states diverge, but the
remote end will never know because closing the stream has no effect
anymore. Thus, send a DISCONNECT message in this case to sync states.

Signed-off-by: Kim Altintop <kim@monadic.xyz>