### PR TITLE
Upgrade link-git to use latest version of git-ref

### DIFF
--- a/link-git/Cargo.toml
+++ b/link-git/Cargo.toml
@@ -30,20 +30,20 @@ tracing = "0.1"
 versions = "3.0.2"
 
 # gitoxide
-git-actor = "^0.6.0"
+git-actor = "^0.7.0"
 git-hash = "^0.8.0"
 git-lock = "^1.0.1"
-git-object = "^0.15.1"
-git-odb = "^0.23.0"
-git-ref = "^0.9.0"
-git-traverse = "^0.10.0"
+git-object = "^0.16.0"
+git-odb = "^0.25.0"
+git-ref = "^0.10.0"
+git-traverse = "^0.11.0"
 
 [dependencies.git-features]
-version = "^0.17.0"
+version = "^0.18.0"
 features = ["progress", "parallel", "zlib-ng-compat"]
 
 [dependencies.git-pack]
-version = "^0.13.0"
+version = "^0.15.0"
 features = ["object-cache-dynamic", "pack-cache-lru-static", "pack-cache-lru-dynamic"]
 
 [dependencies.git-packetline]
@@ -51,7 +51,7 @@ version = "^0.12.0"
 features = ["async-io"]
 
 [dependencies.git-protocol]
-version = "^0.12.0"
+version = "^0.13.0"
 features = ["async-client"]
 
 # compat

--- a/link-git/src/protocol/upload_pack.rs
+++ b/link-git/src/protocol/upload_pack.rs
@@ -218,9 +218,11 @@ fn git_version() -> io::Result<Version> {
             "failed to read `git` version",
         ));
     }
+
+    // parse: git version 2.30.1 <other optional tokens>
     out.stdout
-        .rsplit(|x| x == &b' ')
-        .next()
+        .split(|x| x == &b' ')
+        .nth(2)
         .and_then(|s| {
             let s = std::str::from_utf8(s).ok()?;
             Version::new(s.trim())

--- a/link-git/src/refs/db.rs
+++ b/link-git/src/refs/db.rs
@@ -167,8 +167,7 @@ impl Snapshot {
         N: TryInto<PartialNameRef<'a>, Error = E>,
         file::find::Error: From<E>,
     {
-        self.store
-            .try_find_packed(name, self.packed.as_ref().map(|arc| arc.as_ref()))
+        self.store.try_find_packed(name, self.packed.as_deref())
     }
 
     pub fn transaction(&self) -> Transaction {
@@ -176,7 +175,7 @@ impl Snapshot {
     }
 
     pub fn iter(&self, prefix: Option<impl AsRef<Path>>) -> io::Result<LooseThenPacked> {
-        let packed = self.packed.as_ref().map(|arc| arc.as_ref());
+        let packed = self.packed.as_deref();
         match prefix {
             None => self.store.iter_packed(packed),
             Some(p) => self.store.iter_prefixed_packed(p, packed),

--- a/link-git/src/refs/db.rs
+++ b/link-git/src/refs/db.rs
@@ -13,8 +13,9 @@ use std::{
 };
 
 use git_ref::{
-    file::{self, iter::LooseThenPacked, Transaction, WriteReflog},
+    file::{self, iter::LooseThenPacked, Transaction},
     packed,
+    store::WriteReflog,
     FullName,
     PartialNameRef,
     Reference,
@@ -167,7 +168,7 @@ impl Snapshot {
         file::find::Error: From<E>,
     {
         self.store
-            .try_find(name, self.packed.as_ref().map(|arc| arc.as_ref()))
+            .try_find_packed(name, self.packed.as_ref().map(|arc| arc.as_ref()))
     }
 
     pub fn transaction(&self) -> Transaction {
@@ -177,8 +178,8 @@ impl Snapshot {
     pub fn iter(&self, prefix: Option<impl AsRef<Path>>) -> io::Result<LooseThenPacked> {
         let packed = self.packed.as_ref().map(|arc| arc.as_ref());
         match prefix {
-            None => self.store.iter(packed),
-            Some(p) => self.store.iter_prefixed(packed, p),
+            None => self.store.iter_packed(packed),
+            Some(p) => self.store.iter_prefixed_packed(p, packed),
         }
     }
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -130,7 +130,7 @@ version = "1.1"
 features = ["zeroize_derive"]
 
 [dependencies.git-repository]
-version = "0.11.0"
+version = "0.13.0"
 default-features = false
 features = ["local", "local-time-support"]
 


### PR DESCRIPTION
`git-ref` was was improved such that users aren't forced anymore to
handle packed-refs thanks to an auto-updated shared cache.

As it's possible to still access the previous (but now renamed)
versions of methods that use packed-refs as parameter. Along with
direct access to the latest cached packed-refs (lazy loaded,
auto-reload on modification), one can get snapshot-like access
by reusing the same packed-refs across multiple calls.

All this is in an effort to get closer to a unified API that
can work similarly in a ref-table implementation.

There is also a 'general' store in the works which can be either
loose refs or a ref-table, but that one seems only relevant once
ref-table is actually implemented.

Signed-off-by: Sebastian Thiel <sebastian.thiel@icloud.com>