### PR TITLE
Point everything at the patched git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,12 @@ members = [
   "seed",
   "std-ext",
 ]
+
+[patch.crates-io.git2]
+git = "https://github.com/radicle-dev/git2-rs.git"
+rev = "5971ca18d73eed39384193899177dfb7ac2d0a05"
+
+[patch.crates-io.libgit2-sys]
+git = "https://github.com/radicle-dev/git2-rs.git"
+rev = "5971ca18d73eed39384193899177dfb7ac2d0a05"
+


### PR DESCRIPTION
The patched git2 can be found in radicle-dev/git2-rs. That repo in turn uses radicle-div/libgit via a submodule in it's `libgit2-sys/libgit` folder.

I've tested running this with a couple of upstreams and a seed built against it and the `rere` problem dissappears.