### PR TITLE
git: ignore error due to concurrent sigrefs update

### DIFF
--- a/librad/src/git/storage/fetcher.rs
+++ b/librad/src/git/storage/fetcher.rs
@@ -8,6 +8,7 @@ use std::{
     convert::TryFrom,
     hash::BuildHasherDefault,
     net::SocketAddr,
+    sync::Arc,
     time::Duration,
 };
 
@@ -43,7 +44,7 @@ pub struct Info {
 ///
 /// Create via [`Default`].
 #[derive(Clone, Default)]
-pub struct Fetchers(DashMap<Urn, Info, BuildHasherDefault<FxHasher>>);
+pub struct Fetchers(Arc<DashMap<Urn, Info, BuildHasherDefault<FxHasher>>>);
 
 /// [`Storage`]-specific [`fetch::Fetcher`] impl.
 pub struct Fetcher<'a> {

--- a/test/src/rad/identities.rs
+++ b/test/src/rad/identities.rs
@@ -158,12 +158,11 @@ impl TestProject {
         let urn = self.project.urn();
         let cfg = to.protocol_config().replication;
         let res = to
-            .using_storage(move |storage| {
+            .using_storage(move |storage| -> anyhow::Result<ReplicateResult> {
                 let fetcher = fetcher::PeerToPeer::new(urn, remote_peer, remote_addrs)
                     .build(storage)
-                    .unwrap()
-                    .unwrap();
-                replication::replicate(storage, fetcher, cfg, None)
+                    .expect("creating a git2 remote should not normally fail")?;
+                Ok(replication::replicate(storage, fetcher, cfg, None)?)
             })
             .await??;
         Ok(res)

--- a/test/src/test/integration/librad/smoke/fetch_limit.rs
+++ b/test/src/test/integration/librad/smoke/fetch_limit.rs
@@ -51,10 +51,14 @@ fn replication_does_not_exceed_limit() {
             .unwrap()
             .unwrap();
 
-        for &peer in &[peer2, peer3, peer4, peer5] {
-            proj.pull(peer1, peer).await.unwrap();
-            proj.pull(peer, peer1).await.unwrap();
+        for (i, peer) in [peer2, peer3, peer4, peer5].iter().enumerate() {
+            let peerno = i + 2;
+            proj.pull(peer1, *peer)
+                .await
+                .unwrap_or_else(|e| panic!("pull peer1 -> peer{} failed: {:?}", peerno, e));
         }
-        proj.pull(peer1, peer6).await.ok().unwrap();
+        proj.pull(peer1, peer6)
+            .await
+            .expect("pull peer1 to peer6 failed");
     })
 }


### PR DESCRIPTION
When two `Refs::update` race, only one of them can succeed, because the
ref update only succeeds if the expected parent commit is what the ref
currently points to (ref updates are atomic). While there is a chance
that the winning update commits a slightly outdated view of the refs
tree, this is tolerable, because every modification of the namespace
will trigger a sigrefs update, and thus the state converges.

Not so great, however, is to propagate the commit failure due to a
modified parent as an error, as this may interrupt the replication flow,
leaving the namespace in a potentially half-arsed state.

Therefore, teach `Refs::update` to ignore this kind of error, and return
the most recent committed state instead.

Fixes #761
Signed-off-by: Kim Altintop <kim@eagain.st>
