### PR TITLE
fix build

### DIFF
--- a/git-ext/Cargo.toml
+++ b/git-ext/Cargo.toml
@@ -21,7 +21,7 @@ default-features = false
 features = []
 
 [dependencies.git-repository]
-version = "0.9.1"
+version = "0.11.0"
 optional = true
 
 [dependencies.minicbor]

--- a/link-git-protocol/Cargo.toml
+++ b/link-git-protocol/Cargo.toml
@@ -24,11 +24,11 @@ tempfile = "3.2.0"
 versions = "3.0.2"
 
 [dependencies.git-repository]
-version = "0.9.1"
+version = "0.11.0"
 features = [ "async-network-client", "unstable" ]
 
 [dependencies.git-packetline]
-version = "0.10.0"
+version = "0.12.0"
 features = ["async-io"]
 
 [dependencies.git2]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -124,7 +124,7 @@ version = "1.1"
 features = ["zeroize_derive"]
 
 [dependencies.git-repository]
-version = "0.9.1"
+version = "0.11.0"
 default-features = false
 features = ["local", "local-time-support"]
 


### PR DESCRIPTION
This PR fixes what was reported in this issue: https://github.com/Byron/gitoxide/issues/221 .

#### Takeaways

 - `git-features` was introducing a breaking update to `git-hash` (v0.6 -> v0.8) in a patch release. This should not be possible as `cargo smart-release` is supposed to prevent this kind of thing. I will definitely look into it as this is a key-requirement to preventing issues like these.
 - Having a local `Cargo.lock` caused surprising build results, and since binaries are built here it should probably be tracked by git and updated in a controlled fashion.

<details><summary>History</summary>

Here is what I encountered just to not forget:

* update to latest version of radicle-link repo
* run `cargo check` on master in repo root, all good
* run `cargo test`, and it shows this error. Maybe `tokio` did a patch release with breaking changes?
    ```
    error[E0603]: struct `UnixStream` is private
     --> rad-clib/src/keys/ssh/unix.rs:9:36
      |
    9 | use thrussh_agent::{client::tokio::UnixStream, Constraint};
      |                                    ^^^^^^^^^^ private struct
      |
    note: the struct `UnixStream` is defined here
     --> /Users/byron/.cargo/git/checkouts/thrussh-e462ef97472eec6c/d0248b3/thrussh-agent/src/client/tokio.rs:8:5
      |
    8 | use tokio::net::UnixStream;
      |     ^^^^^^^^^^^^^^^^^^^^^^
    ```
* switch to `xla/seen` branch
* run `cargo check` in root and it shows the error above
* run `cargo clean` just to be sure and `cargo check`. The error above re-appears
* `cd librad` and run `cargo check` - it works. This is unexpected as it should fail.
   - run `cargo build` and it works which now was expected and so does `cargo test`
* run `cargo build --workspace --all-features` which runs on CI and after fixing the above issue with `UnixStream` it does work

Thus far, I am actually happy as it means that apparently `cargo smart-release` did what I expected it to do and bumped versions so that `cargo` won't pick them up.

</details>