### PR TITLE
Core-corrosion: Adding gitoxide to git-protocol integration tests

### DIFF
--- a/git-ext/Cargo.toml
+++ b/git-ext/Cargo.toml
@@ -21,7 +21,7 @@ default-features = false
 features = []
 
 [dependencies.git-repository]
-version = "0.9.0"
+version = "0.9.1"
 optional = true
 
 [dependencies.minicbor]

--- a/link-git-protocol/Cargo.toml
+++ b/link-git-protocol/Cargo.toml
@@ -24,7 +24,7 @@ tempfile = "3.2.0"
 versions = "3.0.2"
 
 [dependencies.git-repository]
-version = "0.9.0"
+version = "0.9.1"
 features = [ "async-network-client", "unstable" ]
 
 [dependencies.git-features]

--- a/link-git-protocol/Cargo.toml
+++ b/link-git-protocol/Cargo.toml
@@ -27,6 +27,18 @@ versions = "3.0.2"
 version = "0.9.0"
 features = [ "async-network-client", "unstable" ]
 
+[dependencies.git-features]
+version = "0.16.1"
+
+[dependencies.git-hash]
+version = "0.6.0"
+
+[dependencies.git-odb]
+version = "0.21.0"
+
+[dependencies.git-pack]
+version = "0.11.0"
+
 [dependencies.git-packetline]
 version = "0.10.0"
 features = ["async-io"]

--- a/link-git-protocol/Cargo.toml
+++ b/link-git-protocol/Cargo.toml
@@ -27,18 +27,6 @@ versions = "3.0.2"
 version = "0.9.1"
 features = [ "async-network-client", "unstable" ]
 
-[dependencies.git-features]
-version = "0.16.1"
-
-[dependencies.git-hash]
-version = "0.6.0"
-
-[dependencies.git-odb]
-version = "0.21.0"
-
-[dependencies.git-pack]
-version = "0.11.0"
-
 [dependencies.git-packetline]
 version = "0.10.0"
 features = ["async-io"]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -93,7 +93,7 @@ version = "1.1"
 features = ["zeroize_derive"]
 
 [dependencies.git-repository]
-version = "0.9.0"
+version = "0.9.1"
 default-features = false
 features = ["local", "local-time-support"]
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -92,6 +92,11 @@ features = ["logging", "dangerous_configuration"]
 version = "1.1"
 features = ["zeroize_derive"]
 
+[dependencies.git-repository]
+version = "0.9.0"
+default-features = false
+features = ["local", "local-time-support"]
+
 [[bin]]
 name = "git-remote-rad"
 path = "../git-helpers/src/bin/remote/main.rs"


### PR DESCRIPTION
A draft PR to get feedback early. I's goal is to add additional Rust to the core of git which is currently accessed through a thin corrosive layer provided by the `git2` crate.

By the end of this PR I'd expect all usages of `git2` to be replaced with at least equivalently readable substitutes provided by `gitoxide` except for where `git2` is explicitly under test.

Doing so is extremely valuable to `gitoxide` as it gets to develop its high-level-yet-performant API based on actual usage of a proven and mature library.