### PR TITLE
git-helpers: remove executable

### DIFF
--- a/git-helpers/Cargo.toml
+++ b/git-helpers/Cargo.toml
@@ -25,7 +25,3 @@ features = []
 version = "0.12"
 default-features = false
 features = []
-
-[[bin]]
-name = "git-remote-rad"
-path = "src/bin/remote/main.rs"


### PR DESCRIPTION
This is only needed for testing, which moved to the test crate. Cargo
also gets confused due to duplicate output file name.
