### PR TITLE
link-git-protocol: upgrade to latest versions of gitoxide crates

### DIFF
--- a/link-git-protocol/Cargo.toml
+++ b/link-git-protocol/Cargo.toml
@@ -30,21 +30,21 @@ version = "0.16.1"
 version = "0.5.0"
 
 [dependencies.git-odb]
-version = "0.16.1"
+version = "0.21.0"
 
 [dependencies.git-pack]
-version = "0.3.1"
+version = "0.9.0"
 
 [dependencies.git-packetline]
-version = "0.6.0"
+version = "0.10.0"
 features = ["async-io"]
 
 [dependencies.git-protocol]
-version = "0.9.0"
+version = "0.10.0"
 features = ["async-client"]
 
 [dependencies.git-transport]
-version = "0.10.0"
+version = "0.11.0"
 features = ["async-client"]
 
 [dependencies.git2]

--- a/link-git-protocol/src/packwriter.rs
+++ b/link-git-protocol/src/packwriter.rs
@@ -189,8 +189,7 @@ impl PackWriter for Standard {
             prog,
             &self.stop,
             Some(Box::new(move |oid, buf| {
-                odb.find_existing(oid, buf, &mut git_pack::cache::Never)
-                    .ok()
+                odb.find(oid, buf, &mut git_pack::cache::Never).ok()
             })),
             opts,
         )

--- a/link-git-protocol/src/upload_pack.rs
+++ b/link-git-protocol/src/upload_pack.rs
@@ -8,7 +8,7 @@ use std::{future::Future, io, path::Path, process::ExitStatus, str::FromStr};
 use async_process::{Command, Stdio};
 use futures_lite::io::{copy, AsyncRead, AsyncWrite};
 use futures_util::try_join;
-use git_packetline::PacketLine;
+use git_packetline::PacketLineRef;
 use once_cell::sync::Lazy;
 use versions::Version;
 
@@ -78,7 +78,7 @@ where
             .map_err(invalid_data)?
             .map_err(invalid_data)?;
         match pkt {
-            PacketLine::Data(data) => std::str::from_utf8(data)
+            PacketLineRef::Data(data) => std::str::from_utf8(data)
                 .map_err(invalid_data)?
                 .parse()
                 .map_err(invalid_data),


### PR DESCRIPTION
Now that the stability guide has landed and a few major refactorings have landed along with the new
git-repository Easy mode I feel safe to kick off https://github.com/Byron/gitoxide/issues/164 with 
bumping the gitoxide crates to the latest available version.
