### PR TITLE
net: buffer framed reads

### DIFF
--- a/librad/src/net/protocol/interrogation/xor.rs
+++ b/librad/src/net/protocol/interrogation/xor.rs
@@ -16,7 +16,7 @@ use crate::identities::{SomeUrn, Urn};
 pub type MaxElements = U10000;
 // approx. `MaxElements * 1.23`, but not exactly for all choices of
 // `MaxElements`
-const MAX_FINGERPRINTS: u64 = 12_330;
+pub(crate) const MAX_FINGERPRINTS: u64 = 12_330;
 
 #[derive(Debug, Error)]
 #[non_exhaustive]

--- a/librad/src/net/protocol/io/recv/gossip.rs
+++ b/librad/src/net/protocol/io/recv/gossip.rs
@@ -6,7 +6,7 @@
 use std::{iter, net::SocketAddr};
 
 use futures::{
-    io::AsyncRead,
+    io::{AsyncRead, BufReader},
     stream::{self, StreamExt as _},
 };
 use futures_codec::FramedRead;
@@ -37,7 +37,10 @@ pub(in crate::net::protocol) async fn gossip<S, T>(
     S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + Clone + 'static,
     T: RemotePeer + AsyncRead + Unpin,
 {
-    let mut recv = FramedRead::new(stream.into_stream(), codec::Gossip::new());
+    let mut recv = FramedRead::new(
+        BufReader::with_capacity(100, stream.into_stream()),
+        codec::Gossip::new(),
+    );
     let remote_id = recv.remote_peer_id();
 
     while let Some(x) = recv.next().await {


### PR DESCRIPTION
Should avoid excessive decoding attempts in pathological cases (see also #680).
