### PR TITLE
daemon: only log with trace level for subroutines

### DIFF
--- a/daemon/src/peer/subroutines.rs
+++ b/daemon/src/peer/subroutines.rs
@@ -276,7 +276,7 @@ where
     }
 
     fn handle_input(&mut self, input: Input) {
-        tracing::debug!(?input, "handling subroutine input");
+        tracing::trace!(?input, "handling subroutine input");
 
         let old_status = self.run_state.status.clone();
 


### PR DESCRIPTION
Logging the `Subrioutines` input is quite noisy because we have frequent “tick” events that often have no effect. If they have an effect we should add logging statements in those places.