### PR TITLE
git-helpers: make remote helper config fields public

### DIFF
--- a/git-helpers/src/remote_helper.rs
+++ b/git-helpers/src/remote_helper.rs
@@ -27,7 +27,7 @@ use radicle_keystore::{
 
 pub struct Config {
     /// Signer for radicle artifacts created by pushes.
-    signer: Option<BoxedSigner>,
+    pub signer: Option<BoxedSigner>,
 }
 
 impl Default for Config {


### PR DESCRIPTION
Without a public field the config struct cannot be used to configure the remote helper.