### PR TITLE
nix: update to rust-1.64

### DIFF
--- a/cli/lnk-clib/src/runtime.rs
+++ b/cli/lnk-clib/src/runtime.rs
@@ -57,7 +57,7 @@ impl Runtime {
                         std::mem::drop(handle);
                     });
                 }
-                join.write().await;
+                let _guard = join.write().await;
             });
         });
 

--- a/git-ref-format/core/src/lit.rs
+++ b/git-ref-format/core/src/lit.rs
@@ -21,7 +21,7 @@ pub trait Lit: Sized + sealed::Sealed {
 
     #[inline]
     fn from_component(c: &name::Component) -> Option<Self> {
-        (c.as_ref() == Self::NAME).then(|| Self::SELF)
+        (c.as_ref() == Self::NAME).then_some(Self::SELF)
     }
 }
 

--- a/librad/src/net/protocol/broadcast.rs
+++ b/librad/src/net/protocol/broadcast.rs
@@ -261,6 +261,7 @@ where
     }
 }
 
+#[allow(clippy::type_complexity)]
 #[tracing::instrument(skip(state, membership, info))]
 pub(super) async fn apply<S, T, M, F, A, P>(
     state: &State<S, T>,

--- a/librad/t/src/integration/smoke/clone.rs
+++ b/librad/t/src/integration/smoke/clone.rs
@@ -164,7 +164,7 @@ impl Leecher<'_> {
                 (
                     host_peer,
                     supply_addr_hints
-                        .then(|| host_addrs)
+                        .then_some(host_addrs)
                         .into_iter()
                         .flatten()
                         .collect(),

--- a/link-identities/src/urn.rs
+++ b/link-identities/src/urn.rs
@@ -298,7 +298,7 @@ where
             .ok_or(Self::Err::Missing("namespace"))
             .and_then(|nid| {
                 (nid == "rad")
-                    .then(|| ())
+                    .then_some(())
                     .ok_or_else(|| Self::Err::InvalidNID(nid.to_string()))
             })?;
 
@@ -307,7 +307,7 @@ where
             .ok_or(Self::Err::Missing("protocol"))
             .and_then(|proto| {
                 (R::PROTOCOL == proto)
-                    .then(|| ())
+                    .then_some(())
                     .ok_or_else(|| Self::Err::InvalidProto(proto.to_string()))
             })?;
 

--- a/link-replication/src/peek.rs
+++ b/link-replication/src/peek.rs
@@ -19,7 +19,7 @@ pub(crate) fn ref_prefixes(id: &PeerId, remote_id: &PeerId) -> impl Iterator<Ite
         refs::scoped(id, remote_id, refs::Owned::refs_rad_self()).into(),
         refs::scoped(id, remote_id, refs::Owned::refs_rad_signed_refs()).into(),
         {
-            let scope = (id != remote_id).then(|| id);
+            let scope = (id != remote_id).then_some(id);
             RefPrefix::from_prefix(scope, refs::Prefix::RadIds)
         },
     ])

--- a/link-replication/src/prepare.rs
+++ b/link-replication/src/prepare.rs
@@ -41,7 +41,7 @@ where
         .iter()
         .filter_map(|r| {
             let remote_id = r.remote_id();
-            (remote_id != local_id).then(|| (remote_id, r))
+            (remote_id != local_id).then_some((remote_id, r))
         })
         .fold(BTreeMap::new(), |mut acc, (remote_id, r)| {
             acc.entry(remote_id).or_insert_with(Vec::new).push(r);

--- a/link-replication/src/refs/parsed.rs
+++ b/link-replication/src/refs/parsed.rs
@@ -110,7 +110,7 @@ where
                     (SIGNED_REFS, None) => Some(Left(Rad::SignedRefs)),
                     (IDS, Some(id)) => {
                         let urn = Urn::try_from_id(id.as_str()).ok()?;
-                        iter.next().is_none().then(|| Left(Rad::Ids { urn }))
+                        iter.next().is_none().then_some(Left(Rad::Ids { urn }))
                     },
 
                     _ => None,

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c97cf9d581e09b767f5e3503b43dc3e4cd91bd99",
-        "sha256": "02r3y1x4sdzdy0qzds6286v51406jk7ywks6fjivmb3c5mlhvq8x",
+        "rev": "af29a900f10dd6e467622202fb4f6d944d72a3a6",
+        "sha256": "14ja8mlnzyvxc4csrxxnr6iy9syv8h9c5frzs9f6glb43ra1rxfb",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/c97cf9d581e09b767f5e3503b43dc3e4cd91bd99.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/af29a900f10dd6e467622202fb4f6d944d72a3a6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,28 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 


### PR DESCRIPTION
Rust 1.64.0 was released[0].

Update the nix files to get the latest release and fix the latest clippy errors.

[0]: https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>