### PR TITLE
io: graceful shutdown

### DIFF
--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -196,10 +196,12 @@ where
                         addrs_tx
                             .send(bound.listen_addrs())
                             .expect("subroutines is gone");
-                        if let Err(e) = net::protocol::accept(bound, disco.clone().discover()).await
-                        {
+                        let (shutdown, run) =
+                            net::protocol::accept(bound, disco.clone().discover());
+                        if let Err(e) = run.await {
                             log::error!("accept error: {}", e);
                         }
+                        shutdown.await
                     },
                     Err(e) => {
                         log::error!("bound error: {}", e);

--- a/librad/src/net/protocol/io/connections.rs
+++ b/librad/src/net/protocol/io/connections.rs
@@ -3,12 +3,12 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::{net::SocketAddr, panic};
+use std::net::SocketAddr;
 
 use either::Either;
 use futures::{
     future::{self, TryFutureExt as _},
-    stream::{FuturesUnordered, Stream, StreamExt as _},
+    stream::{Stream, StreamExt as _},
 };
 use indexmap::IndexSet;
 
@@ -48,45 +48,27 @@ where
     let listen_addrs = state.endpoint.listen_addrs();
     state.phone.emit(event::Endpoint::Up { listen_addrs });
 
-    let mut tasks = FuturesUnordered::new();
     let ingress = ingress.fuse();
     futures::pin_mut!(ingress);
-    loop {
-        futures::select! {
-            conn = ingress.next() => match conn {
-                Some(conn) => match conn {
-                    Ok((_, streams)) => {
-                        tasks.push(state.spawner.spawn(streams::incoming(state.clone(), streams)));
-                    },
-                    Err(err)=> match err {
-                        Connection(_) | PeerId(_) | RemoteIdUnavailable | SelfConnect => {
-                            tracing::warn!(err = %err, "ingress connections error");
-                        },
-                        Connect(_) | Endpoint(_) | Io(_) | Shutdown | Signer(_) | Task(_) => {
-                            tracing::error!(err = %err, "ingress connections error");
-                            break;
-                        },
-                    },
-                },
-                None => {
-                    break;
-                }
+    while let Some(conn) = ingress.next().await {
+        match conn {
+            Ok((_, streams)) => {
+                state
+                    .spawner
+                    .spawn(streams::incoming(state.clone(), streams))
+                    .detach();
             },
-
-            task = tasks.next() => {
-                if let Some(Err(e)) = task {
-                    drop(e.into_cancelled())
-                }
-            }
+            Err(err) => match err {
+                Connection(_) | PeerId(_) | RemoteIdUnavailable | SelfConnect => {
+                    tracing::warn!(err = %err, "ingress connections error");
+                },
+                Connect(_) | Endpoint(_) | Io(_) | Shutdown | Signer(_) | Task(_) => {
+                    tracing::error!(err = %err, "ingress connections error");
+                    break;
+                },
+            },
         }
     }
-    tracing::debug!("ingress connections done, draining tasks");
-    while let Some(res) = tasks.next().await {
-        if let Err(e) = res {
-            drop(e.into_cancelled())
-        }
-    }
-    tracing::debug!("tasks drained");
 
     Err(quic::Error::Shutdown)
 }

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -199,9 +199,11 @@ impl Node {
                 loop {
                     match peer.bind().await {
                         Ok(bound) => {
-                            if let Err(e) = bound.accept(disco.clone().discover()).await {
+                            let (shutdown, run) = bound.accept(disco.clone().discover());
+                            if let Err(e) = run.await {
                                 tracing::error!(err = ?e, "Accept error")
                             }
+                            shutdown.await
                         },
                         Err(e) => {
                             tracing::error!(err = ?e, "Bind error");


### PR DESCRIPTION
Latest installment of the cancellation saga: the shutdown sequence for
an endpoint needs to be carefully grafted in order to not stall blocking
tasks (which call back into the async context), and it is advisable to
call `wait_idle` on the endpoint. In turn, our aggressive cancellation
policy needs to be loosened a bit to not immediately abort everything,
but drain outstanding tasks. Iow, if tests hand on shutdown, it is now a
programmer error.

Arguably, the return type of `accept` is now pretty weird (one future
for shutdown, and another one to actually drive the accept loop). Not
sure if there is a better formulation, as we are also constrained by
opaque types.

Note that the `menage` tests are still failing, which appears to depend
on whether the force-flag-honouring libgit2 is picked up or not.