### PR TITLE
librad: remove `err` logging from instrument macro

### DIFF
--- a/librad/src/git/identities/any.rs
+++ b/librad/src/git/identities/any.rs
@@ -26,7 +26,7 @@ pub use identities::git::Urn;
 /// Note that the [`Urn::path`] is honoured, and the identity is read from the
 /// tip of the branch it resolves to. If that branch is not found, `None` is
 /// returned.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn get(storage: &Storage, urn: &Urn) -> Result<Option<SomeIdentity>, Error> {
     let branch = Reference::try_from(urn)?;
     tracing::trace!(
@@ -47,7 +47,7 @@ pub fn get(storage: &Storage, urn: &Urn) -> Result<Option<SomeIdentity>, Error> 
 }
 
 /// List all identities found in `storage`.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn list<'a>(
     storage: &'a Storage,
 ) -> Result<impl Iterator<Item = Result<SomeIdentity, Error>> + 'a, Error> {

--- a/librad/src/git/identities/local.rs
+++ b/librad/src/git/identities/local.rs
@@ -113,7 +113,7 @@ impl LocalIdentity {
 /// If the identity could not be found, `None` is returned. If the identity
 /// passes verification, is signed by the [`Signer`] of `storage`, and delegates
 /// to the key of the [`Signer`], the [`LocalIdentity`] is returned in a `Some`.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn load(storage: &Storage, urn: Urn) -> Result<Option<LocalIdentity>, Error> {
     let urn = urn.with_path(reflike!("refs/rad/self"));
     tracing::debug!("loading local id from {}", urn);
@@ -130,7 +130,7 @@ pub fn load(storage: &Storage, urn: Urn) -> Result<Option<LocalIdentity>, Error>
 ///
 /// If no default identity was configured, `None` is returned. Otherwise, the
 /// result is the result of calling [`load`] with the pre-configured [`Urn`].
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn default(storage: &Storage) -> Result<Option<LocalIdentity>, Error> {
     match storage.config()?.user()? {
         Some(urn) => load(storage, urn),

--- a/librad/src/git/identities/person.rs
+++ b/librad/src/git/identities/person.rs
@@ -35,7 +35,7 @@ pub use identities::{
 /// Read a [`Person`] from the tip of the ref [`Urn::path`] points to.
 ///
 /// If the ref is not found, `None` is returned.
-#[tracing::instrument(level = "trace", skip(storage), err)]
+#[tracing::instrument(level = "trace", skip(storage))]
 pub fn get(storage: &Storage, urn: &Urn) -> Result<Option<Person>, Error> {
     match storage.reference(&Reference::try_from(urn)?) {
         Ok(Some(reference)) => {
@@ -59,7 +59,7 @@ pub fn get(storage: &Storage, urn: &Urn) -> Result<Option<Person>, Error> {
 /// not be the same as the tip of the ref [`Urn::path`] points to. That is, this
 /// function cannot be used to assert that the state after an [`update`] is
 /// valid.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn verify(storage: &Storage, urn: &Urn) -> Result<Option<VerifiedPerson>, Error> {
     let branch = Reference::try_from(urn)?;
     tracing::debug!("verifying {} from {}", urn, branch);
@@ -79,7 +79,7 @@ pub fn verify(storage: &Storage, urn: &Urn) -> Result<Option<VerifiedPerson>, Er
 }
 
 /// Get the root [`Urn`] for the given `payload` and set of `delegations`.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn urn<P>(storage: &Storage, payload: P, delegations: delegation::Direct) -> Result<Urn, Error>
 where
     P: Into<PersonPayload> + Debug,
@@ -94,7 +94,7 @@ where
 /// key, such that the newly created [`Person`] is also a valid
 /// [`LocalIdentity`] -- it is, in fact, its own [`LocalIdentity`]. This can be
 /// changed via [`update`].
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn create<P>(
     storage: &Storage,
     payload: P,
@@ -120,7 +120,7 @@ where
 }
 
 /// Update the [`Person`] at `urn`.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn update<L, P, D>(
     storage: &Storage,
     urn: &Urn,
@@ -147,7 +147,7 @@ where
 }
 
 /// Merge and sign the [`Person`] state as seen by `from`.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Person, Error> {
     let ours = get(storage, urn)?.ok_or_else(|| Error::NotFound(urn.clone()))?;
     let theirs = {

--- a/librad/src/git/identities/project.rs
+++ b/librad/src/git/identities/project.rs
@@ -34,7 +34,7 @@ type Namespace = namespace::Namespace<Revision>;
 /// Read a [`Project`] from the tip of the ref [`Urn::path`] points to.
 ///
 /// If the ref is not found, `None` is returned.
-#[tracing::instrument(level = "trace", skip(storage), err)]
+#[tracing::instrument(level = "trace", skip(storage))]
 pub fn get(storage: &Storage, urn: &Urn) -> Result<Option<Project>, Error> {
     match storage.reference(&Reference::try_from(urn)?) {
         Ok(Some(reference)) => {
@@ -58,7 +58,7 @@ pub fn get(storage: &Storage, urn: &Urn) -> Result<Option<Project>, Error> {
 /// not be the same as the tip of the ref [`Urn::path`] points to. That is, this
 /// function cannot be used to assert that the state after an [`update`] is
 /// valid.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn verify(storage: &Storage, urn: &Urn) -> Result<Option<VerifiedProject>, Error> {
     match storage.reference(&Reference::try_from(urn)?) {
         Ok(Some(reference)) => {
@@ -80,7 +80,7 @@ pub fn verify(storage: &Storage, urn: &Urn) -> Result<Option<VerifiedProject>, E
 }
 
 /// Get the root [`Urn`] for the given `payload` and set of `delegations`.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn urn<P>(storage: &Storage, payload: P, delegations: IndirectDelegation) -> Result<Urn, Error>
 where
     P: Into<ProjectPayload> + Debug,
@@ -90,7 +90,7 @@ where
 }
 
 /// Create a new [`Project`].
-#[tracing::instrument(level = "debug", skip(storage, whoami), err)]
+#[tracing::instrument(level = "debug", skip(storage, whoami))]
 pub fn create<P>(
     storage: &Storage,
     whoami: LocalIdentity,
@@ -110,7 +110,7 @@ where
 }
 
 /// Update the [`Project`] at `urn`.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn update<L, P, D>(
     storage: &Storage,
     urn: &Urn,
@@ -137,7 +137,7 @@ where
 }
 
 /// Merge and sign the [`Project`] state as seen by `from`.
-#[tracing::instrument(level = "debug", skip(storage), err)]
+#[tracing::instrument(level = "debug", skip(storage))]
 pub fn merge(storage: &Storage, urn: &Urn, from: PeerId) -> Result<Project, Error> {
     let ours = get(storage, urn)?.ok_or_else(|| Error::NotFound(urn.clone()))?;
     let theirs = {

--- a/librad/src/git/include.rs
+++ b/librad/src/git/include.rs
@@ -87,7 +87,7 @@ impl<Path> Include<Path> {
 
     /// Writes the contents of the [`git2::Config`] of the include file to disk.
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "debug", skip(self), err)]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn save(self) -> Result<(), Error>
     where
         Path: AsRef<path::Path>,

--- a/librad/src/git/local/transport.rs
+++ b/librad/src/git/local/transport.rs
@@ -91,7 +91,7 @@ pub struct Connected {
 
 impl Connected {
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self))]
     pub fn wait(&mut self) -> Result<(), Error> {
         let status = self.process.wait()?;
         if status.success() {
@@ -171,7 +171,7 @@ impl From<Box<dyn CanOpenStorage>> for LocalTransport {
 }
 
 impl LocalTransport {
-    #[tracing::instrument(level = "debug", skip(self, service, stdio), err)]
+    #[tracing::instrument(level = "debug", skip(self, service, stdio))]
     pub fn connect(
         &mut self,
         url: LocalUrl,

--- a/librad/src/git/p2p/server.rs
+++ b/librad/src/git/p2p/server.rs
@@ -97,7 +97,7 @@ where
     W: AsyncWrite + Unpin,
 {
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self))]
     pub async fn run(mut self) -> io::Result<()> {
         let Header { service, repo, .. } = self.header;
         match *service {
@@ -130,7 +130,7 @@ enum UploadPack {
 }
 
 impl UploadPack {
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "debug")]
     fn advertise<N>(repo_path: &Path, namespace: N) -> io::Result<Self>
     where
         N: AsNamespace + Clone + Debug,
@@ -181,7 +181,7 @@ impl UploadPack {
         .map(Self::AdvertiseRefs)
     }
 
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "debug")]
     fn upload_pack(repo_path: &Path) -> io::Result<Self> {
         let mut git = Command::new("git");
         git.arg("-c").arg("uploadpack.allowanysha1inwant=true");
@@ -204,7 +204,7 @@ impl UploadPack {
     }
 
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(skip(self, recv, send), err)]
+    #[tracing::instrument(skip(self, recv, send))]
     async fn run<R, W>(self, mut recv: R, mut send: W) -> io::Result<()>
     where
         R: AsyncRead + Unpin,

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -225,7 +225,7 @@ pub struct Refs {
 
 impl Refs {
     /// Compute the [`Refs`] from the current storage state at [`Urn`].
-    #[tracing::instrument(level = "debug", skip(storage, urn), fields(urn = %urn), err)]
+    #[tracing::instrument(level = "debug", skip(storage, urn), fields(urn = %urn))]
     pub fn compute(storage: &Storage, urn: &Urn) -> Result<Self, stored::Error> {
         let namespace = Namespace::from(urn);
         let namespace_prefix = format!("refs/namespaces/{}/", namespace);
@@ -292,7 +292,7 @@ impl Refs {
     ///
     /// If the blob where the signed [`Refs`] are expected to be stored is not
     /// found, `None` is returned.
-    #[tracing::instrument(skip(storage, urn), fields(urn = %urn), err)]
+    #[tracing::instrument(skip(storage, urn), fields(urn = %urn))]
     pub fn load<P>(storage: &Storage, urn: &Urn, peer: P) -> Result<Option<Self>, stored::Error>
     where
         P: Into<Option<PeerId>> + Debug,
@@ -322,7 +322,7 @@ impl Refs {
     /// If the result of [`Self::compute`] is the same as the alread-stored
     /// [`Refs`], no commit is made and `None` is returned. Otherwise, the
     /// new and persisted [`Refs`] are returned in a `Some`.
-    #[tracing::instrument(skip(storage, urn), fields(urn = %urn), err)]
+    #[tracing::instrument(skip(storage, urn), fields(urn = %urn))]
     pub fn update(storage: &Storage, urn: &Urn) -> Result<Option<Self>, stored::Error> {
         let branch = Reference::rad_signed_refs(Namespace::from(urn), None);
         tracing::debug!("updating signed refs for {}", branch);

--- a/librad/src/git/replication.rs
+++ b/librad/src/git/replication.rs
@@ -168,7 +168,7 @@ enum ModeInternal {
 /// set, which is enforced by the
 /// [`crate::git::local::transport::LocalTransport`].
 #[allow(clippy::unit_arg)]
-#[tracing::instrument(skip(storage, fetcher, whoami), err)]
+#[tracing::instrument(skip(storage, fetcher, whoami))]
 pub fn replicate<'a, F>(
     storage: &'a Storage,
     mut fetcher: F,
@@ -337,7 +337,7 @@ where
 /// If we are fetching updates then we only fetch the relevant remotes that we
 /// already know about.
 #[allow(clippy::unit_arg)]
-#[tracing::instrument(skip(storage, fetcher, urn), fields(urn = %urn), err)]
+#[tracing::instrument(skip(storage, fetcher, urn), fields(urn = %urn))]
 fn determine_mode<F>(
     storage: &Storage,
     fetcher: &mut F,
@@ -416,7 +416,7 @@ fn unsafe_into_urn(reference: Reference<git_ext::RefLike>) -> Urn {
 ///
 /// No-op if the ref already exists. Returns the [`ext::Oid`] the ref points to
 /// after the operation.
-#[tracing::instrument(level = "trace", skip(storage, urn), fields(urn = %urn), err)]
+#[tracing::instrument(level = "trace", skip(storage, urn), fields(urn = %urn))]
 fn ensure_rad_id(storage: &Storage, urn: &Urn, tip: ext::Oid) -> Result<ext::Oid, Error> {
     let id_ref = identities::common::IdRef::from(urn);
     id_ref
@@ -510,7 +510,7 @@ mod person {
     ///   * Ensuring we have a top-level `rad/id` that points to the latest
     ///     version
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage), err)]
+    #[tracing::instrument(level = "trace", skip(storage))]
     pub fn ensure_setup(
         storage: &Storage,
         rad_id: &Urn,
@@ -547,7 +547,7 @@ mod person {
     /// Adopt the `rad/id` that has the most up-to-date commit from the set of
     /// `Person` delegates.
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage), err)]
+    #[tracing::instrument(level = "trace", skip(storage))]
     pub fn adopt_latest(
         storage: &Storage,
         urn: &Urn,
@@ -620,7 +620,7 @@ mod project {
     ///   * Ensuring we have a top-level `rad/id` that points to the latest
     ///     version
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage, fetcher), err)]
+    #[tracing::instrument(level = "trace", skip(storage, fetcher))]
     pub fn ensure_setup<F>(
         storage: &Storage,
         fetcher: &mut F,
@@ -714,7 +714,7 @@ mod project {
     /// For each delegate in `remotes/<remote_peer>/rad/ids/*` get the view for
     /// that delegate that _should_ be local the `storage` after a fetch.
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage), err)]
+    #[tracing::instrument(level = "trace", skip(storage))]
     pub fn delegate_views(
         storage: &Storage,
         proj: Project,
@@ -766,7 +766,7 @@ mod project {
 
     /// Persist a delegate identity in our storage.
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage), err)]
+    #[tracing::instrument(level = "trace", skip(storage))]
     pub fn adopt_delegate_person(
         storage: &Storage,
         peer: PeerId,
@@ -796,7 +796,7 @@ mod project {
 
     /// Track all direct delegations of a `Project`.
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage), err)]
+    #[tracing::instrument(level = "trace", skip(storage))]
     fn track_direct(storage: &Storage, proj: &VerifiedProject) -> Result<(), Error> {
         let local_peer_id = storage.peer_id();
 
@@ -815,7 +815,7 @@ mod project {
     /// Adopt the `rad/id` that has the most up-to-date commit from the set of
     /// `Project` delegates.
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(level = "trace", skip(storage), err)]
+    #[tracing::instrument(level = "trace", skip(storage))]
     pub fn adopt_latest(
         storage: &Storage,
         urn: &Urn,

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -151,12 +151,12 @@ impl Storage {
         &self.backend.path()
     }
 
-    #[tracing::instrument(level = "debug", skip(self), err)]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn has_urn(&self, urn: &Urn) -> Result<bool, Error> {
         self.has_ref(&Reference::try_from(urn)?)
     }
 
-    #[tracing::instrument(level = "debug", skip(self), err)]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn has_ref<'a>(&self, reference: &'a Reference<One>) -> Result<bool, Error> {
         self.backend
             .find_reference(RefLike::from(reference).as_str())
@@ -173,7 +173,7 @@ impl Storage {
     /// `rad/id` if not provided)
     /// 3. The tip SHA was not in the history of the commit
     /// 4. The `oid` was the [`zero`][`git2::Oid::zero`] SHA.
-    #[tracing::instrument(level = "debug", skip(self, urn), fields(urn = %urn), err)]
+    #[tracing::instrument(level = "debug", skip(self, urn), fields(urn = %urn))]
     pub fn has_commit<Oid>(&self, urn: &Urn, oid: Oid) -> Result<bool, Error>
     where
         Oid: AsRef<git2::Oid> + Debug,
@@ -206,7 +206,7 @@ impl Storage {
     /// `rad/id` if not provided)
     /// 3. The SHA of the tag was not the same as the resolved reference
     /// 4. The `oid` was the [`zero`][`git2::Oid::zero`] SHA.
-    #[tracing::instrument(level = "debug", skip(self, urn), fields(urn = %urn), err)]
+    #[tracing::instrument(level = "debug", skip(self, urn), fields(urn = %urn))]
     pub fn has_tag<Oid>(&self, urn: &Urn, oid: Oid) -> Result<bool, Error>
     where
         Oid: AsRef<git2::Oid> + Debug,
@@ -223,7 +223,7 @@ impl Storage {
         Ok(tip.map(|tip| tip.id() == oid).unwrap_or(false))
     }
 
-    #[tracing::instrument(level = "debug", skip(self), err)]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn has_object<Oid>(&self, oid: Oid) -> Result<bool, Error>
     where
         Oid: AsRef<git2::Oid> + Debug,
@@ -238,7 +238,7 @@ impl Storage {
         Ok(self.backend.odb()?.exists(*oid))
     }
 
-    #[tracing::instrument(level = "debug", skip(self), err)]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn find_object<Oid>(&self, oid: Oid) -> Result<Option<git2::Object>, Error>
     where
         Oid: AsRef<git2::Oid> + Debug,
@@ -254,7 +254,7 @@ impl Storage {
             .or_matches(is_not_found_err, || Ok(None))
     }
 
-    #[tracing::instrument(level = "trace", skip(self), err)]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn tip(&self, urn: &Urn, kind: git2::ObjectType) -> Result<Option<git2::Object>, Error> {
         let reference = self
             .backend
@@ -268,7 +268,7 @@ impl Storage {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self), err)]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn reference<'a>(
         &'a self,
         reference: &Reference<One>,
@@ -279,7 +279,7 @@ impl Storage {
             .or_matches(is_not_found_err, || Ok(None))
     }
 
-    #[tracing::instrument(level = "trace", skip(self), err)]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn references<'a>(
         &'a self,
         reference: &Reference<Many>,
@@ -287,7 +287,7 @@ impl Storage {
         self.references_glob(glob::RefspecMatcher::from(RefspecPattern::from(reference)))
     }
 
-    #[tracing::instrument(level = "trace", skip(self), err)]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn reference_names<'a>(
         &'a self,
         reference: &Reference<Many>,
@@ -295,7 +295,7 @@ impl Storage {
         self.reference_names_glob(glob::RefspecMatcher::from(RefspecPattern::from(reference)))
     }
 
-    #[tracing::instrument(level = "trace", skip(self), err)]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn references_glob<'a, G: 'a>(
         &'a self,
         glob: G,
@@ -316,7 +316,7 @@ impl Storage {
             }))
     }
 
-    #[tracing::instrument(level = "trace", skip(self), err)]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn reference_names_glob<'a, G: 'a>(
         &'a self,
         glob: G,
@@ -335,7 +335,7 @@ impl Storage {
         }))
     }
 
-    #[tracing::instrument(level = "trace", skip(self), err)]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn blob<'a>(
         &'a self,
         reference: &'a Reference<One>,

--- a/librad/src/git/storage/fetcher.rs
+++ b/librad/src/git/storage/fetcher.rs
@@ -464,7 +464,7 @@ mod imp {
             &self.info
         }
 
-        #[tracing::instrument(skip(self), err)]
+        #[tracing::instrument(skip(self))]
         pub fn fetch(
             &mut self,
             fetchspecs: Fetchspecs<PeerId, Revision>,

--- a/librad/src/git/tracking.rs
+++ b/librad/src/git/tracking.rs
@@ -42,7 +42,7 @@ pub enum Error {
 /// # Errors
 ///
 /// Attempting to track oneself (ie. [`Storage::peer_id`]) is an error.
-#[tracing::instrument(skip(storage), err)]
+#[tracing::instrument(skip(storage))]
 pub fn track(storage: &Storage, urn: &Urn, peer: PeerId) -> Result<bool, Error> {
     let local_peer = storage.peer_id();
 
@@ -86,7 +86,7 @@ pub fn track(storage: &Storage, urn: &Urn, peer: PeerId) -> Result<bool, Error> 
 /// (yet) atomic, this may fail, leaving "dangling" refs in the storage. It is
 /// safe to call this function repeatedly, so as to ensure all remote tracking
 /// branches have been pruned.
-#[tracing::instrument(skip(storage), err)]
+#[tracing::instrument(skip(storage))]
 pub fn untrack(storage: &Storage, urn: &Urn, peer: PeerId) -> Result<bool, Error> {
     let remote_name = tracking_remote_name(urn, &peer);
     let was_removed = storage
@@ -112,7 +112,7 @@ pub fn untrack(storage: &Storage, urn: &Urn, peer: PeerId) -> Result<bool, Error
 }
 
 /// Determine if `peer` is tracked in the context of `urn`.
-#[tracing::instrument(level = "trace", skip(storage), err)]
+#[tracing::instrument(level = "trace", skip(storage))]
 pub fn is_tracked(storage: &Storage, urn: &Urn, peer: PeerId) -> Result<bool, Error> {
     storage
         .as_raw()

--- a/librad/src/git/types/remote.rs
+++ b/librad/src/git/types/remote.rs
@@ -121,7 +121,7 @@ impl<Url> Remote<Url> {
     /// Note that this means that _other_ configuration keys are left
     /// untouched, if present.
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(skip(self, repo), fields(name = self.name.as_str()), err)]
+    #[tracing::instrument(skip(self, repo), fields(name = self.name.as_str()))]
     pub fn save(&mut self, repo: &git2::Repository) -> Result<(), git2::Error>
     where
         Url: ToString,
@@ -160,7 +160,7 @@ impl<Url> Remote<Url> {
 
     /// Find a persisted remote by name.
     #[allow(clippy::unit_arg)]
-    #[tracing::instrument(skip(repo), err)]
+    #[tracing::instrument(skip(repo))]
     pub fn find(repo: &git2::Repository, name: RefLike) -> Result<Option<Self>, FindError>
     where
         Url: FromStr,
@@ -234,7 +234,7 @@ pub enum LocalFetchspec {
 
 impl Remote<LocalUrl> {
     /// Get the remote repository's reference advertisement list.
-    #[tracing::instrument(skip(self, repo, open_storage), err)]
+    #[tracing::instrument(skip(self, repo, open_storage))]
     pub fn remote_heads<F>(
         &mut self,
         open_storage: F,
@@ -265,7 +265,7 @@ impl Remote<LocalUrl> {
     }
 
     /// Push the provided [`LocalPushspec`].
-    #[tracing::instrument(skip(self, repo, open_storage), err)]
+    #[tracing::instrument(skip(self, repo, open_storage))]
     pub fn push<F>(
         &mut self,
         open_storage: F,
@@ -367,7 +367,7 @@ impl Remote<LocalUrl> {
         })
     }
 
-    #[tracing::instrument(skip(self, repo, open_storage), err)]
+    #[tracing::instrument(skip(self, repo, open_storage))]
     pub fn fetch<F>(
         &mut self,
         open_storage: F,

--- a/librad/src/identities/git/load.rs
+++ b/librad/src/identities/git/load.rs
@@ -256,7 +256,7 @@ impl<'a> TryFrom<ByOid<'a>> for Project {
 
 type InlinedPerson = generic::Identity<Doc<PersonPayload, PersonDelegations>, Revision, ContentId>;
 
-#[tracing::instrument(level = "debug", skip(repo, tree), err)]
+#[tracing::instrument(level = "debug", skip(repo, tree))]
 fn resolve_inlined_person(
     repo: &git2::Repository,
     tree: &git2::Tree,

--- a/librad/src/net/protocol/broadcast.rs
+++ b/librad/src/net/protocol/broadcast.rs
@@ -56,7 +56,7 @@ where
     },
 }
 
-#[tracing::instrument(skip(membership, storage, info), err)]
+#[tracing::instrument(skip(membership, storage, info))]
 pub(super) async fn apply<M, S, F, A, P>(
     membership: &M,
     storage: &S,

--- a/librad/src/net/protocol/io/graft.rs
+++ b/librad/src/net/protocol/io/graft.rs
@@ -69,7 +69,7 @@ pub mod config {
 /// recursively. Using this function thus requires to inspect the git header for
 /// the presence of a nonce (or else skip the rere), and to keep track of recent
 /// nonces in case of nonce re-use.
-#[tracing::instrument(level = "debug", skip(spawner, storage, config, addr_hints), err)]
+#[tracing::instrument(level = "debug", skip(spawner, storage, config, addr_hints))]
 pub async fn rere<S, Addrs>(
     spawner: &executor::Spawner,
     storage: &S,

--- a/test/src/git.rs
+++ b/test/src/git.rs
@@ -5,7 +5,7 @@
 
 use librad::git_ext::reference::RefLike;
 
-#[tracing::instrument(skip(repo), err)]
+#[tracing::instrument(skip(repo))]
 pub fn create_commit(
     repo: &git2::Repository,
     on_branch: RefLike,


### PR DESCRIPTION
The `err` parameter for the `tracing::instrument` macro logs at error
level unconditionally when the `Result`-returning function returns, err,
`Err`. This was once useful for debugging, but nowadays adds noise: it
is often hard to tell where the log line comes from, it's not always an
error (ie. it might be handled), or multiple log lines are emitted for
the same error condition.

Thus, remove it everywhere.