### PR TITLE
daemon: qualify announcement path

### DIFF
--- a/daemon/src/peer/announcement.rs
+++ b/daemon/src/peer/announcement.rs
@@ -88,7 +88,7 @@ where
             None => continue,
         };
         for ((one_level, oid), category) in refs.iter_categorised() {
-            let path = RefLike::from(category).join(one_level.clone());
+            let path = RefLike::from(one_level.clone().into_qualified(category.into()));
             let urn = urn.clone().with_path(path);
             updates.insert((urn, *oid));
         }


### PR DESCRIPTION
Fixes #757 

The previous implementation used `join` over `into_qualified`, this
would result in the following in a reference of the form `rad/id`. This
reference can be ambiguous -- either meaning `refs/rad/id` or
`refs/heads/rad/id`.

We know, however, that this should be `refs/rad/id`. So using the
`into_qualified` function would give us the correct path of
`refs/rad/id`.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>