### PR TITLE
git-protocol: bump gitoxide `git-protocol`

### DIFF
--- a/git-protocol/Cargo.toml
+++ b/git-protocol/Cargo.toml
@@ -40,7 +40,7 @@ version = "0.6.0"
 features = ["async-io"]
 
 [dependencies.git-protocol]
-version = "0.8.1"
+version = "0.9.0"
 features = ["async-client"]
 
 [dependencies.git-transport]


### PR DESCRIPTION
The faulty 0.8 got yanked, so move on to 0.9.
Cf. 90a024f3 (git-protocol: fix bad gitoxide release, 2021-08-16)

Signed-off-by: Kim Altintop <kim@eagain.st>