### PR TITLE
testing: move daemon test to centralisised test crate

### DIFF
--- a/.github/workflows/fast.yaml
+++ b/.github/workflows/fast.yaml
@@ -66,6 +66,7 @@ jobs:
           ./ci/macos-gnu
           echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
       - run: ./ci/test-fast
+        timeout-minutes: 20
         shell: bash
 
   test-win:
@@ -86,4 +87,5 @@ jobs:
         run: rustup update nightly-2021-03-25 --no-self-update && rustup default nightly-2021-03-25
         shell: bash
       - run: ./ci/test-fast
+        timeout-minutes: 20
         shell: bash

--- a/ci/test-fast
+++ b/ci/test-fast
@@ -2,4 +2,4 @@
 set -eou pipefail
 
 echo '--- Library tests'
-cargo test --lib --all-features
+cargo test --lib --all-features unit

--- a/radicle-link-test/Cargo.toml
+++ b/radicle-link-test/Cargo.toml
@@ -49,11 +49,11 @@ features = []
 [dependencies.librad]
 path = "../librad"
 
-[dependencies.radicle-git-ext]
-path = "../git-ext"
-
 [dependencies.radicle-daemon]
 path = "../daemon"
+
+[dependencies.radicle-git-ext]
+path = "../git-ext"
 
 [dependencies.rand]
 version = "0.7"

--- a/radicle-link-test/src/daemon.rs
+++ b/radicle-link-test/src/daemon.rs
@@ -3,4 +3,5 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
+#[macro_use]
 pub mod common;

--- a/radicle-link-test/src/daemon/common.rs
+++ b/radicle-link-test/src/daemon/common.rs
@@ -3,25 +3,34 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::{path::PathBuf, time::Duration};
+use std::{future::Future, net::SocketAddr, path::PathBuf, time::Duration};
 
+use anyhow::Context as _;
 use futures::{future, StreamExt as _};
-use tokio::{
-    sync::broadcast,
-    time::{error::Elapsed, timeout},
-};
+use tokio::{sync::broadcast, time::timeout};
 
 use librad::{
-    git::Urn,
+    git::{identities::local::LocalIdentity, Urn},
     git_ext::OneLevel,
     keys::SecretKey,
-    net::discovery,
     peer::PeerId,
     reflike,
     signer,
+    signer::BoxedSigner,
 };
 
-use radicle_daemon::{config, project, seed::Seed, Paths, Peer, PeerEvent, PeerStatus, RunConfig};
+use radicle_daemon::{
+    config,
+    identities::payload::Person,
+    peer,
+    project,
+    seed::Seed,
+    state::init_owner,
+    Paths,
+    PeerEvent,
+    PeerStatus,
+    RunConfig,
+};
 
 #[doc(hidden)]
 #[macro_export]
@@ -37,7 +46,6 @@ macro_rules! await_event {
     }};
 }
 
-#[macro_export]
 macro_rules! assert_event {
     ( $receiver:expr , $pattern:pat ) => {{
         $crate::await_event!($receiver, |res| match res.unwrap() {
@@ -55,40 +63,51 @@ macro_rules! assert_event {
 
 /// Assert that we received a cloned event for the expected `RadUrl`.
 pub async fn assert_cloned(
-    mut receiver: broadcast::Receiver<PeerEvent>,
+    receiver: &mut broadcast::Receiver<PeerEvent>,
     expected_urn: &Urn,
     expected_remote: PeerId,
-) -> Result<(), Elapsed> {
+) -> Result<(), anyhow::Error> {
     assert_event!(
         receiver,
         PeerEvent::RequestCloned(urn, remote_peer) if urn == *expected_urn && remote_peer == expected_remote
-    )
+    ).context("assert_cloned")
+}
+
+pub async fn assert_fetched(
+    receiver: &mut broadcast::Receiver<PeerEvent>,
+) -> Result<(), anyhow::Error> {
+    assert_event!(receiver, PeerEvent::GossipFetched { .. }).context("assert_fetched")
 }
 
 /// Assert that we received a query event for the expected `RadUrn`.
 pub async fn requested(
-    mut receiver: broadcast::Receiver<PeerEvent>,
+    receiver: &mut broadcast::Receiver<PeerEvent>,
     expected: &Urn,
-) -> Result<(), Elapsed> {
+) -> Result<(), anyhow::Error> {
     assert_event!(
         receiver,
         PeerEvent::RequestQueried(urn) if urn == *expected
     )
+    .context("requested")
 }
 
 /// Assert that the `PeerStatus` transitions to `Online` and the number of
 /// connected peers is equal to or more than `min_connected`.
-pub async fn connected(
-    mut receiver: broadcast::Receiver<PeerEvent>,
+async fn connected(
+    receiver: &mut broadcast::Receiver<PeerEvent>,
     min_connected: usize,
-) -> Result<(), Elapsed> {
+) -> Result<(), anyhow::Error> {
     assert_event!(
         receiver,
-        PeerEvent::StatusChanged { new: PeerStatus::Online { connected_peers, .. }, .. } if connected_peers.len() >= min_connected
+        PeerEvent::StatusChanged {
+            new: PeerStatus::Online { connected_peers, .. },
+            ..
+        } if connected_peers.len() >= min_connected
     )
+    .context("connected")
 }
 
-pub async fn started(mut receiver: broadcast::Receiver<PeerEvent>) -> Result<(), Elapsed> {
+async fn started(receiver: &mut broadcast::Receiver<PeerEvent>) -> Result<(), anyhow::Error> {
     assert_event!(
         receiver,
         PeerEvent::StatusChanged {
@@ -96,36 +115,122 @@ pub async fn started(mut receiver: broadcast::Receiver<PeerEvent>) -> Result<(),
             ..
         }
     )
+    .context("started")
 }
 
-pub async fn build_peer(
-    tmp_dir: &tempfile::TempDir,
-    run_config: RunConfig,
-) -> Result<Peer<signer::BoxedSigner, discovery::Static>, Box<dyn std::error::Error>> {
-    let key = SecretKey::new();
-    let signer = signer::BoxedSigner::from(key);
-    let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store")))?;
-    let conf = config::default(signer, tmp_dir.path())?;
-    let disco = config::static_seed_discovery(&[]);
-    let peer = radicle_daemon::Peer::new(conf, disco, store, run_config);
-
-    Ok(peer)
+pub struct PeerHandle {
+    pub peer_id: PeerId,
+    pub listen_addrs: Vec<SocketAddr>,
+    pub path: PathBuf,
+    pub owner: LocalIdentity,
+    pub peer: librad::net::peer::Peer<BoxedSigner>,
+    pub events: broadcast::Receiver<PeerEvent>,
+    pub control: peer::Control,
 }
 
-pub async fn build_peer_with_seeds(
-    tmp_dir: &tempfile::TempDir,
-    seeds: Vec<Seed>,
-    run_config: RunConfig,
-) -> Result<Peer<signer::BoxedSigner, discovery::Static>, Box<dyn std::error::Error>> {
-    let key = SecretKey::new();
-    let signer = signer::BoxedSigner::from(key);
-    let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store")))?;
-    let paths = Paths::from_root(tmp_dir.path())?;
-    let conf = config::configure(paths, signer, *config::LOCALHOST_ANY);
-    let disco = config::static_seed_discovery(&seeds);
-    let peer = radicle_daemon::Peer::new(conf, disco, store, run_config);
+pub struct Harness {
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+    rt: tokio::runtime::Runtime,
+    tmp: Vec<tempfile::TempDir>,
+}
 
-    Ok(peer)
+impl Harness {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            tasks: Vec::new(),
+            rt: tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+            tmp: Vec::new(),
+        }
+    }
+
+    pub fn add_peer<S: AsRef<str>>(
+        &mut self,
+        owner_name: S,
+        run_config: RunConfig,
+        seeds: &[Seed],
+    ) -> Result<PeerHandle, anyhow::Error> {
+        let tmp = tempfile::tempdir()?;
+        let key = SecretKey::new();
+        let signer = signer::BoxedSigner::from(key);
+        let store = kv::Store::new(kv::Config::new(tmp.path().join("store")))?;
+        let paths = Paths::from_root(tmp.path())?;
+        let conf = config::configure(paths, signer, *config::LOCALHOST_ANY);
+        let disco = config::static_seed_discovery(seeds);
+        let peer = {
+            let _enter = self.rt.enter();
+            radicle_daemon::Peer::new(conf, disco, store, run_config)
+        };
+
+        let peer_inner = peer.peer.clone();
+        let peer_id = peer_inner.peer_id();
+        let mut events = peer.subscribe();
+        let mut control = peer.control();
+
+        // Must launch now for `control` to work
+        let running = self
+            .rt
+            .spawn(async move { peer.run().await.expect("peer died unexpectedly") });
+
+        // Wait for startup
+        self.rt.block_on(async {
+            started(&mut events).await?;
+            if !seeds.is_empty() {
+                connected(&mut events, 1).await?;
+            }
+
+            Ok::<_, anyhow::Error>(())
+        })?;
+
+        let (listen_addrs, owner) = self.rt.block_on(async {
+            let listen_addrs = control.listen_addrs().await;
+            let owner = init_owner(
+                &peer_inner,
+                Person {
+                    name: owner_name.as_ref().into(),
+                },
+            )
+            .await?;
+
+            Ok::<_, anyhow::Error>((listen_addrs, owner))
+        })?;
+
+        let hodl = PeerHandle {
+            peer_id,
+            listen_addrs,
+            path: tmp.path().to_path_buf(),
+            owner,
+            peer: peer_inner,
+            events,
+            control,
+        };
+
+        self.tasks.push(running);
+        self.tmp.push(tmp);
+
+        Ok(hodl)
+    }
+
+    pub fn enter<F: Future>(&self, fut: F) -> F::Output {
+        self.rt.block_on(fut)
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.tasks.drain(..).for_each(|t| t.abort())
+    }
+}
+
+pub async fn blocking<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f).await.unwrap()
 }
 
 pub fn radicle_project(path: PathBuf) -> project::Create {

--- a/radicle-link-test/src/integration/daemon/common.rs
+++ b/radicle-link-test/src/integration/daemon/common.rs
@@ -1,4 +1,0 @@
-// Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
-//
-// This file is part of radicle-link, distributed under the GPLv3 with Radicle
-// Linking Exception. For full terms see the included LICENSE file.

--- a/radicle-link-test/src/lib.rs
+++ b/radicle-link-test/src/lib.rs
@@ -16,6 +16,7 @@ extern crate nonzero_ext;
 #[macro_use]
 extern crate futures_await_test;
 
+#[macro_use]
 pub mod daemon;
 pub mod git;
 pub mod librad;


### PR DESCRIPTION
In the process, confine setup/teardown boilerplate in a `Harness` struct
similar to the `testnet`, ensuring, amongst other things, that the
temporary directories outlive the runtime.

Also some error context + proper spawn_blocking where advisable.

Signed-off-by: Kim Altintop <kim@eagain.st>