### PR TITLE
profile: refactor Profile

### DIFF
--- a/librad/src/profile.rs
+++ b/librad/src/profile.rs
@@ -128,8 +128,8 @@ impl Profile {
     }
 
     /// Returns the profile identifier
-    pub fn id(&self) -> &str {
-        &self.id.0
+    pub fn id(&self) -> &ProfileId {
+        &self.id
     }
 
     /// Returns [`Paths`] for this profile.

--- a/librad/src/profile/id.rs
+++ b/librad/src/profile/id.rs
@@ -37,7 +37,7 @@ pub enum Error {
 /// A valid profile ID is not empty, does not contain path separators, is
 /// not a windows path prefix like `C:`, and is not a special component
 /// like `.` or `..`.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ProfileId(pub(super) String);
 
 impl FromStr for ProfileId {

--- a/librad/src/profile/id.rs
+++ b/librad/src/profile/id.rs
@@ -1,0 +1,187 @@
+// Copyright © 2021 The Radicle Link Contributors
+//
+// This file is part of radicle-link, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    env,
+    fmt,
+    fs,
+    io,
+    path,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+use super::{RadHome, RAD_PROFILE};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("invalid profile ID while parsing: {id}")]
+    FromStr { id: String },
+    #[error("invalid profile ID in RAD_PROFILE environment variable: {id}")]
+    FromEnv { id: String },
+    #[error("invalid profile ID loaded from {path}: {id}")]
+    FromFile { id: String, path: PathBuf },
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+/// An identifier that provides separation between multiple [`super::Paths`].
+/// For example, two separate profiles can be created under
+/// `/home/.local/share/radicle-link/0000` and
+/// `/home/.local/share/radicle-link/0001`.
+///
+/// A valid profile ID is not empty, does not contain path separators, is
+/// not a windows path prefix like `C:`, and is not a special component
+/// like `.` or `..`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProfileId(pub(super) String);
+
+impl FromStr for ProfileId {
+    type Err = Error;
+
+    fn from_str(id: &str) -> Result<Self, Self::Err> {
+        ProfileId::valid(Validate::Str { id: id.to_string() })
+    }
+}
+
+impl fmt::Display for ProfileId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str(&self.0)
+    }
+}
+
+impl Default for ProfileId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+enum Validate {
+    File { id: String, path: PathBuf },
+    Env { id: String },
+    Str { id: String },
+}
+
+impl Validate {
+    fn id_ref(&self) -> &str {
+        match self {
+            Self::File { id, .. } => id,
+            Self::Env { id } => id,
+            Self::Str { id } => id,
+        }
+    }
+
+    fn id(self) -> String {
+        match self {
+            Self::File { id, .. } => id,
+            Self::Env { id } => id,
+            Self::Str { id } => id,
+        }
+    }
+}
+
+impl From<Validate> for Error {
+    fn from(v: Validate) -> Error {
+        match v {
+            Validate::File { id, path } => Self::FromFile { id, path },
+            Validate::Env { id } => Self::FromEnv { id },
+            Validate::Str { id } => Self::FromStr { id },
+        }
+    }
+}
+
+impl ProfileId {
+    /// Generate a new, hyphenated UUID-v4 identifier.
+    pub fn new() -> Self {
+        ProfileId(Uuid::new_v4().to_hyphenated().to_string())
+    }
+
+    /// Read a `ProfileId` from the `PROFILE_ID` environment variable. The value
+    /// must pass validation, as documented in [`ProfileId`].
+    pub fn from_env() -> Result<Option<Self>, Error> {
+        env::var(RAD_PROFILE)
+            .ok()
+            .map(|id| Self::valid(Validate::Env { id }))
+            .transpose()
+    }
+
+    /// Read the `ProfileId` from a file or create the file and write a newly
+    /// generated `ProfileId` to it.
+    pub fn load(home: &RadHome) -> Result<Self, Error> {
+        match Self::active(home)? {
+            Some(id) => Ok(id),
+            None => {
+                let id = Self::new();
+                let config = home.config()?;
+                let path = config.join("active_profile");
+                fs::create_dir_all(config)?;
+                fs::write(path, &id.0)?;
+                Ok(id)
+            },
+        }
+    }
+
+    /// Read the `ProfileId` from the `active_profile` file. If the file is not
+    /// found then `None` is returned.
+    ///
+    /// The `ProfileId` is the first line of the file. If the file does not
+    /// exist a new ID is generated and written to the file.
+    pub fn active(home: &RadHome) -> Result<Option<Self>, Error> {
+        let active_path = home.config()?.join("active_profile");
+
+        match fs::read_to_string(&active_path) {
+            Ok(content) => {
+                let id = content.lines().next().unwrap_or("").to_string();
+                Self::valid(Validate::File {
+                    id,
+                    path: active_path,
+                })
+                .map(Some)
+            },
+            Err(err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    Ok(None)
+                } else {
+                    Err(Error::from(err))
+                }
+            },
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn valid(v: Validate) -> Result<Self, Error> {
+        let id = v.id_ref();
+        if Self::is_valid(id) {
+            Ok(Self(v.id()))
+        } else {
+            Err(v.into())
+        }
+    }
+
+    /// Returns `true` if `id` is a valid profile ID.
+    ///
+    /// A valid profile ID is not empty, does not contain path separators, is
+    /// not a windows path prefix like `C:`, and is not a special component
+    /// like `.` or `..`.
+    fn is_valid(id: &str) -> bool {
+        let mut components = Path::new(id).components();
+
+        match components.next() {
+            Some(path::Component::Normal(_)) => {},
+            _ => return false,
+        }
+
+        if components.next().is_some() {
+            return false;
+        }
+
+        true
+    }
+}

--- a/test/src/test/unit/librad/profile.rs
+++ b/test/src/test/unit/librad/profile.rs
@@ -39,17 +39,17 @@ fn load_profile_id_test() {
 fn profile_paths() {
     let tmp_home = tempfile::tempdir().unwrap();
 
-    let id = "foo";
+    let id: ProfileId = "foo".parse().unwrap();
 
     let profile_id_path = tmp_home.path().join("active_profile");
-    std::fs::write(profile_id_path, id).unwrap();
+    std::fs::write(profile_id_path, id.as_str()).unwrap();
 
     let profile = Profile::from_root(tmp_home.path(), None).unwrap();
-    assert_eq!(profile.id(), id);
+    assert_eq!(profile.id(), &id);
     assert!(profile
         .paths()
         .git_dir()
-        .starts_with(tmp_home.path().join(id)));
+        .starts_with(tmp_home.path().join(id.as_str())));
 }
 
 #[test]

--- a/test/src/test/unit/librad/profile.rs
+++ b/test/src/test/unit/librad/profile.rs
@@ -4,72 +4,84 @@
 // Linking Exception. For full terms see the included LICENSE file.
 
 use std::fs;
+use tempfile::TempDir;
 
-use librad::profile::{load_profile_id, Error, Profile};
+use librad::profile::{id, Profile, ProfileId, RadHome};
+
+pub struct TempHome {
+    tmp: TempDir,
+    home: RadHome,
+}
+
+fn temp() -> TempHome {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().to_path_buf();
+    TempHome {
+        tmp,
+        home: RadHome::Root(root),
+    }
+}
 
 #[test]
 fn load_profile_id_test() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tmp_home = temp();
 
-    let id1 = load_profile_id(tempdir.path()).unwrap();
-    let id2 = load_profile_id(tempdir.path()).unwrap();
+    let id1 = ProfileId::load(&tmp_home.home).unwrap();
+    let id2 = ProfileId::load(&tmp_home.home).unwrap();
     assert_eq!(id2, id1);
-    fs::remove_dir_all(tempdir.path()).unwrap();
+    fs::remove_dir_all(tmp_home.tmp.path()).unwrap();
 
-    let id3 = load_profile_id(tempdir.path()).unwrap();
+    let id3 = ProfileId::load(&tmp_home.home).unwrap();
     assert_ne!(id3, id1);
 }
 
 #[test]
 fn profile_paths() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tmp_home = tempfile::tempdir().unwrap();
 
     let id = "foo";
 
-    let profile_id_path = tempdir.path().join("active_profile");
+    let profile_id_path = tmp_home.path().join("active_profile");
     std::fs::write(profile_id_path, id).unwrap();
 
-    let profile = Profile::from_root(tempdir.path(), None).unwrap();
+    let profile = Profile::from_root(tmp_home.path(), None).unwrap();
     assert_eq!(profile.id(), id);
     assert!(profile
         .paths()
         .git_dir()
-        .starts_with(tempdir.path().join(id)));
+        .starts_with(tmp_home.path().join(id)));
 }
 
 #[test]
 fn invalid_profile_id_from_file() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tmp_home = temp();
 
-    let profile_id_path = tempdir.path().join("active_profile");
+    let profile_id_path = tmp_home.tmp.path().join("active_profile");
     let invalid_id = "foo/bar";
     std::fs::write(profile_id_path, invalid_id).unwrap();
 
-    let result = load_profile_id(tempdir.path());
-    assert!(matches!(
-        result,
-        Err(Error::InvalidProfileIdFromFile { .. })
-    ));
+    let result = ProfileId::load(&tmp_home.home);
+    assert!(matches!(result, Err(id::Error::FromFile { .. })));
 }
 
 #[test]
 fn load_profile_strip() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tmp_home = temp();
 
-    let profile_id_path = tempdir.path().join("active_profile");
+    let profile_id_path = tmp_home.tmp.path().join("active_profile");
     let content = "foo\nbar";
     std::fs::write(profile_id_path, content).unwrap();
-    let id = load_profile_id(tempdir.path()).unwrap();
-    assert_eq!(id, "foo");
+    let id = ProfileId::load(&tmp_home.home).unwrap();
+    assert_eq!(id, "foo".parse().unwrap());
 }
 
 #[test]
 fn empty_profile_file() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tmp_home = temp();
 
-    let profile_id_path = tempdir.path().join("active_profile");
+    let profile_id_path = tmp_home.tmp.path().join("active_profile");
     let content = "";
     std::fs::write(profile_id_path, content).unwrap();
-    let err = load_profile_id(tempdir.path()).unwrap_err();
-    assert!(matches!(err, Error::InvalidProfileIdFromFile { .. }))
+    let err = ProfileId::load(&tmp_home.home).unwrap_err();
+    assert!(matches!(err, id::Error::FromFile { .. }))
 }


### PR DESCRIPTION
While scoping out the introduction of creating, getting, and setting
profiles, I saw some room for refactoring to better see the flow of
profile creation and loading.

This patch introduces the `profile::id` module which contains the
`ProfileId` type. It surfaces the many ways to construct a ProfileId:
* From a UUID
* Read from RAD_PROFILE
* Read from active_profile
* Read from active_profile or default to creating one

Before this change, a profile ID was simply a String, but now that it is
behind a newtype wrapper, it's more obvious that it must go through
validation during construction.

The other introduction to this change is the RadHome enum which captures
where the Profile is living: XDG or some given Root.

The construction of a Profile is now computed in terms of RadHome and
ProfileId.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>