### PR TITLE
net: avoid error log when endpoint is shutting down

### DIFF
--- a/librad/src/net/protocol/io/connections.rs
+++ b/librad/src/net/protocol/io/connections.rs
@@ -32,7 +32,7 @@ use crate::{
 /// # Panics
 ///
 /// Panics if one of the tasks spawned by this function panics.
-#[tracing::instrument(skip(state, ingress), err)]
+#[tracing::instrument(skip(state, ingress))]
 pub(in crate::net::protocol) async fn incoming<S, I>(
     state: State<S>,
     ingress: I,


### PR DESCRIPTION
We log error conditions explicitly, and the auto-error just adds noise
when shutting down gracefully.