### PR TITLE
fix git2-rs patch not getting used

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -204,4 +204,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
     "https://github.com/ZcashFoundation/ed25519-zebra",
+    "https://github.com/radicle-dev/git2-rs",
 ]

--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -80,7 +80,7 @@ version = "0.4"
 features = []
 
 [dependencies.git2]
-version = ">= 0.13.12, 0.13"
+version = "=0.13.18"
 default-features = false
 features = []
 


### PR DESCRIPTION
Cargo patch won't use the patched version if it can satisfy the
dependency in other ways, e.g. via a newer version of the crate. Due to
the wonders of caret dependencies, we thus need to pin git2-rs to the
version used in the patch override.
