### PR TITLE
daemon: use tracing crate and improve logging

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -11,7 +11,7 @@ async-stream = "0.3"
 either = "1.6"
 futures = { version = "0.3", features = [ "compat" ] }
 lazy_static = "1.4"
-log = "0.4"
+tracing = "0.1"
 nonempty = "0.6"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_millis = "0.1"
@@ -39,7 +39,6 @@ path = "../git-helpers"
 [dev-dependencies]
 assert_matches = "1.3"
 pretty_assertions = "0.6"
-pretty_env_logger = "0.3"
 tempfile = "3.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -120,7 +120,7 @@ impl discovery::Discovery for StreamDiscovery {
                 match self.seeds_receiver.changed().await {
                     Ok(_) => {},
                     Err(_) => {
-                        log::warn!("Peer discovery stream dropped");
+                        tracing::warn!("Peer discovery stream dropped");
                         break;
                     }
                 }

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -206,11 +206,11 @@ where
                             .expect("subroutines is gone");
                         let (_, run) = net::protocol::accept(bound, disco.clone().discover());
                         if let Err(e) = run.await {
-                            log::error!("accept error: {}", e);
+                            tracing::error!(error = ?e, "accept error");
                         }
                     },
                     Err(e) => {
-                        log::error!("bound error: {}", e);
+                        tracing::error!(error = ?e, "bound error");
                         return Err(Error::Bootstrap(e));
                     },
                 }

--- a/daemon/src/peer/gossip.rs
+++ b/daemon/src/peer/gossip.rs
@@ -26,8 +26,8 @@ where
         rev: rev.map(|rev| Rev::Git(rev.into())),
         origin: None,
     }) {
-        Ok(()) => log::trace!("successfully announced for urn=`{}`, rev=`{:?}`", urn, rev),
-        Err(_payload) => log::warn!("failed to announce for urn=`{}`, rev=`{:?}`", urn, rev),
+        Ok(()) => tracing::trace!(%urn, ?rev, "successfully announced URN"),
+        Err(_payload) => tracing::warn!(%urn, ?rev, "failed to announce URN"),
     }
 }
 
@@ -41,11 +41,7 @@ where
         rev: None,
         origin,
     }) {
-        Ok(()) => log::trace!(
-            "successfully queried for urn=`{}`, origin=`{:?}`",
-            urn,
-            origin
-        ),
-        Err(_payload) => log::warn!("failed to query for urn=`{}`, origin=`{:?}`", urn, origin),
+        Ok(()) => tracing::trace!(%urn, ?origin, "successfully queried URN"),
+        Err(_payload) => tracing::warn!(%urn, "failed to query URN"),
     };
 }

--- a/daemon/src/peer/include.rs
+++ b/daemon/src/peer/include.rs
@@ -14,8 +14,7 @@ pub async fn update<S>(peer: Peer<S>, urn: Urn)
 where
     S: Clone + Signer,
 {
-    match state::update_include(&peer, urn.clone()).await {
-        Ok(path) => log::debug!("Updated include file @ {}", path.display()),
-        Err(err) => log::debug!("Failed to update include file for `{}`: {}", urn, err),
+    if let Err(err) = state::update_include(&peer, urn.clone()).await {
+        tracing::error!(%urn, error = ?err, "Failed to update include file");
     }
 }

--- a/daemon/src/peer/run_state.rs
+++ b/daemon/src/peer/run_state.rs
@@ -199,7 +199,7 @@ impl RunState {
     /// new state and in some cases produes commands which should be
     /// executed in the appropriate subroutines.
     pub fn transition(&mut self, input: Input) -> Vec<Command> {
-        log::trace!("TRANSITION START: {:?} {:?}", input, self.status);
+        tracing::trace!(?input, status = ?self.status, "transition start");
 
         let cmds = match input {
             Input::Announce(announce_input) => self.handle_announce(announce_input),
@@ -211,7 +211,7 @@ impl RunState {
             Input::Stats(stats_input) => self.handle_stats(stats_input),
         };
 
-        log::trace!("TRANSITION END: {:?} {:?}", self.status, cmds);
+        tracing::trace!(?cmds, status = ?self.status, "transition end");
 
         cmds
     }
@@ -356,7 +356,7 @@ impl RunState {
                     urn,
                 },
             ) => {
-                log::warn!("Cloning failed with: {}", reason);
+                tracing::warn!(?reason, "cloning failed");
                 self.waiting_room
                     .cloning_failed(&urn, remote_peer, SystemTime::now(), reason)
             },

--- a/daemon/src/peer/run_state/running_waiting_room.rs
+++ b/daemon/src/peer/run_state/running_waiting_room.rs
@@ -328,7 +328,7 @@ impl RunningWaitingRoom {
             },
             // FIXME(alexjg): Figure out how to report this error to the client
             Err(error) => {
-                log::warn!("WaitingRoom::Error : {}", error);
+                tracing::warn!(?error, "waiting room error");
                 Vec::new()
             },
         }

--- a/daemon/src/project/checkout.rs
+++ b/daemon/src/project/checkout.rs
@@ -112,7 +112,7 @@ where
     remote.save(&repo)?;
     for (reference, oid) in remote.fetch(storage, &repo, LocalFetchspec::Configured)? {
         let msg = format!("Fetched `{}->{}`", reference, oid);
-        log::debug!("{}", msg);
+        tracing::debug!("{}", msg);
 
         // FIXME(finto): we should ignore refs that don't start with heads to avoid
         // unintended side-effects.

--- a/daemon/src/project/create/validation.rs
+++ b/daemon/src/project/create/validation.rs
@@ -233,10 +233,7 @@ impl Repository {
                 url,
                 default_branch,
             } => {
-                log::debug!(
-                    "Setting up existing repository @ '{}'",
-                    repo.path().display()
-                );
+                tracing::debug!(path = ?repo.path(), "Setting up existing repository");
                 Self::setup_remote(&repo, open_storage, url, &default_branch)?;
                 Ok(repo)
             },
@@ -248,7 +245,7 @@ impl Repository {
                 signature,
             } => {
                 let path = path.join(name);
-                log::debug!("Setting up new repository @ '{}'", path.display());
+                tracing::debug!(?path, "Setting up new repository",);
                 let repo = Self::initialise(path, description, &default_branch)?;
                 Self::initial_commit(
                     &repo,
@@ -284,7 +281,7 @@ impl Repository {
         description: &str,
         default_branch: &OneLevel,
     ) -> Result<git2::Repository, git2::Error> {
-        log::debug!("Setting up new repository @ '{}'", path.display());
+        tracing::debug!(?path, "Setting up new repository");
         let mut options = git2::RepositoryInitOptions::new();
         options.no_reinit(true);
         options.mkpath(true);
@@ -336,7 +333,7 @@ impl Repository {
     {
         let _default_branch_ref = Self::existing_branch(repo, default_branch)?;
 
-        log::debug!("Creating rad remote");
+        tracing::debug!("Creating rad remote");
 
         let fetchspec = Refspec {
             src: refspec_pattern!("refs/heads/*"),
@@ -359,7 +356,7 @@ impl Repository {
                 force: Force::True,
             },
         )? {
-            log::debug!("Pushed local branch `{}`", pushed);
+            tracing::debug!(branch = ?pushed, "Pushed local branch");
         }
         Ok(git_remote)
     }
@@ -383,10 +380,7 @@ impl Repository {
     ) -> Result<Option<Remote<LocalUrl>>, Error> {
         match Remote::<LocalUrl>::find(repo, reflike!("rad")) {
             Err(remote::FindError::ParseUrl(_)) => {
-                log::warn!("an old/invalid URL was found when trying to load the `rad` remote");
-                log::warn!(
-                    "we are going to rename the remote to `rad_old` and create a new `rad` remote"
-                );
+                tracing::warn!("renaming invalid rad URL");
                 repo.remote_rename("rad", "rad_old")?;
                 Ok(None)
             },


### PR DESCRIPTION
We replace the `log` crate with `tracing` for `daemon` and clean up some logging statements.