### PR TITLE
protocol: avoid boxing of control stream

### DIFF
--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -5,7 +5,8 @@
 
 use std::{fmt::Debug, future::Future, net::SocketAddr, sync::Arc, time::Duration};
 
-use futures::{channel::mpsc, stream::StreamExt as _};
+use async_stream::stream;
+use futures::channel::mpsc;
 use nonempty::NonEmpty;
 use nonzero_ext::nonzero;
 use rand_pcg::Pcg64Mcg;
@@ -245,11 +246,10 @@ where
         spawner.spawn(accept::periodic(state.clone(), periodic)),
         spawner.spawn(accept::ground_control(
             state.clone(),
-            async_stream::stream! {
+            stream! {
                 let mut r = phone.downstream.subscribe();
                 loop { yield r.recv().await; }
-            }
-            .boxed(),
+            },
         )),
     ];
     let run = async move {

--- a/librad/src/net/protocol/accept.rs
+++ b/librad/src/net/protocol/accept.rs
@@ -110,13 +110,14 @@ where
 }
 
 #[tracing::instrument(skip(state, rx))]
-pub(super) async fn ground_control<S, E>(state: State<S>, mut rx: E)
+pub(super) async fn ground_control<S, E>(state: State<S>, rx: E)
 where
     S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + 'static,
-    E: futures::Stream<Item = Result<event::Downstream, RecvError>> + Unpin,
+    E: futures::Stream<Item = Result<event::Downstream, RecvError>>,
 {
     use event::Downstream;
 
+    futures::pin_mut!(rx);
     while let Some(x) = rx.next().await {
         match x {
             Err(RecvError::Closed) => {


### PR DESCRIPTION
It's moved, so can be pinned in the handler function.
