### PR TITLE
Retain outgoing uni streams

### DIFF
--- a/librad/src/net/protocol.rs
+++ b/librad/src/net/protocol.rs
@@ -61,6 +61,8 @@ mod state;
 pub use state::Quota;
 use state::{RateLimits, State, StateConfig, Storage};
 
+pub type Endpoint = quic::Endpoint<2>;
+
 #[derive(Clone, Debug)]
 pub struct Config {
     pub paths: Paths,

--- a/librad/src/net/protocol/info.rs
+++ b/librad/src/net/protocol/info.rs
@@ -91,6 +91,14 @@ pub struct GenericPeerInfo<Addr, T> {
     pub seen_addrs: BoundedVec<U16, Addr>,
 }
 
+impl<Addr> GenericPeerInfo<Addr, PeerAdvertisement<Addr>> {
+    pub fn addrs(&self) -> impl Iterator<Item = &Addr> {
+        self.seen_addrs
+            .iter()
+            .chain(&self.advertised_info.listen_addrs)
+    }
+}
+
 // XXX: derive fails to add the trait bound on Addr
 impl<'__b777, Addr: minicbor::Decode<'__b777>, T: minicbor::Decode<'__b777>>
     minicbor::Decode<'__b777> for GenericPeerInfo<Addr, T>

--- a/librad/src/net/protocol/io.rs
+++ b/librad/src/net/protocol/io.rs
@@ -11,13 +11,11 @@ use super::{
     gossip,
     info::{PartialPeerInfo, PeerAdvertisement},
     membership,
+    Endpoint,
     ProtocolStorage,
     State,
 };
-use crate::{
-    net::{connection::RemoteAddr as _, quic},
-    PeerId,
-};
+use crate::{net::connection::RemoteAddr as _, PeerId};
 
 mod codec;
 
@@ -80,7 +78,7 @@ where
 }
 
 pub(super) fn peer_advertisement(
-    endpoint: &quic::Endpoint,
+    endpoint: &Endpoint,
 ) -> impl Fn() -> PeerAdvertisement<SocketAddr> + '_ {
     move || {
         let mut listen_addrs = BoundedVec::from(iter::empty());

--- a/librad/src/net/protocol/io.rs
+++ b/librad/src/net/protocol/io.rs
@@ -22,7 +22,7 @@ use crate::{
 mod codec;
 
 pub(super) mod connections;
-pub(super) use connections::{connect, connect_peer_info};
+pub(super) use connections::connect;
 
 pub mod error;
 
@@ -39,7 +39,7 @@ pub(super) async fn discovered<S>(state: State<S>, peer: PeerId, addrs: Vec<Sock
 where
     S: ProtocolStorage<SocketAddr, Update = gossip::Payload> + Clone + 'static,
 {
-    if state.endpoint.get_connection(peer).is_some() {
+    if state.has_connection(peer) {
         return;
     }
 

--- a/librad/src/net/protocol/io/connections.rs
+++ b/librad/src/net/protocol/io/connections.rs
@@ -16,7 +16,7 @@ pub use super::error;
 use super::streams;
 use crate::{
     net::{
-        protocol::{event::upstream as event, gossip, ProtocolStorage, State},
+        protocol::{event::upstream as event, gossip, Endpoint, ProtocolStorage, State},
         quic,
     },
     PeerId,
@@ -71,7 +71,7 @@ where
 
 #[tracing::instrument(skip(endpoint, addrs))]
 pub async fn connect<'a, Addrs>(
-    endpoint: &quic::Endpoint,
+    endpoint: &Endpoint,
     remote_id: PeerId,
     addrs: Addrs,
 ) -> Option<(

--- a/librad/src/net/protocol/io/recv/interrogation.rs
+++ b/librad/src/net/protocol/io/recv/interrogation.rs
@@ -23,9 +23,9 @@ use crate::{
             cache,
             interrogation::{self, Request, Response},
             io::{self, codec},
+            Endpoint,
             State,
         },
-        quic,
         upgrade::{self, Upgraded},
     },
 };
@@ -81,7 +81,7 @@ pub(in crate::net::protocol) async fn interrogation<S, T>(
 }
 
 fn handle_request(
-    endpoint: &quic::Endpoint,
+    endpoint: &Endpoint,
     urns: &cache::urns::Filter,
     remote_addr: SocketAddr,
     req: interrogation::Request,

--- a/librad/src/net/protocol/io/send/rpc.rs
+++ b/librad/src/net/protocol/io/send/rpc.rs
@@ -56,15 +56,15 @@ where
 
     match rpc.into() {
         Membership(msg) => {
-            let upgraded = upgrade::upgrade(stream, upgrade::Membership).await?;
-            FramedWrite::new(upgraded, codec::Membership::new())
+            let mut upgraded = upgrade::upgrade(stream, upgrade::Membership).await?;
+            FramedWrite::new(&mut upgraded, codec::Membership::new())
                 .send(msg)
                 .await?;
         },
 
         Gossip(msg) => {
-            let upgraded = upgrade::upgrade(stream, upgrade::Gossip).await?;
-            FramedWrite::new(upgraded, codec::Gossip::new())
+            let mut upgraded = upgrade::upgrade(stream, upgrade::Gossip).await?;
+            FramedWrite::new(&mut upgraded, codec::Gossip::new())
                 .send(msg)
                 .await?;
         },

--- a/librad/src/net/protocol/state.rs
+++ b/librad/src/net/protocol/state.rs
@@ -20,6 +20,7 @@ use super::{
     membership,
     nonce,
     tick,
+    Endpoint,
     ProtocolStorage,
     TinCans,
 };
@@ -50,7 +51,7 @@ pub(super) struct StateConfig {
 #[derive(Clone)]
 pub(super) struct State<S> {
     pub local_id: PeerId,
-    pub endpoint: quic::Endpoint,
+    pub endpoint: Endpoint,
     pub git: GitServer,
     pub membership: membership::Hpv<Pcg64Mcg, SocketAddr>,
     pub storage: Storage<S>,

--- a/librad/src/net/protocol/tick.rs
+++ b/librad/src/net/protocol/tick.rs
@@ -105,7 +105,7 @@ where
                 let conn = state
                     .connection(to.peer_id, to.addrs().copied().collect::<Vec<_>>())
                     .await
-                    .ok_or_else(|| error::BestEffortSend::CouldNotConnect { to })?;
+                    .ok_or(error::BestEffortSend::CouldNotConnect { to })?;
                 Ok(io::send_rpc(&conn, message)
                     .await
                     .map_err(error::BestEffortSend::SendGossip)?)

--- a/librad/src/net/quic.rs
+++ b/librad/src/net/quic.rs
@@ -6,7 +6,14 @@
 use std::time::Duration;
 
 mod connection;
-pub use connection::{BoxedIncomingStreams, Connection, ConnectionId, Conntrack, IncomingStreams};
+pub use connection::{
+    BorrowUniError,
+    BoxedIncomingStreams,
+    Connection,
+    ConnectionId,
+    Conntrack,
+    IncomingStreams,
+};
 
 mod endpoint;
 pub use endpoint::{BoundEndpoint, Endpoint, IncomingConnections};

--- a/librad/src/net/quic/endpoint.rs
+++ b/librad/src/net/quic/endpoint.rs
@@ -157,9 +157,7 @@ impl Endpoint {
     }
 
     pub fn get_connection(&self, to: PeerId) -> Option<Connection> {
-        self.conntrack
-            .get(to)
-            .map(|conn| Connection::existing(to, self.conntrack.clone(), conn))
+        self.conntrack.get(to)
     }
 
     pub fn disconnect(&self, peer: &PeerId) {


### PR DESCRIPTION
See message of most recent commit.

_Note: `quinn:TransportConfig::max_concurrent_*_streams` applies to the remote end, so we can change this to a more restrictive value only after this was rolled out_