### PR TITLE
protocol: Guard against underflow in promotion

### DIFF
--- a/librad/src/net/protocol/membership/hpv.rs
+++ b/librad/src/net/protocol/membership/hpv.rs
@@ -315,7 +315,15 @@ where
     }
 
     pub fn choose_passive_to_promote(&mut self) -> Vec<PeerInfo<Addr>> {
-        let n = self.params.max_active - self.num_active();
+        assert!(
+            self.params.max_active >= self.num_active(),
+            "number of active peers is larger than the configured max"
+        );
+        let n = self
+            .params
+            .max_active
+            .checked_sub(self.num_active())
+            .unwrap_or(1);
         self.view.passive_info().choose_multiple(&mut self.rng, n)
     }
 


### PR DESCRIPTION
If the number of peers currently active in the view is larger than the
configured max, the calculation to pick a random number of peers from
the passive list will panic. If the subtraction on usize underflows it
will return `usize::MAX` which in turn will cause trouble in the
allocation code of raw vectors as it hits the max capacity branch in the
alloc_guard. The reason this is happening in the first is that
`choose_mutliple` of the rand crate creates a `Vec` with the given
`amount` in our case `n`. See links below to decent into madness:

https://github.com/rust-random/rand/blob/30d2d98df5d09c524a30c8772fc7c8b203f5b70a/src/seq/mod.rs#L468
https://github.com/rust-lang/rust/blob/master/library/alloc/src/raw_vec.rs#L188
https://github.com/rust-lang/rust/blob/e5f83d24aee866a14753a7cedbb4e301dfe5bef5/library/alloc/src/raw_vec.rs#L198

Signed-off-by: Alexander Simmerl <a.simmerl@gmail.com>