### PR TITLE
storage: introduce read-only type

### DIFF
--- a/daemon/src/peer/announcement.rs
+++ b/daemon/src/peer/announcement.rs
@@ -75,12 +75,7 @@ async fn build<S>(peer: &Peer<S>) -> Result<Updates, Error>
 where
     S: Clone + Signer,
 {
-    let identities = match state::list_identities(peer).await {
-        // TODO(xla): We need to avoid the case where there is no owner yet for the peer api, there
-        // should be machinery to kick off these routines only if our app state is ready for it.
-        Err(state::Error::Storage(librad::git::storage::Error::Config(_))) => Vec::new(),
-        result => result?,
-    };
+    let identities = state::list_identities(peer).await?;
     let mut updates: Updates = HashSet::new();
     for identity in identities {
         let urn = match identity {

--- a/daemon/src/state.rs
+++ b/daemon/src/state.rs
@@ -26,7 +26,10 @@ use librad::{
         local::{transport, url::LocalUrl},
         refs::Refs,
         replication::{self, ReplicateResult},
-        storage::fetcher::{self, BuildFetcher},
+        storage::{
+            fetcher::{self, BuildFetcher},
+            ReadOnlyStorage as _,
+        },
         tracking,
         types::{Namespace, Reference, Single},
         Urn,

--- a/librad/src/git/identities/any.rs
+++ b/librad/src/git/identities/any.rs
@@ -10,7 +10,7 @@ use itertools::Itertools as _;
 
 use super::{
     super::{
-        storage::{self, glob},
+        storage::{self, glob, ReadOnlyStorage as _},
         types::Reference,
     },
     error::Error,

--- a/librad/src/git/identities/any.rs
+++ b/librad/src/git/identities/any.rs
@@ -102,6 +102,9 @@ where
     Xor::try_from_iter(list_urns(storage)?.map_ok(SomeUrn::from))
 }
 
-fn identities(storage: &storage::ReadOnly) -> Identities<!> {
-    storage.identities()
+fn identities<S>(storage: &S) -> Identities<!>
+where
+    S: AsRef<storage::ReadOnly>,
+{
+    storage.as_ref().identities()
 }

--- a/librad/src/git/identities/common.rs
+++ b/librad/src/git/identities/common.rs
@@ -3,11 +3,11 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use git_ext::is_exists_err;
+use git_ext::{self as ext, is_exists_err};
 use std_ext::result::ResultExt as _;
 
 use super::super::{
-    storage::Storage,
+    storage::{self, ReadOnlyStorage as _, Storage},
     types::{Force, Namespace, Reference},
 };
 use crate::identities::git::Urn;
@@ -22,8 +22,13 @@ impl<'a> From<&'a Urn> for IdRef<'a> {
 }
 
 impl<'a> IdRef<'a> {
-    pub fn oid(&self, storage: &Storage) -> Result<git2::Oid, git2::Error> {
-        Reference::rad_id(Namespace::from(self.0)).oid(storage.as_raw())
+    pub fn oid<S>(&self, storage: &S) -> Result<ext::Oid, storage::Error>
+    where
+        S: AsRef<storage::ReadOnly>,
+    {
+        storage
+            .as_ref()
+            .reference_oid(&Reference::rad_id(Namespace::from(self.0)))
     }
 
     pub fn create(

--- a/librad/src/git/identities/person.rs
+++ b/librad/src/git/identities/person.rs
@@ -93,7 +93,8 @@ where
     S: AsRef<storage::ReadOnly>,
     P: Into<PersonPayload> + Debug,
 {
-    let (_, revision) = identities(storage.as_ref()).base(payload.into(), delegations)?;
+    let storage = storage.as_ref();
+    let (_, revision) = identities(storage).base(payload.into(), delegations)?;
     Ok(Urn::new(revision))
 }
 

--- a/librad/src/git/identities/person.rs
+++ b/librad/src/git/identities/person.rs
@@ -10,7 +10,7 @@ use radicle_git_ext::{is_not_found_err, OneLevel};
 use super::{
     super::{
         refs::Refs,
-        storage::{self, Storage},
+        storage::{self, ReadOnlyStorage as _, Storage},
         types::Reference,
     },
     common,

--- a/librad/src/git/identities/project.rs
+++ b/librad/src/git/identities/project.rs
@@ -72,8 +72,8 @@ where
         Ok(Some(reference)) => {
             let tip = reference.peel_to_commit()?.id();
             let lookup = |urn| {
-                let refname = Reference::rad_id(Namespace::from(urn)).to_string();
-                storage.as_raw().refname_to_id(&refname)
+                let refname = Reference::rad_id(Namespace::from(urn));
+                storage.reference_oid(&refname).map(|oid| oid.into())
             };
             identities(storage)
                 .verify(tip, lookup)

--- a/librad/src/git/identities/project.rs
+++ b/librad/src/git/identities/project.rs
@@ -11,7 +11,7 @@ use git_ext::{is_not_found_err, OneLevel};
 use super::{
     super::{
         refs::Refs as Sigrefs,
-        storage::{self, Storage},
+        storage::{self, ReadOnlyStorage as _, Storage},
         types::{namespace, reference, Force, Reference, Single, SymbolicRef},
     },
     common,

--- a/librad/src/git/identities/relations.rs
+++ b/librad/src/git/identities/relations.rs
@@ -11,7 +11,7 @@ use crate::{
     git::{
         identities,
         refs::{stored, Refs},
-        storage::{self, Storage},
+        storage::{self, ReadOnlyStorage as _, Storage},
         tracking,
         types::{Namespace, Reference},
         Urn,

--- a/librad/src/git/local/transport.rs
+++ b/librad/src/git/local/transport.rs
@@ -19,7 +19,7 @@ use super::{
     super::{
         identities,
         refs::{self, Refs},
-        storage::{self, glob, Storage},
+        storage::{self, glob, ReadOnlyStorage as _, Storage},
         types::Namespace,
         Urn,
     },

--- a/librad/src/git/local/transport.rs
+++ b/librad/src/git/local/transport.rs
@@ -183,7 +183,7 @@ impl LocalTransport {
         let storage = _box.as_ref();
 
         let urn = url.into();
-        guard_has_urn(storage, &urn)?;
+        guard_has_urn(storage.as_ref(), &urn)?;
 
         let mut git = Command::new("git");
         git.envs(::std::env::vars().filter(|(key, _)| key.starts_with("GIT_TRACE")))
@@ -201,7 +201,7 @@ impl LocalTransport {
         match service {
             Service::UploadPack | Service::UploadPackLs => {
                 // Fetching remotes is ok, pushing is not
-                visible_remotes(storage, &urn)?.for_each(|remote_ref| {
+                visible_remotes(storage.as_ref(), &urn)?.for_each(|remote_ref| {
                     git.arg("-c")
                         .arg(format!("uploadpack.hiderefs=!^{}", remote_ref));
                 });
@@ -271,7 +271,7 @@ impl LocalTransport {
 
 fn guard_has_urn<S>(storage: S, urn: &Urn) -> Result<(), Error>
 where
-    S: AsRef<Storage>,
+    S: AsRef<storage::ReadOnly>,
 {
     let have = storage.as_ref().has_urn(urn).map_err(Error::from)?;
     if !have {
@@ -283,7 +283,7 @@ where
 
 fn visible_remotes<S>(storage: S, urn: &Urn) -> Result<impl Iterator<Item = ext::RefLike>, Error>
 where
-    S: AsRef<Storage>,
+    S: AsRef<storage::ReadOnly>,
 {
     let remotes = storage
         .as_ref()

--- a/librad/src/git/refs.rs
+++ b/librad/src/git/refs.rs
@@ -23,7 +23,7 @@ use serde::{
 use thiserror::Error;
 
 use super::{
-    storage::{self, Storage},
+    storage::{self, ReadOnlyStorage, Storage},
     tracking,
     types::{Namespace, Reference, RefsCategory},
 };

--- a/librad/src/git/replication.rs
+++ b/librad/src/git/replication.rs
@@ -18,7 +18,7 @@ use super::{
     fetch,
     identities::{self, local::LocalIdentity},
     refs::{self, Refs},
-    storage::{self, Storage},
+    storage::{self, ReadOnlyStorage, Storage},
     tracking,
     types::{reference, Force, Namespace, Reference},
 };

--- a/librad/src/git/replication.rs
+++ b/librad/src/git/replication.rs
@@ -423,10 +423,7 @@ fn ensure_rad_id(storage: &Storage, urn: &Urn, tip: ext::Oid) -> Result<ext::Oid
         .create(storage, tip)
         .map_err(|e| Error::Store(e.into()))?;
 
-    id_ref
-        .oid(storage)
-        .map(Into::into)
-        .map_err(|e| Error::Store(e.into()))
+    id_ref.oid(storage).map(Into::into).map_err(Error::Store)
 }
 
 /// Untrack the list of `PeerId`s, which also has the side-effect of removing

--- a/librad/src/git/storage.rs
+++ b/librad/src/git/storage.rs
@@ -4,20 +4,12 @@
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle
 // Linking Exception. For full terms see the included LICENSE file.
 
-use std::{
-    convert::TryFrom,
-    fmt::Debug,
-    marker::PhantomData,
-    path::{Path, PathBuf},
-};
+use std::{convert::TryFrom, fmt::Debug, marker::PhantomData, path::PathBuf};
 
-use git_ext::{self as ext, blob, is_not_found_err, RefLike, RefspecPattern};
-use std_ext::result::ResultExt as _;
+use git_ext::is_not_found_err;
 use thiserror::Error;
 
-use super::types::{reference, Many, One, Reference};
 use crate::{
-    identities::git::{Identities, Urn},
     paths::Paths,
     peer::PeerId,
     signer::{BoxedSigner, Signer, SomeSigner},
@@ -27,37 +19,32 @@ pub mod config;
 pub mod fetcher;
 pub mod glob;
 pub mod pool;
+pub mod read;
 pub mod watch;
 
 pub use config::Config;
 pub use fetcher::{Fetcher, Fetchers};
 pub use glob::Pattern;
 pub use pool::{Pool, PoolError, Pooled, PooledRef};
+pub use read::{Error, Storage as ReadOnly};
 pub use watch::{NamespaceEvent, Watcher};
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum Error {
-    #[error("signer key does not match the key used at initialisation")]
-    SignerKeyMismatch,
-
-    #[error("malformed URN")]
-    Ref(#[from] reference::FromUrnError),
-
+pub enum OpenError {
     #[error(transparent)]
     Config(#[from] config::Error),
 
     #[error(transparent)]
-    Blob(#[from] ext::blob::Error),
-
-    #[error(transparent)]
     Git(#[from] git2::Error),
+
+    #[error("signer key does not match the key used at initialisation")]
+    SignerKeyMismatch,
 }
 
 /// Low-level operations on the link "monorepo".
 pub struct Storage {
-    backend: git2::Repository,
-    peer_id: PeerId,
+    inner: read::Storage,
     signer: BoxedSigner,
     fetchers: Fetchers,
 }
@@ -76,7 +63,7 @@ impl Storage {
     /// the same way two `git` processes can access the same repository.
     /// However, if you need multiple [`Storage`]s to be shared between
     /// threads, use a [`Pool`] instead.
-    pub fn open<S>(paths: &Paths, signer: S) -> Result<Self, Error>
+    pub fn open<S>(paths: &Paths, signer: S) -> Result<Self, OpenError>
     where
         S: Signer + Clone,
         S::Error: std::error::Error + Send + Sync + 'static,
@@ -84,7 +71,7 @@ impl Storage {
         Self::with_fetchers(paths, signer, Default::default())
     }
 
-    pub fn with_fetchers<S>(paths: &Paths, signer: S, fetchers: Fetchers) -> Result<Self, Error>
+    pub fn with_fetchers<S>(paths: &Paths, signer: S, fetchers: Fetchers) -> Result<Self, OpenError>
     where
         S: Signer + Clone,
         S::Error: std::error::Error + Send + Sync + 'static,
@@ -110,12 +97,11 @@ impl Storage {
         let peer_id = Config::try_from(&backend)?.peer_id()?;
 
         if peer_id != PeerId::from_signer(&signer) {
-            return Err(Error::SignerKeyMismatch);
+            return Err(OpenError::SignerKeyMismatch);
         }
 
         Ok(Self {
-            backend,
-            peer_id,
+            inner: read::Storage { backend, peer_id },
             signer: BoxedSigner::from(SomeSigner { signer }),
             fetchers,
         })
@@ -130,7 +116,7 @@ impl Storage {
     /// error is propagated promptly -- e.g. when you use a [`Pool`],
     /// initialisation would happen lazily, which makes it easy to miss
     /// errors.
-    pub fn init<S>(paths: &Paths, signer: S) -> Result<(), Error>
+    pub fn init<S>(paths: &Paths, signer: S) -> Result<(), OpenError>
     where
         S: Signer + Clone,
         S::Error: std::error::Error + Send + Sync + 'static,
@@ -140,7 +126,7 @@ impl Storage {
     }
 
     #[deprecated = "use `open` instead"]
-    pub fn open_or_init<S>(paths: &Paths, signer: S) -> Result<Self, Error>
+    pub fn open_or_init<S>(paths: &Paths, signer: S) -> Result<Self, OpenError>
     where
         S: Signer + Clone,
         S::Error: std::error::Error + Send + Sync + 'static,
@@ -148,211 +134,28 @@ impl Storage {
         Self::open(paths, signer)
     }
 
+    pub fn from_read_only<S>(ro: ReadOnly, signer: S, fetchers: Fetchers) -> Result<Self, OpenError>
+    where
+        S: Signer + Clone,
+        S::Error: std::error::Error + Send + Sync + 'static,
+    {
+        if ro.peer_id != PeerId::from_signer(&signer) {
+            return Err(OpenError::SignerKeyMismatch);
+        }
+
+        Ok(Self {
+            inner: ro,
+            signer: BoxedSigner::from(SomeSigner { signer }),
+            fetchers,
+        })
+    }
+
+    pub fn read_only(&self) -> &ReadOnly {
+        &self.inner
+    }
+
     pub fn peer_id(&self) -> &PeerId {
-        &self.peer_id
-    }
-
-    pub fn path(&self) -> &Path {
-        &self.backend.path()
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub fn has_urn(&self, urn: &Urn) -> Result<bool, Error> {
-        self.has_ref(&Reference::try_from(urn)?)
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub fn has_ref<'a>(&self, reference: &'a Reference<One>) -> Result<bool, Error> {
-        self.backend
-            .find_reference(RefLike::from(reference).as_str())
-            .and(Ok(true))
-            .or_matches(is_not_found_err, || Ok(false))
-    }
-
-    /// Check the existence of `oid` as a **commit**.
-    ///
-    /// The result will be `false` if:
-    ///
-    /// 1. No commit could be found for `oid`
-    /// 2. The reference path for the `urn` could not be found (it defaults to
-    /// `rad/id` if not provided)
-    /// 3. The tip SHA was not in the history of the commit
-    /// 4. The `oid` was the [`zero`][`git2::Oid::zero`] SHA.
-    #[tracing::instrument(level = "debug", skip(self, urn), fields(urn = %urn))]
-    pub fn has_commit<Oid>(&self, urn: &Urn, oid: Oid) -> Result<bool, Error>
-    where
-        Oid: AsRef<git2::Oid> + Debug,
-    {
-        let (oid, kind) = match self.find_object(oid)? {
-            None => return Ok(false),
-            Some(object) => match object.kind() {
-                Some(git2::ObjectType::Commit) => (object.id(), git2::ObjectType::Commit),
-                _ => return Ok(false),
-            },
-        };
-
-        let tip = self.tip(urn, kind)?;
-        Ok(tip
-            .map(|tip| {
-                Ok::<_, git2::Error>(
-                    tip.id() == oid || self.backend.graph_descendant_of(tip.id(), oid)?,
-                )
-            })
-            .transpose()?
-            .unwrap_or(false))
-    }
-
-    /// Check the existence of `oid` as a **tag**.
-    ///
-    /// The result will be `false` if:
-    ///
-    /// 1. No tag could be found for `oid`
-    /// 2. The reference path for the `urn` could not be found (it defaults to
-    /// `rad/id` if not provided)
-    /// 3. The SHA of the tag was not the same as the resolved reference
-    /// 4. The `oid` was the [`zero`][`git2::Oid::zero`] SHA.
-    #[tracing::instrument(level = "debug", skip(self, urn), fields(urn = %urn))]
-    pub fn has_tag<Oid>(&self, urn: &Urn, oid: Oid) -> Result<bool, Error>
-    where
-        Oid: AsRef<git2::Oid> + Debug,
-    {
-        let (oid, kind) = match self.find_object(oid)? {
-            None => return Ok(false),
-            Some(object) => match object.kind() {
-                Some(git2::ObjectType::Tag) => (object.id(), git2::ObjectType::Tag),
-                _ => return Ok(false),
-            },
-        };
-
-        let tip = self.tip(urn, kind)?;
-        Ok(tip.map(|tip| tip.id() == oid).unwrap_or(false))
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub fn has_object<Oid>(&self, oid: Oid) -> Result<bool, Error>
-    where
-        Oid: AsRef<git2::Oid> + Debug,
-    {
-        let oid = oid.as_ref();
-        if oid.is_zero() {
-            // XXX: should this be a panic or error?
-            tracing::warn!("zero oid");
-            return Ok(false);
-        }
-
-        Ok(self.backend.odb()?.exists(*oid))
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub fn find_object<Oid>(&self, oid: Oid) -> Result<Option<git2::Object>, Error>
-    where
-        Oid: AsRef<git2::Oid> + Debug,
-    {
-        let oid = oid.as_ref();
-        if oid.is_zero() {
-            return Ok(None);
-        }
-
-        self.backend
-            .find_object(*oid, None)
-            .map(Some)
-            .or_matches(is_not_found_err, || Ok(None))
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub fn tip(&self, urn: &Urn, kind: git2::ObjectType) -> Result<Option<git2::Object>, Error> {
-        let reference = self
-            .backend
-            .find_reference(RefLike::from(&Reference::try_from(urn)?).as_str())
-            .map(Some)
-            .or_matches::<Error, _, _>(is_not_found_err, || Ok(None))?;
-
-        match reference {
-            None => Ok(None),
-            Some(r) => r.peel(kind).map(Some).map_err(Error::from),
-        }
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub fn reference<'a>(
-        &'a self,
-        reference: &Reference<One>,
-    ) -> Result<Option<git2::Reference<'a>>, Error> {
-        reference
-            .find(&self.backend)
-            .map(Some)
-            .or_matches(is_not_found_err, || Ok(None))
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub fn references<'a>(
-        &'a self,
-        reference: &Reference<Many>,
-    ) -> Result<impl Iterator<Item = Result<git2::Reference<'a>, Error>> + 'a, Error> {
-        self.references_glob(glob::RefspecMatcher::from(RefspecPattern::from(reference)))
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub fn reference_names<'a>(
-        &'a self,
-        reference: &Reference<Many>,
-    ) -> Result<impl Iterator<Item = Result<ext::RefLike, Error>> + 'a, Error> {
-        self.reference_names_glob(glob::RefspecMatcher::from(RefspecPattern::from(reference)))
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub fn references_glob<'a, G: 'a>(
-        &'a self,
-        glob: G,
-    ) -> Result<impl Iterator<Item = Result<git2::Reference<'a>, Error>> + 'a, Error>
-    where
-        G: Pattern + Debug,
-    {
-        Ok(self
-            .backend
-            .references()?
-            .filter_map(move |reference| match reference {
-                Ok(reference) => match reference.name() {
-                    Some(name) if glob.matches(name) => Some(Ok(reference)),
-                    _ => None,
-                },
-
-                Err(e) => Some(Err(e.into())),
-            }))
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub fn reference_names_glob<'a, G: 'a>(
-        &'a self,
-        glob: G,
-    ) -> Result<impl Iterator<Item = Result<ext::RefLike, Error>> + 'a, Error>
-    where
-        G: Pattern + Debug,
-    {
-        let iter = ReferenceNames {
-            iter: self.backend.references()?,
-        };
-        Ok(iter.filter_map(move |refname| match refname {
-            Ok(reflike) if glob.matches(Path::new(reflike.as_str())) => Some(Ok(reflike)),
-            Ok(_) => None,
-
-            Err(e) => Some(Err(e)),
-        }))
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub fn blob<'a>(
-        &'a self,
-        reference: &'a Reference<One>,
-        path: &'a Path,
-    ) -> Result<Option<git2::Blob<'a>>, Error> {
-        ext::Blob::Tip {
-            branch: reference.into(),
-            path,
-        }
-        .get(self.as_raw())
-        .map(Some)
-        .or_matches(|e| matches!(e, blob::Error::NotFound(_)), || Ok(None))
+        self.inner.peer_id()
     }
 
     pub fn config(&self) -> Result<Config<BoxedSigner>, Error> {
@@ -375,10 +178,6 @@ impl Storage {
         &self.signer
     }
 
-    pub(super) fn identities<'a, T: 'a>(&'a self) -> Identities<'a, T> {
-        Identities::from(self.as_raw())
-    }
-
     // TODO: we would need to wrap a few more low-level git operations (such as:
     // create commit, manipulate refs, manipulate config) in order to be able to
     // model "capabilities" in terms of traits.
@@ -397,25 +196,16 @@ impl AsRef<Storage> for Storage {
     }
 }
 
-struct ReferenceNames<'a> {
-    iter: git2::References<'a>,
+impl AsRef<read::Storage> for Storage {
+    fn as_ref(&self) -> &read::Storage {
+        &self.inner
+    }
 }
 
-impl<'a> Iterator for ReferenceNames<'a> {
-    type Item = Result<ext::RefLike, Error>;
+impl std::ops::Deref for Storage {
+    type Target = ReadOnly;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let names = self.iter.names();
-        for name in names {
-            match name {
-                Err(e) => return Some(Err(e.into())),
-                Ok(name) => match ext::RefLike::try_from(name).ok() {
-                    Some(refl) => return Some(Ok(refl)),
-                    None => continue,
-                },
-            }
-        }
-
-        None
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }

--- a/librad/src/git/storage/fetcher.rs
+++ b/librad/src/git/storage/fetcher.rs
@@ -312,7 +312,7 @@ pub async fn retrying<P, B, E, F, A>(
     f: F,
 ) -> Result<A, error::Retrying<E>>
 where
-    P: super::Pooled + Send + 'static,
+    P: super::Pooled<Storage> + Send + 'static,
     B: BuildFetcher<Error = E> + Clone + Send + 'static,
     E: std::error::Error + Send + Sync + 'static,
     F: Fn(&Storage, Fetcher) -> A + Send + Sync + 'static,
@@ -335,7 +335,7 @@ where
         f: F,
     ) -> Result<A, Inner<B, F, E>>
     where
-        P: super::Pooled + Send + 'static,
+        P: super::Pooled<Storage> + Send + 'static,
         B: BuildFetcher<Error = E> + Send + 'static,
         F: Fn(&Storage, Fetcher) -> A + Send + Sync + 'static,
         E: std::error::Error + Send + Sync + 'static,

--- a/librad/src/git/storage/read.rs
+++ b/librad/src/git/storage/read.rs
@@ -1,0 +1,317 @@
+// Copyright © 2019-2021 The Radicle Foundation <hello@radicle.foundation>
+// Copyright © 2021 The Radicle Link Contributors
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{convert::TryFrom, fmt::Debug, marker::PhantomData, path::Path};
+
+use git_ext::{self as ext, blob, is_not_found_err, RefLike, RefspecPattern};
+use std_ext::result::ResultExt as _;
+use thiserror::Error;
+
+use crate::{
+    git::types::{reference, Many, One, Reference},
+    identities::git::{Identities, Urn},
+    paths::Paths,
+    peer::PeerId,
+};
+
+use super::{
+    config::{self, Config},
+    glob::{self, Pattern},
+};
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+
+    #[error("malformed URN")]
+    Ref(#[from] reference::FromUrnError),
+
+    #[error(transparent)]
+    Blob(#[from] ext::blob::Error),
+
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+}
+
+/// Low-level operations on the link "monorepo".
+pub struct Storage {
+    pub(super) backend: git2::Repository,
+    pub(super) peer_id: PeerId,
+}
+
+impl Storage {
+    /// Open the read-only [`Storage`], which must exist.
+    ///
+    /// In contrast to a read-write [`super::Storage`], this does not require a
+    /// `Signer`.
+    ///
+    /// # Concurrency
+    ///
+    /// [`Storage`] can be sent between threads, but it can't be shared between
+    /// threads. _Some_ operations are safe to perform concurrently in much
+    /// the same way two `git` processes can access the same repository.
+    /// However, if you need multiple [`Storage`]s to be shared between
+    /// threads, use a [`super::Pool`] instead.
+    pub fn open(paths: &Paths) -> Result<Self, Error> {
+        crate::git::init();
+        let backend = git2::Repository::open(paths.git_dir())?;
+        let peer_id = Config::try_from(&backend)?.peer_id()?;
+        Ok(Self { backend, peer_id })
+    }
+
+    pub fn peer_id(&self) -> &PeerId {
+        &self.peer_id
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.backend.path()
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub fn has_urn(&self, urn: &Urn) -> Result<bool, Error> {
+        self.has_ref(&Reference::try_from(urn)?)
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub fn has_ref<'a>(&self, reference: &'a Reference<One>) -> Result<bool, Error> {
+        self.backend
+            .find_reference(RefLike::from(reference).as_str())
+            .and(Ok(true))
+            .or_matches(is_not_found_err, || Ok(false))
+    }
+
+    /// Check the existence of `oid` as a **commit**.
+    ///
+    /// The result will be `false` if:
+    ///
+    /// 1. No commit could be found for `oid`
+    /// 2. The reference path for the `urn` could not be found (it defaults to
+    /// `rad/id` if not provided)
+    /// 3. The tip SHA was not in the history of the commit
+    /// 4. The `oid` was the [`zero`][`git2::Oid::zero`] SHA.
+    #[tracing::instrument(level = "debug", skip(self, urn), fields(urn = %urn))]
+    pub fn has_commit<Oid>(&self, urn: &Urn, oid: Oid) -> Result<bool, Error>
+    where
+        Oid: AsRef<git2::Oid> + Debug,
+    {
+        let (oid, kind) = match self.find_object(oid)? {
+            None => return Ok(false),
+            Some(object) => match object.kind() {
+                Some(git2::ObjectType::Commit) => (object.id(), git2::ObjectType::Commit),
+                _ => return Ok(false),
+            },
+        };
+
+        let tip = self.tip(urn, kind)?;
+        Ok(tip
+            .map(|tip| {
+                Ok::<_, git2::Error>(
+                    tip.id() == oid || self.backend.graph_descendant_of(tip.id(), oid)?,
+                )
+            })
+            .transpose()?
+            .unwrap_or(false))
+    }
+
+    /// Check the existence of `oid` as a **tag**.
+    ///
+    /// The result will be `false` if:
+    ///
+    /// 1. No tag could be found for `oid`
+    /// 2. The reference path for the `urn` could not be found (it defaults to
+    /// `rad/id` if not provided)
+    /// 3. The SHA of the tag was not the same as the resolved reference
+    /// 4. The `oid` was the [`zero`][`git2::Oid::zero`] SHA.
+    #[tracing::instrument(level = "debug", skip(self, urn), fields(urn = %urn))]
+    pub fn has_tag<Oid>(&self, urn: &Urn, oid: Oid) -> Result<bool, Error>
+    where
+        Oid: AsRef<git2::Oid> + Debug,
+    {
+        let (oid, kind) = match self.find_object(oid)? {
+            None => return Ok(false),
+            Some(object) => match object.kind() {
+                Some(git2::ObjectType::Tag) => (object.id(), git2::ObjectType::Tag),
+                _ => return Ok(false),
+            },
+        };
+
+        let tip = self.tip(urn, kind)?;
+        Ok(tip.map(|tip| tip.id() == oid).unwrap_or(false))
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub fn has_object<Oid>(&self, oid: Oid) -> Result<bool, Error>
+    where
+        Oid: AsRef<git2::Oid> + Debug,
+    {
+        let oid = oid.as_ref();
+        if oid.is_zero() {
+            // XXX: should this be a panic or error?
+            tracing::warn!("zero oid");
+            return Ok(false);
+        }
+
+        Ok(self.backend.odb()?.exists(*oid))
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub fn find_object<Oid>(&self, oid: Oid) -> Result<Option<git2::Object>, Error>
+    where
+        Oid: AsRef<git2::Oid> + Debug,
+    {
+        let oid = oid.as_ref();
+        if oid.is_zero() {
+            return Ok(None);
+        }
+
+        self.backend
+            .find_object(*oid, None)
+            .map(Some)
+            .or_matches(is_not_found_err, || Ok(None))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn tip(&self, urn: &Urn, kind: git2::ObjectType) -> Result<Option<git2::Object>, Error> {
+        let reference = self
+            .backend
+            .find_reference(RefLike::from(&Reference::try_from(urn)?).as_str())
+            .map(Some)
+            .or_matches::<Error, _, _>(is_not_found_err, || Ok(None))?;
+
+        match reference {
+            None => Ok(None),
+            Some(r) => r.peel(kind).map(Some).map_err(Error::from),
+        }
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn reference<'a>(
+        &'a self,
+        reference: &Reference<One>,
+    ) -> Result<Option<git2::Reference<'a>>, Error> {
+        reference
+            .find(&self.backend)
+            .map(Some)
+            .or_matches(is_not_found_err, || Ok(None))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn references<'a>(
+        &'a self,
+        reference: &Reference<Many>,
+    ) -> Result<impl Iterator<Item = Result<git2::Reference<'a>, Error>> + 'a, Error> {
+        self.references_glob(glob::RefspecMatcher::from(RefspecPattern::from(reference)))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn reference_names<'a>(
+        &'a self,
+        reference: &Reference<Many>,
+    ) -> Result<impl Iterator<Item = Result<ext::RefLike, Error>> + 'a, Error> {
+        self.reference_names_glob(glob::RefspecMatcher::from(RefspecPattern::from(reference)))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn references_glob<'a, G: 'a>(
+        &'a self,
+        glob: G,
+    ) -> Result<impl Iterator<Item = Result<git2::Reference<'a>, Error>> + 'a, Error>
+    where
+        G: Pattern + Debug,
+    {
+        Ok(self
+            .backend
+            .references()?
+            .filter_map(move |reference| match reference {
+                Ok(reference) => match reference.name() {
+                    Some(name) if glob.matches(name) => Some(Ok(reference)),
+                    _ => None,
+                },
+
+                Err(e) => Some(Err(e.into())),
+            }))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn reference_names_glob<'a, G: 'a>(
+        &'a self,
+        glob: G,
+    ) -> Result<impl Iterator<Item = Result<ext::RefLike, Error>> + 'a, Error>
+    where
+        G: Pattern + Debug,
+    {
+        let iter = ReferenceNames {
+            iter: self.backend.references()?,
+        };
+        Ok(iter.filter_map(move |refname| match refname {
+            Ok(reflike) if glob.matches(Path::new(reflike.as_str())) => Some(Ok(reflike)),
+            Ok(_) => None,
+
+            Err(e) => Some(Err(e)),
+        }))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn blob<'a>(
+        &'a self,
+        reference: &'a Reference<One>,
+        path: &'a Path,
+    ) -> Result<Option<git2::Blob<'a>>, Error> {
+        ext::Blob::Tip {
+            branch: reference.into(),
+            path,
+        }
+        .get(self.as_raw())
+        .map(Some)
+        .or_matches(|e| matches!(e, blob::Error::NotFound(_)), || Ok(None))
+    }
+
+    pub fn config(&self) -> Result<Config<PhantomData<!>>, Error> {
+        Ok(Config::try_from(&self.backend)?)
+    }
+
+    pub(in crate::git) fn identities<'a, T: 'a>(&'a self) -> Identities<'a, T> {
+        Identities::from(self.as_raw())
+    }
+
+    // TODO: we would need to wrap a few more low-level git operations (such as:
+    // create commit, manipulate refs, manipulate config) in order to be able to
+    // model "capabilities" in terms of traits.
+    pub(in crate::git) fn as_raw(&self) -> &git2::Repository {
+        &self.backend
+    }
+}
+
+impl AsRef<Storage> for Storage {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+struct ReferenceNames<'a> {
+    iter: git2::References<'a>,
+}
+
+impl<'a> Iterator for ReferenceNames<'a> {
+    type Item = Result<ext::RefLike, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let names = self.iter.names();
+        for name in names {
+            match name {
+                Err(e) => return Some(Err(e.into())),
+                Ok(name) => match ext::RefLike::try_from(name).ok() {
+                    Some(refl) => return Some(Ok(refl)),
+                    None => continue,
+                },
+            }
+        }
+
+        None
+    }
+}

--- a/librad/src/git/storage/read.rs
+++ b/librad/src/git/storage/read.rs
@@ -6,6 +6,7 @@
 
 use std::{convert::TryFrom, fmt::Debug, marker::PhantomData, path::Path};
 
+use git2::string_array::StringArray;
 use git_ext::{self as ext, blob, is_not_found_err, RefLike, RefspecPattern};
 use std_ext::result::ResultExt as _;
 use thiserror::Error;
@@ -276,6 +277,18 @@ impl Storage {
         .get(&self.backend)
         .map(Some)
         .or_matches(|e| matches!(e, blob::Error::NotFound(_)), || Ok(None))
+    }
+
+    pub fn remotes(&self) -> Result<StringArray, Error> {
+        self.backend.remotes().map_err(Error::from)
+    }
+
+    pub fn has_remote(&self, urn: &Urn, peer: PeerId) -> Result<bool, Error> {
+        let name = format!("{}/{}", urn.encode_id(), peer);
+        self.backend
+            .find_remote(&name)
+            .and(Ok(true))
+            .or_matches(is_not_found_err, || Ok(false))
     }
 
     pub fn config(&self) -> Result<Config<PhantomData<!>>, Error> {

--- a/librad/src/git/tracking.rs
+++ b/librad/src/git/tracking.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use super::{
     p2p::url::GitUrlRef,
-    storage::{self, glob, Storage},
+    storage::{self, glob, ReadOnlyStorage, Storage},
 };
 use crate::peer::PeerId;
 

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -25,7 +25,6 @@ pub use super::protocol::{
     Interrogation,
     PeerInfo,
 };
-pub use deadpool::managed::PoolError;
 
 pub mod error;
 pub mod storage;
@@ -92,7 +91,7 @@ pub struct Peer<S> {
     config: Config<S>,
     phone: protocol::TinCans,
     peer_store: PeerStorage,
-    user_store: git::storage::Pool,
+    user_store: git::storage::Pool<git::storage::Storage>,
     caches: protocol::Caches,
     spawner: Arc<executor::Spawner>,
 }
@@ -269,7 +268,7 @@ where
     /// return the [`git::storage::Storage`] to the pool.
     pub async fn storage(
         &self,
-    ) -> Result<impl AsRef<git::storage::Storage>, PoolError<git::storage::error::Init>> {
+    ) -> Result<impl AsRef<git::storage::Storage>, git::storage::pool::PoolError> {
         self.user_store
             .get()
             .map_ok(git::storage::pool::PooledRef::from)

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -253,6 +253,21 @@ where
             .await?)
     }
 
+    /// Borrow a [`git::storage::ReadOnly`] from the pool, and run a blocking
+    /// computation on it.
+
+    pub async fn using_read_only<F, A>(&self, blocking: F) -> Result<A, error::Storage>
+    where
+        F: FnOnce(&git::storage::ReadOnly) -> A + Send + 'static,
+        A: Send + 'static,
+    {
+        let storage = self.user_store.get().await?;
+        Ok(self
+            .spawner
+            .spawn_blocking(move || blocking(&storage.read_only()))
+            .await?)
+    }
+
     /// Borrow a [`git::storage::Storage`] from the pool directly.
     ///
     /// # WARNING

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -269,7 +269,7 @@ where
     /// return the [`git::storage::Storage`] to the pool.
     pub async fn storage(
         &self,
-    ) -> Result<impl AsRef<git::storage::Storage>, PoolError<git::storage::OpenError>> {
+    ) -> Result<impl AsRef<git::storage::Storage>, PoolError<git::storage::error::Init>> {
         self.user_store
             .get()
             .map_ok(git::storage::pool::PooledRef::from)

--- a/librad/src/net/peer.rs
+++ b/librad/src/net/peer.rs
@@ -269,7 +269,7 @@ where
     /// return the [`git::storage::Storage`] to the pool.
     pub async fn storage(
         &self,
-    ) -> Result<impl AsRef<git::storage::Storage>, PoolError<git::storage::Error>> {
+    ) -> Result<impl AsRef<git::storage::Storage>, PoolError<git::storage::OpenError>> {
         self.user_store
             .get()
             .map_ok(git::storage::pool::PooledRef::from)

--- a/librad/src/net/peer/error.rs
+++ b/librad/src/net/peer/error.rs
@@ -35,7 +35,7 @@ impl From<executor::JoinError> for Storage {
 #[derive(Debug, Error)]
 pub enum Init {
     #[error(transparent)]
-    Storage(#[from] storage::OpenError),
+    Storage(#[from] storage::error::Init),
 
     #[error(transparent)]
     Cache(#[from] Box<cache::urns::Error>),

--- a/librad/src/net/peer/error.rs
+++ b/librad/src/net/peer/error.rs
@@ -35,7 +35,7 @@ impl From<executor::JoinError> for Storage {
 #[derive(Debug, Error)]
 pub enum Init {
     #[error(transparent)]
-    Storage(#[from] storage::Error),
+    Storage(#[from] storage::OpenError),
 
     #[error(transparent)]
     Cache(#[from] Box<cache::urns::Error>),

--- a/librad/src/net/peer/storage.rs
+++ b/librad/src/net/peer/storage.rs
@@ -35,7 +35,7 @@ pub struct Config {
 
 #[derive(Clone)]
 pub struct Storage {
-    pool: Pool,
+    pool: Pool<storage::Storage>,
     config: Config,
     urns: cache::urns::Filter,
     limits: Arc<RateLimiter<Keyed<(PeerId, Urn)>>>,
@@ -45,7 +45,7 @@ pub struct Storage {
 impl Storage {
     pub fn new(
         spawner: Arc<executor::Spawner>,
-        pool: Pool,
+        pool: Pool<storage::Storage>,
         config: Config,
         urns: cache::urns::Filter,
     ) -> Self {
@@ -274,8 +274,8 @@ impl broadcast::LocalStorage<SocketAddr> for Storage {
 }
 
 #[async_trait]
-impl storage::Pooled for Storage {
-    async fn get(&self) -> Result<PooledRef, PoolError> {
+impl storage::Pooled<storage::Storage> for Storage {
+    async fn get(&self) -> Result<PooledRef<storage::Storage>, PoolError> {
         self.pool.get().await.map(PooledRef::from)
     }
 }

--- a/librad/src/net/peer/storage.rs
+++ b/librad/src/net/peer/storage.rs
@@ -13,7 +13,7 @@ use crate::{
     executor,
     git::{
         replication,
-        storage::{self, fetcher, Pool, PoolError, PooledRef},
+        storage::{self, fetcher, Pool, PoolError, PooledRef, ReadOnlyStorage as _},
         tracking,
         Urn,
     },

--- a/librad/src/net/peer/storage.rs
+++ b/librad/src/net/peer/storage.rs
@@ -121,10 +121,10 @@ impl Storage {
         let head = head.into().map(ext::Oid::from);
         self.spawner
             .spawn_blocking(move || match head {
-                None => git.has_urn(&urn).unwrap_or(false),
+                None => git.as_ref().has_urn(&urn).unwrap_or(false),
                 Some(head) => {
-                    git.has_commit(&urn, head).unwrap_or(false)
-                        || git.has_tag(&urn, head).unwrap_or(false)
+                    git.as_ref().has_commit(&urn, head).unwrap_or(false)
+                        || git.as_ref().has_tag(&urn, head).unwrap_or(false)
                 },
             })
             .await

--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -269,9 +269,12 @@ where
     (sht, run)
 }
 
-pub trait ProtocolStorage<A>: broadcast::LocalStorage<A> + storage::Pooled + Send + Sync {}
+pub trait ProtocolStorage<A>:
+    broadcast::LocalStorage<A> + storage::Pooled<storage::Storage> + Send + Sync
+{
+}
 impl<A, T> ProtocolStorage<A> for T where
-    T: broadcast::LocalStorage<A> + storage::Pooled + Send + Sync
+    T: broadcast::LocalStorage<A> + storage::Pooled<storage::Storage> + Send + Sync
 {
 }
 

--- a/librad/src/net/protocol/io/graft.rs
+++ b/librad/src/net/protocol/io/graft.rs
@@ -79,7 +79,7 @@ pub async fn rere<S, Addrs>(
     addr_hints: Addrs,
 ) -> Result<Option<replication::ReplicateResult>, error::Rere>
 where
-    S: storage::Pooled + Send + Sync + 'static,
+    S: storage::Pooled<storage::Storage> + Send + Sync + 'static,
     Addrs: IntoIterator<Item = SocketAddr>,
 {
     fetcher::retrying(

--- a/librad/src/net/protocol/io/recv/interrogation.rs
+++ b/librad/src/net/protocol/io/recv/interrogation.rs
@@ -45,7 +45,7 @@ pub(in crate::net::protocol) async fn interrogation<S, T>(
     state: State<S>,
     stream: Upgraded<upgrade::Interrogation, T>,
 ) where
-    S: storage::Pooled + Send + 'static,
+    S: storage::Pooled<storage::Storage> + Send + 'static,
     T: Duplex<Addr = SocketAddr>,
     T::Read: AsyncRead + Unpin,
     T::Write: AsyncWrite + Unpin,

--- a/librad/src/net/protocol/state.rs
+++ b/librad/src/net/protocol/state.rs
@@ -293,11 +293,11 @@ impl<S> broadcast::RateLimited for Storage<S> {
 }
 
 #[async_trait]
-impl<S> storage::Pooled for Storage<S>
+impl<S> storage::Pooled<storage::Storage> for Storage<S>
 where
-    S: storage::Pooled + Send + Sync,
+    S: storage::Pooled<storage::Storage> + Send + Sync,
 {
-    async fn get(&self) -> Result<PooledRef, PoolError> {
+    async fn get(&self) -> Result<PooledRef<storage::Storage>, PoolError> {
         self.inner.get().await
     }
 }

--- a/test/src/test/integration/librad/scenario/menage.rs
+++ b/test/src/test/integration/librad/scenario/menage.rs
@@ -18,7 +18,7 @@ use librad::{
     self,
     git::{
         local::url::LocalUrl,
-        storage::Storage,
+        storage::{ReadOnlyStorage as _, Storage},
         tracking,
         types::{remote, Flat, Force, GenericRef, Namespace, Reference, Refspec, Remote},
         Urn,

--- a/test/src/test/integration/librad/smoke/clone.rs
+++ b/test/src/test/integration/librad/smoke/clone.rs
@@ -17,7 +17,7 @@ use librad::{
     git::{
         identities,
         replication,
-        storage::fetcher,
+        storage::{fetcher, ReadOnlyStorage as _},
         types::{Namespace, Reference},
     },
 };

--- a/test/src/test/integration/librad/smoke/gossip.rs
+++ b/test/src/test/integration/librad/smoke/gossip.rs
@@ -12,6 +12,7 @@ use futures::StreamExt as _;
 use librad::{
     git::{
         local::url::LocalUrl,
+        storage::ReadOnlyStorage as _,
         types::{remote, Fetchspec, Force, Reference, Remote},
         Urn,
     },

--- a/test/src/test/integration/librad/smoke/gossip.rs
+++ b/test/src/test/integration/librad/smoke/gossip.rs
@@ -164,7 +164,6 @@ fn fetches_on_gossip_notify() {
                 let peer1_id = peer1.peer_id();
                 move |storage| {
                     let peer2_has_commit = storage
-                        .as_ref()
                         .has_commit(&commit_urn, Box::new(commit_id))
                         .unwrap();
                     assert!(peer2_has_commit);

--- a/test/src/test/integration/librad/smoke/graft.rs
+++ b/test/src/test/integration/librad/smoke/graft.rs
@@ -10,7 +10,7 @@ use crate::{
     rad::{identities::TestProject, testnet},
 };
 use librad::{
-    git::{tracking, util},
+    git::{storage::ReadOnlyStorage as _, tracking, util},
     git_ext::tree,
     reflike,
 };

--- a/test/src/test/unit/librad/git/project.rs
+++ b/test/src/test/unit/librad/git/project.rs
@@ -36,11 +36,11 @@ fn create_anonymous() -> anyhow::Result<()> {
     )?;
     assert_eq!(
         Some(proj.urn()),
-        identities::project::get(&storage, &proj.urn())?.map(|proj| proj.urn())
+        identities::project::get(&storage.read_only(), &proj.urn())?.map(|proj| proj.urn())
     );
     assert_eq!(
         Some(proj.urn()),
-        identities::any::get(&storage, &proj.urn())?
+        identities::any::get(&storage.read_only(), &proj.urn())?
             .and_then(SomeIdentity::project)
             .map(|proj| proj.urn())
     );


### PR DESCRIPTION
Fixes #461

We introduce the read-only variant of Storage. The use of this variant
implies that it will be used for read-only purposes, and so it does not
hold a signer.

Storage is re-formulated to be a combination of the read-only store
along with the signer and fetchers.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>