### PR TITLE
git-protocol: fix bad gitoxide release

### DIFF
--- a/git-protocol/Cargo.toml
+++ b/git-protocol/Cargo.toml
@@ -40,11 +40,11 @@ version = "0.6.0"
 features = ["async-io"]
 
 [dependencies.git-protocol]
-version = "0.8.0"
+version = "0.8.1"
 features = ["async-client"]
 
 [dependencies.git-transport]
-version = "0.9.0"
+version = "0.10.0"
 features = ["async-client"]
 
 [dependencies.git2]

--- a/git-protocol/src/fetch.rs
+++ b/git-protocol/src/fetch.rs
@@ -169,10 +169,6 @@ impl<P: PackWriter> DelegateBlocking for Fetch<P, P::Output> {
         // send done, as we don't bother with further negotiation
         Ok(Action::Cancel)
     }
-
-    fn indicate_client_done_when_fetch_completes(&self) -> bool {
-        false
-    }
 }
 
 #[async_trait(?Send)]
@@ -259,6 +255,7 @@ where
                 &mut delegate,
                 |_| unreachable!("credentials helper requested"),
                 progress::Discard,
+                git_protocol::FetchConnection::AllowReuse,
             ))
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 

--- a/git-protocol/src/ls.rs
+++ b/git-protocol/src/ls.rs
@@ -110,10 +110,6 @@ impl DelegateBlocking for LsRefs {
     ) -> io::Result<Action> {
         unreachable!("`negotiate` called even though no `fetch` command was sent")
     }
-
-    fn indicate_client_done_when_fetch_completes(&self) -> bool {
-        false
-    }
 }
 
 #[async_trait(?Send)]
@@ -141,6 +137,7 @@ where
         &mut delegate,
         |_| unreachable!("credentials helper requested"),
         progress::Discard,
+        git_protocol::FetchConnection::AllowReuse,
     )
     .await
     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;

--- a/git-protocol/src/transport.rs
+++ b/git-protocol/src/transport.rs
@@ -63,7 +63,7 @@ where
         &[Protocol::V2]
     }
 
-    fn is_stateful(&self) -> bool {
+    fn connection_persists_across_multiple_requests(&self) -> bool {
         false
     }
 }


### PR DESCRIPTION
gitoxide's `git-protocol` released a breaking change from version 0.8.0
to 0.8.1. Satisfy the new API, require a lower bound of 0.8.1, and hope
for the best.
