### PR TITLE
add integration test for bins package

### DIFF
--- a/bins/Cargo.lock
+++ b/bins/Cargo.lock
@@ -839,6 +839,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2b2decb0484e15560df3210cf0d78654bb0864b2c138977c07e377a1bae0e2"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,6 +2957,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50f3d255966981eb4e4c5df3e983e6f7d163221f547406d83b6a460ff5c5ee8"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "quanta"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,8 +3057,6 @@ dependencies = [
 [[package]]
 name = "radicle-keystore"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128583c70269a44d3e2144585b1f41a7f43ba11a2d8580266977268004a78a7b"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -3565,6 +3584,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "tests"
+version = "0.1.0"
+dependencies = [
+ "pty",
 ]
 
 [[package]]

--- a/bins/Cargo.toml
+++ b/bins/Cargo.toml
@@ -5,4 +5,5 @@ members = [
   "lnk-gitd",
   "lnk-identities-dev",
   "lnk-profile-dev",
+  "tests",
 ]

--- a/bins/tests/Cargo.toml
+++ b/bins/tests/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tests"
+version = "0.1.0"
+edition = "2021"
+
+[dev-dependencies]
+pty = "0.2"
+
+[[test]]
+name = "integration_test"
+path = "integration_test.rs"

--- a/bins/tests/integration_test.rs
+++ b/bins/tests/integration_test.rs
@@ -1,0 +1,79 @@
+//! Integration test to exercise the programs in `bins`.
+
+use pty::fork::*;
+use std::{
+    env,
+    io::{Read, Write},
+    process::Command,
+};
+
+/// This test is inspired by https://github.com/alexjg/linkd-playground
+#[test]
+fn happy_path_to_push_changes() {
+    let peer1_home = "/tmp/link-local-1";
+    let peer2_home = "/tmp/link-local-2";
+    let seed_home = "/tmp/seed-home";
+    let passphrase = b"play\n";
+
+    println!("create lnk homes for two peers and one seed");
+    if !run_lnk(LnkCmd::ProfileCreate, peer1_home, passphrase) {
+        return;
+    }
+    if !run_lnk(LnkCmd::ProfileCreate, peer2_home, passphrase) {
+        return;
+    }
+    if !run_lnk(LnkCmd::ProfileCreate, seed_home, passphrase) {
+        return;
+    }
+
+    println!("add ssh keys");
+    if !run_lnk(LnkCmd::ProfileSshAdd, peer1_home, passphrase) {
+        return;
+    }
+}
+
+enum LnkCmd {
+    ProfileCreate,
+    ProfileSshAdd,
+}
+
+/// Runs a `cmd` for `lnk_home`. Rebuilds `lnk` if necessary.
+/// Returns true if this is the parent (i.e. test) process,
+/// returns false if this is the child (i.e. lnk) process.
+fn run_lnk(cmd: LnkCmd, lnk_home: &str, passphrase: &[u8]) -> bool {
+    let fork = Fork::from_ptmx().unwrap();
+    if let Some(mut parent) = fork.is_parent().ok() {
+        parent.write_all(passphrase).unwrap();
+        println!("wrote passphase for {}", lnk_home);
+
+        let mut output = String::new();
+        parent.read_to_string(&mut output).unwrap();
+        println!("{}: {}", lnk_home, output.trim());
+
+        true
+    } else {
+        // Child process is to run `lnk`.
+        let package_dir = env!("CARGO_MANIFEST_DIR");
+        let manifest_path = format!("{}/Cargo.toml", package_dir.strip_suffix("/tests").unwrap());
+        // println!("manifest_path: {}", &manifest_path);
+
+        // cargo run \
+        // --manifest-path $LINK_CHECKOUT/bins/Cargo.toml \
+        // -p lnk -- "$@"
+        let mut lnk_cmd = Command::new("cargo");
+        lnk_cmd
+            .env("LNK_HOME", lnk_home)
+            .arg("run")
+            .arg("--manifest-path")
+            .arg(manifest_path)
+            .arg("-p")
+            .arg("lnk");
+        let full_cmd = match cmd {
+            LnkCmd::ProfileCreate => lnk_cmd.arg("--").arg("profile").arg("create"),
+            LnkCmd::ProfileSshAdd => lnk_cmd.arg("--").arg("profile").arg("ssh").arg("add"),
+        };
+        full_cmd.status().expect("lnk profile create failed:");
+
+        false
+    }
+}


### PR DESCRIPTION
This is the first version patch to add an integration test for `bins` package.  The current diff is to verify the basic test approach and logic is good.

This test is not embedded in CI workflow yet. Run `cargo test` under `bins` to execute the test. 

Here is a log:
```
radicle-link/bins (integration-test) $ cargo test -- --nocapture
    Finished test [unoptimized + debuginfo] target(s) in 0.54s
     Running unittests src/main.rs (target/debug/deps/lnk_gitd-927caf8ecbab8795)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running integration_test.rs (target/debug/deps/integration_test-3922dec250c75bce)

running 1 test
create lnk homes for two peers and one seed
wrote passphase for /tmp/link-local-1
/tmp/link-local-1: play
    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `/Users/work/radicle-link/bins/target/debug/lnk profile create`
please enter your passphrase: profile id: a415957e-456d-45bc-b611-f848d90b978e
peer id: hyngqn4bq3t9zrju6ugm55mfbc7hea88z11546zamujix1pnze9ub4
wrote passphase for /tmp/link-local-2
/tmp/link-local-2: play
    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `/Users/work/radicle-link/bins/target/debug/lnk profile create`
please enter your passphrase: profile id: 4d849b1c-272a-400b-8a55-cfe6b6583198
peer id: hyb8ercwdfbcqs8g66q7eqtx7nggw1fgpw86kmp1on3pc6ajeshtrk
wrote passphase for /tmp/seed-home
/tmp/seed-home: play
    Finished dev [unoptimized + debuginfo] target(s) in 0.29s
     Running `/Users/work/radicle-link/bins/target/debug/lnk profile create`
please enter your passphrase: profile id: 7e1985ae-5f1d-4e90-ad45-e8aa48c2031e
peer id: hybweucynzp697s1gy5jwsktm41n6qunca7mxwu6iksec357wrbp8r
add ssh keys
wrote passphase for /tmp/link-local-1
/tmp/link-local-1: play
    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `/Users/work/radicle-link/bins/target/debug/lnk profile ssh add`
please enter your passphrase: added key for profile id `a415957e-456d-45bc-b611-f848d90b978e`
test happy_path_to_push_changes ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 46.45s
```