### PR TITLE
Add message receiving USDTs (PoC)

### DIFF
--- a/librad/Cargo.toml
+++ b/librad/Cargo.toml
@@ -61,6 +61,11 @@ uuid = { version = "0.8", features = ["v4"] }
 webpki = "0.21"
 xorf = "0.7"
 
+[build-dependencies.sonde]
+git = "https://github.com/viraptor/sonde-rs"
+rev = "88c3b872eaa7fdfe6ffbef34e1c920d4c9401544"
+optional = true
+
 [dependencies.deadpool]
 version = "0.7"
 default-features = false
@@ -143,3 +148,6 @@ features = ["serde"]
 [dependencies.zeroize]
 version = "1.1"
 features = ["zeroize_derive"]
+
+[features]
+usdt = ["sonde"]

--- a/librad/build.rs
+++ b/librad/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    #[cfg(feature = "usdt")]
+    sonde::Builder::new()
+        .file("./radicle_link.d")
+        .compile();
+}

--- a/librad/radicle_link.d
+++ b/librad/radicle_link.d
@@ -1,0 +1,4 @@
+provider radicle_link {
+    probe have_recv(char*, char*);
+    probe want_recv(char*, char*);
+};

--- a/librad/src/lib.rs
+++ b/librad/src/lib.rs
@@ -18,6 +18,11 @@
 #![feature(try_trait_v2)]
 #![feature(control_flow_enum)]
 
+#[cfg(feature = "usdt")]
+pub mod usdt {
+    include!(env!("SONDE_RUST_API_FILE"));
+}
+
 #[macro_use]
 extern crate async_trait;
 #[macro_use]


### PR DESCRIPTION
This requires the systemtap development package as well as dtrace tool
to be present during building.

The specific notifications are configured in radicle_link.d and the
names can be used to filter the results. Currently the notifications
work only on Linux, but a different crate can be used for the same
result on MacOS.

The result can be tested on a running seed with:

```
sudo bpftrace -p $(pgrep -f radicle-seed-node) -e '
  usdt:*/radicle-seed-node:radicleusdt:have_recv {
    printf("have, peer %s, urn %s\n", str(arg0), str(arg1));
  }
  usdt:*/radicle-seed-node:radicleusdt:want_recv {
    printf("want, peer %s, urn %s\n", str(arg0), str(arg1));
  }'
```

The solution uses [sonde-rs](https://github.com/wasmerio/sonde-rs) for actual notifications. Unfortunately the upstream version doesn't compile now and the patch is needed https://github.com/wasmerio/sonde-rs/pull/2 (already referenced in `Cargo.toml`)

This is a working proof-of-concept - more monitoring points can be added over time.