### PR TITLE
daemon: don’t panic when discovery stream ends

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -115,7 +115,14 @@ impl discovery::Discovery for StreamDiscovery {
                 for seed in seeds {
                     yield seed.into();
                 }
-                self.seeds_receiver.changed().await.unwrap();
+
+                match self.seeds_receiver.changed().await {
+                    Ok(_) => {},
+                    Err(_) => {
+                        log::warn!("Peer discovery stream dropped");
+                        break;
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
When the sender for the seed nodes is dropped we stop emitting values from the discovery stream instead of panicking.

We’re [seeing these panics](https://buildkite.com/monadic/radicle-upstream/builds/9127#cc84739f-dd04-40e4-88e7-10367875b581/6-169) regularly in Upstream CI when the node is reloaded.