### PR TITLE
librad: fix deadlock when waiting for idle

### DIFF
--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -255,9 +255,9 @@ where
         async move {
             let res = io::connections::incoming(state, incoming).await;
             drop(_git_factory);
-            drop(tasks);
             tracing::debug!("waiting on idle connections...");
             endpoint.wait_idle().await;
+            drop(tasks);
             tracing::debug!("protocol shut down");
             res
         }


### PR DESCRIPTION
We fix a deadlock when we wait for the quic endpoint to become idle.

The deadlock happens when we wait for `endpoint.wait_idle()` while we are simultaneously still trying to connect to a remote that does not respond (i.e. it neither accepts nor refuses the connection) in `connect` called by `librad::net::protocol::io::discovered()`.

To make `endpoint.wait_idle()` future finish we need to advance the connection task so we drop it after the future has finished instead of before.